### PR TITLE
Clarify basic gdsync errors

### DIFF
--- a/src/godot/classautomate/checkform.nim
+++ b/src/godot/classautomate/checkform.nim
@@ -1,0 +1,48 @@
+import godotcore/GodotClass
+
+import std/macros
+
+import propertyinfo
+
+const errmsgSelfTypeMismatch = "invalid form; In order to synchronize the function, the first argument must inherit from the class provided by godot."
+const errmsgSignalResultTypeMismatch = "invalid form; to define signal, result must be type Error."
+
+macro lineerror(msg: static string; expr) =
+  error msg, expr
+
+proc precheckIsCorrectClassMethod*(node: NimNode) =
+  if node.kind notin {nnkProcDef, nnkFuncDef, nnkConverterDef, nnkMethodDef}:
+    error "invalid form; only supports proc, func, converter and method.", node
+  if node.params.len <= 1:
+    error errmsgSelfTypeMismatch, node
+  for pragma in node.pragma:
+    if pragma.eqIdent "signal":
+      if node.kind notin {nnkProcDef}:
+        error "invalid form; to define signal, function must be proc.", node
+      if node.params[0].kind == nnkEmpty or node.params[0].eqIdent "void":
+        error errmsgSignalResultTypeMismatch, node
+
+proc withCorrectClassMethodForm*(node, stmt: NimNode): NimNode =
+  let arg0T = node.params[1][1]
+  result = newNimNode nnkWhenStmt
+
+  result.add nnkElifBranch.newTree(
+    (quote do: `arg0T` isnot GodotClass),
+    bindsym"lineerror".newcall(newlit errmsgSelfTypeMismatch, node.params[1])
+  )
+  for arg in node.params[2..^1]:
+    let argT = arg[1]
+    result.add nnkElifBranch.newTree(
+      (quote do: `argT` isnot SomeProperty),
+      bindsym"lineerror".newcall(newlit "invalid form; the type `" & argT.repr & "` is not supported for argument.", arg)
+    )
+
+  for pragma in node.pragma:
+    if pragma.eqIdent "signal":
+      var resT = node.params[0]
+      result.add nnkElifBranch.newTree(
+        (quote do: `resT` isnot Error),
+        bindsym"lineerror".newcall(newlit errmsgSignalResultTypeMismatch, node.name)
+      )
+
+  result.add nnkElse.newTree(stmt)

--- a/src/godot/classautomate/procs.nim
+++ b/src/godot/classautomate/procs.nim
@@ -2,11 +2,13 @@ import std/macros
 
 import contracts
 import methodinfo
+import checkform
 
 import godotcore/commandindex
 import godotcore/GodotClass
 
 proc sync_procDef*(procdef: NimNode): NimNode =
+  precheckIsCorrectClassMethod: procdef
   let name = procdef.name
   let arg0_T = procdef.params[1][1]
 
@@ -22,8 +24,7 @@ proc sync_procDef*(procdef: NimNode): NimNode =
 
   let methodinfoDef = procdef.classMethodInfo(gdname)
 
-
-  quote do:
+  procdef.withCorrectClassMethodForm quote do:
     `procdef`
     process(contract(`arg0T`).procedure, `gdname`):
       let glue = `methodinfoDef`

--- a/src/godot/classautomate/signals.nim
+++ b/src/godot/classautomate/signals.nim
@@ -2,6 +2,7 @@ import std/tables
 import godotcore/utils/macros
 
 import contracts
+import checkform
 
 import godotcore/dirty/gdextension_interface
 import godotcore/GodotClass
@@ -36,6 +37,7 @@ template argumentSize(info: ClassSignalInfo): Int =
   info.arguments.len
 
 proc sync_signal*(procDef: NimNode): NimNode =
+  precheckIsCorrectClassMethod: procdef
   let arg0 = procDef.params[1][0]
   let arg0_T = procDef.params[1][1]
   var gdname = procDef.name.toStrLit
@@ -68,7 +70,7 @@ proc sync_signal*(procDef: NimNode): NimNode =
     let variantArr = `variantArrDef`
     `arg0`.emitSignal(signalName, variantArr)
 
-  quote do:
+  procdef.withCorrectClassMethodForm quote do:
     `procdef`
     process(`arg0_T`.contract.signal, `gdname`):
       let info = ClassSignalInfo(

--- a/src/godot/classautomate/virtuals.nim
+++ b/src/godot/classautomate/virtuals.nim
@@ -4,6 +4,7 @@ import godotcore/events
 import godotcore/GodotClass
 
 import contracts
+import checkform
 
 import std/tables
 import godotcore/utils/macros
@@ -12,6 +13,7 @@ proc get_virtual_bind*(p_userdata: pointer; p_name: ConstStringNamePtr): ClassCa
   cast[GodotClassMeta](p_userdata).virtualMethods.getOrDefault(cast[ptr StringName](p_name)[], nil)
 
 proc sync_methodDef*(body: Nimnode): NimNode =
+  precheckIsCorrectClassMethod: body
   let methoddef = body
   # for sym in bindsym(methoddef[0], brForceOpen):
   #   hint repr sym.getImpl, body
@@ -20,7 +22,7 @@ proc sync_methodDef*(body: Nimnode): NimNode =
   let methodstrlit = newlit methodstr
   let methodname = ident methodstr & "_bind"
 
-  quote do:
+  methoddef.withCorrectClassMethodForm quote do:
     `methoddef`
     process(contract(`selfT`).virtual, `methodstrlit`):
       vmethods(`selfT`)[stringName `selfT`.EngineClass.vmap[`methodstrlit`]] = `selfT`.`methodname`


### PR DESCRIPTION
This PR is to ensure that an easy-to-understand error is displayed for incorrect definitions such as the following:

```nim
proc myproc*() {.gdsync.} = discard
proc myproc*(x: int) {.gdsync.} = discard
# stderr: invalid form; In order to synchronize the function, the first argument must inherit from the class provided by godot.
```

```nim
import std/times
proc myproc*(self: ValidClass; x: times.Time) {.gdsync.} = discard
# stderr: invalid form; the type `times.Time` is not supported for argument.
```

```nim
proc mysignal*(self: ValidClass) {.gdsync, signal.}
proc mysignal*(self: ValidClass): int {.gdsync, signal.}
# stderr: invalid form; to define signal, result must be type Error.
```