### PR TITLE
Feat: genEditorHelp switch and generate editor-helps.

### DIFF
--- a/src/gdext/buildconf.nim
+++ b/src/gdext/buildconf.nim
@@ -5,30 +5,21 @@ when not declared(switch):
     Extension_decimalPrecision {.strdefine: "Extension.decimalPrecision".} = "float"
 
     Assistance_checkEnv {.booldefine: "Assistance.checkenv".} = on
+    Assistance_genEditorHelp {.booldefine: "Assistance.genEditorHelp".} = on
 
     Dev_debugCallbacks {.booldefine: "Dev.debugCallbacks".} = off
     Dev_debugEvents {.booldefine: "Dev.debugEvents".} = off
 
-  type ExtensionObj* = object
-    name*: string
-    entrySymbol*: string
-    decimalPrecision*: string
-  type AssistanceObj* = object
-    checkEnv*: bool
-  type DevObj* = object
-    debugCallbacks*: bool
-    debugEvents*: bool
-
-  const
-    Extension* = ExtensionObj(
+    Extension* = (
       name: Extension_name,
       entrySymbol: Extension_entrySymbol,
       decimalPrecision: Extension_decimalPrecision,
     )
-    Assistance* = AssistanceObj(
+    Assistance* = (
       checkEnv: Assistance_checkEnv,
+      genEditorHelp: Assistance_genEditorHelp,
     )
-    Dev* = DevObj(
+    Dev* = (
       debugCallbacks: Dev_debugCallbacks,
       debugEvents: Dev_debugEvents,
     )
@@ -48,6 +39,7 @@ else:
 
   type Godot* = object
   type Extension* = object
+  type Assistance* = object
 
   const RunningSystem* = case hostOS
   of "windows":
@@ -80,6 +72,9 @@ else:
     # the cache is overwritten and the cc is performed from scratch,
     # resulting in slower build speeds.
     switch("nimcache", nimCacheDir()/RunningSystem/Build/name)
+
+  proc `genEditorHelp=`*(_: typedesc[Assistance]; b: bool) =
+    switch("define", "Assistance.genEditorHelp:" & $b)
 
   # GDExtension is loaded into the engine as a DLL.
   --app: lib

--- a/src/gdext/core/typeshift.nim
+++ b/src/gdext/core/typeshift.nim
@@ -231,3 +231,6 @@ proc decode_result*[T: RefCounted](p: pointer; Result: typedesc[GdRef[T]]): Resu
   p.decode_result(T).asGdRef
 
 {.pop.}
+
+template APIType*(T: typedesc[Object]): typedesc = T
+template APIType*(T: typedesc[not Object]): typedesc = encoded T

--- a/src/gdext/core/userclass/procs.nim
+++ b/src/gdext/core/userclass/procs.nim
@@ -11,7 +11,11 @@ import contracts
 import methodinfo
 import virtuals
 
+when Assistance.genEditorHelp:
+  import gdext/doctools
+
 const errmsgSelfTypeMismatch = "invalid form; In order to synchronize the function, the first argument must inherit from the class provided by gdext."
+
 
 macro registerProc*(procdef): untyped =
   let procdef =
@@ -23,10 +27,15 @@ macro registerProc*(procdef): untyped =
 
   let methodinfoDef = procdef.classMethodInfo(gdname)
 
-  quote do:
+  result = quote do:
     proc `gdname` {.execon: Contract[typedesc[`Self`]].procedure.} =
       let info = `methodinfoDef`
       classDB.registerMethod(className(typedesc `Self`), addr info)
+
+  when Assistance.genEditorHelp:
+    let desc = procdef.getEditorHelp
+    result.body.add quote do:
+      docClassDB[typedesc `Self`].methods.add DocMethod(name: `gdname`, description: `desc`)
 
 proc makeNimMainProc(procdef: NimNode): NimNode =
   newProc(

--- a/src/gdext/core/userclass/tools.nim
+++ b/src/gdext/core/userclass/tools.nim
@@ -1,8 +1,25 @@
 import std/[sequtils]
 
+import gdext/buildconf
 import gdext/utils/macros
 import gdext/core/gdclass
 import propertyinfo
+
+proc docComment*(def: NimNode): NimNode =
+  if def.kind notin RoutineNodes: return
+  if def.body.len == 0: return
+  if def.body[0].kind != nnkCommentStmt: return
+  def.body[0]
+
+proc getDescription*(def: NimNode): string =
+  let desc = def.getPragmaVal("description") or def.docComment
+  if desc != nil: desc.strval
+  else: ""
+
+when Assistance.genEditorHelp:
+  import gdext/doctools
+  proc getEditorHelp*(def: NimNode): string =
+    def.getDescription.descToEditorHelp
 
 proc withCheckTypes*(node, onSelfTypeFailed, onDefault: NimNode): NimNode =
   let lineerror = bindSym "lineerror"

--- a/src/gdext/doctools.nim
+++ b/src/gdext/doctools.nim
@@ -1,0 +1,114 @@
+import gdext/buildconf
+
+when Assistance.genEditorHelp:
+  import gdext/gdinterface/objects
+  import gdext/gen/builtinclasses
+
+  import std/[strformat, strutils, tables]
+
+  const DocHeader = """<?xml version="1.0" encoding="UTF-8" ?>
+  """
+  var NoNamespaceSchemaLocation* = "https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd"
+
+  type
+    DocClass* = object
+      briefDescription*: string
+      description*: string
+      tutorials*: string
+      methods*: seq[DocMethod]
+      members*: seq[DocMember]
+      signals*: seq[DocSignal]
+      constants*: seq[DocConstant]
+    DocMethod* = object
+      name*: string
+      description*: string
+    DocMember* = object
+      name*: string
+      typ*: string
+      description*: string
+    DocSignal* = object
+      name*: string
+      description*: string
+    DocConstant* = object
+      name*: string
+      description*: string
+
+
+  type DocClassDB = Table[StringName, DocClass]
+  var docClassDB*: DocClassDB
+
+  proc `[]=`*(table: var DocClassDB; typ: typedesc; value: sink DocClass) =
+    table[className typ] = value
+
+  proc `[]`*(table: var DocClassDB; key: StringName): var DocClass =
+    table.mgetOrPut(key, DocClass())
+  proc `[]`*(table: var DocClassDB; typ: typedesc): var DocClass =
+    table.mgetOrPut(className typ, DocClass())
+
+
+  proc render*(tag, name, description: string; result: var string) =
+    result.add &"""
+  <{tag} name="{name}">
+  <description>
+  {description}
+  </description>
+  </{tag}>
+  """
+  proc render*(doc: DocMethod; result: var string) =
+    render("method", doc.name, doc.description, result)
+  proc render*(doc: DocMember; result: var string) =
+    result.add &"""
+  <member name="{doc.name}" type="{doc.typ}">
+  {doc.description}
+  </member>
+  """
+  proc render*(doc: DocSignal; result: var string) =
+    render("signal", doc.name, doc.description, result)
+  proc render*(doc: DocConstant; result: var string) =
+    render("constant", doc.name, doc.description, result)
+
+  proc render(doc: seq; tag: string; result: var string) =
+    result.add &"<{tag}>\n"
+    for elem in doc:
+      elem.render(result)
+    result.add &"</{tag}>\n"
+
+  proc render(doc: seq[DocMethod]; result: var string) =
+    doc.render("methods", result)
+  proc render(doc: seq[DocMember]; result: var string) =
+    doc.render("members", result)
+  proc render(doc: seq[DocSignal]; result: var string) =
+    doc.render("signals", result)
+  proc render(doc: seq[DocConstant]; result: var string) =
+    doc.render("constants", result)
+
+
+  proc render*(doc: DocClass; name: StringName; result: var string) =
+    result.add &"""
+  <class name="{name}" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="{NoNamespaceSchemaLocation}">
+  <brief_description>
+  {doc.briefDescription}
+  </brief_description>
+  <description>
+  {doc.description}
+  </description>
+  <tutorials>
+  {doc.tutorials}
+  </tutorials>
+  """
+    doc.methods.render(result)
+    doc.members.render(result)
+    doc.signals.render(result)
+    doc.constants.render(result)
+
+    result.add "</class>\n"
+
+proc descToEditorHelp*(str: string): string =
+  str.replace("\n", "[br]")
+
+proc generateEditorHelp*() =
+  var doctext = DocHeader
+  for key, class in docClassDB.mpairs:
+    class.render(key, doctext)
+  interfaceEditorHelpLoadXmlFromUtf8Chars(cstring doctext)
+  clear docClassDB

--- a/src/gdext/surface/init.nim
+++ b/src/gdext/surface/init.nim
@@ -10,6 +10,9 @@ import gdext/surface/userclass
 import gdext/extclasses/gdextensionmain
 import gdext/buildconf
 
+when Assistance.genEditorHelp:
+  import gdext/doctools
+
 
 const initialize_core* = event("initialize_core")
 const initialize_servers* = event("initialize_servers")
@@ -57,6 +60,8 @@ template GDExtension_EntryPoint*: untyped =
       const loadedClasses = contracts.invoked.len
       gLoaded = loadedClasses
       {.emit: "NimMain();".}
+      when Assistance.genEditorHelp:
+        doctools.generateEditorHelp()
 
   proc deinitialize(userdata: pointer; p_level: InitializationLevel) {.gdcall.} = errproof:
     case p_level

--- a/src/gdext/surface/userclass.nim
+++ b/src/gdext/surface/userclass.nim
@@ -18,6 +18,9 @@ when Dev.debugCallbacks:
   import std/importutils
   privateAccess Object
 
+when Assistance.genEditorHelp:
+  import gdext/doctools
+
 proc set_func(p_instance: ClassInstancePtr; p_name: ConstStringNamePtr; p_value: ConstVariantPtr): Bool {.gdcall.} =
   cast[Object](p_instance).set(p_name, p_value)
 
@@ -112,6 +115,7 @@ proc creationInfo(T: typedesc[SomeUserClass]; is_virtual, is_abstract: bool): Cl
 template name*(newname: static string) {.pragma.}
 template signal* {.pragma.}
 template initLevel*(level: InitializationLevel) {.pragma.}
+template description*(desc: string) {.pragma.}
 
 var implicitRegistrations {.compileTime.}: array[InitializationLevel, seq[NimNode]]
 
@@ -174,6 +178,9 @@ proc register*(T: typedesc) =
     interface_Editor_addPlugin addr cn
     plugins.add cn
   registered.add cn
+
+  when Assistance.genEditorHelp and T.hasCustomPragma(description):
+    docClassDB[T].description = T.getCustomPragmaVal(description).descToEditorHelp
 
 proc unregisterAll* =
   for i in countdown(plugins.high, 0):

--- a/testproject/editor/main.tscn
+++ b/testproject/editor/main.tscn
@@ -14,3 +14,5 @@ icon = ExtResource("2_x3ep8")
 
 [node name="SignalSubscriber" type="SignalSubscriber" parent="." node_paths=PackedStringArray("publisher")]
 publisher = NodePath("../SignalPublisher")
+
+[node name="DocTestNode" type="DocTestNode" parent="."]

--- a/testproject/editor/nim/bootstrap.nim
+++ b/testproject/editor/nim/bootstrap.nim
@@ -4,6 +4,7 @@ import gdext
 # import myclass
 import classes/gdproptestnode
 import classes/gdproptestnode_pragmas
+import classes/gddoctestnode
 import classes/gdsignalpublisher
 import classes/gdsignalsubscriber
 

--- a/testproject/editor/nim/config.nims
+++ b/testproject/editor/nim/config.nims
@@ -1,6 +1,7 @@
 import gdext/buildconf
 
 Extension.name = "GdextTester"
+Assistance.genEditorHelp = on
 
 --path: "src"
 --path: "../../../src"

--- a/testproject/editor/nim/src/classes/gddoctestnode.nim
+++ b/testproject/editor/nim/src/classes/gddoctestnode.nim
@@ -1,0 +1,42 @@
+import gdext
+
+type DocTestNode* {.gdsync, description: """
+A node defined for documentation testing.
+"## comments" are ignored because there is no way to retrieve them.""".} = ptr object of Node
+  pragma_param* {.gdexport, description: "This is a description for {.gdexport.}'ed params".}: string = "pragma-param"
+  getset_param: string = "getset-param"
+
+gdexport "getset_param",
+  proc(self: DocTestNode): string = self.getset_param,
+  proc(self: DocTestNode; value: string) = self.getset_param = value,
+  description = "This is a description for gdexport(getter, setter)'ed params"
+
+
+proc signalWithDescription* (self: DoctestNode): Error {.gdsync, signal, description: """
+This is a description for Signal.""".}
+
+proc procWithNoDocComments(self: DocTestNode): string {.gdsync.} =
+  "doctest"
+
+proc procWithDescription(self: DocTestNode): string {.gdsync, description: """
+This is a description for Proc that provided by pragma""".} =
+  "doctest"
+
+proc procWithDocComments(self: DocTestNode): string {.gdsync.} =
+  ## Just returns String "doctest"
+  ## Note that as same as `nim doc`, very first doc-comment is only applied.
+  ## Additionally, runnableExamples will also be ignored.
+  ## The ability to convert reStructuredText to Godot.RichText is not implemented.
+  runnableExamples:
+    "doctest"
+  result = "doctest"
+  ## IGNORED
+
+  ## IGNORED
+
+proc procWithDescriptionAndComment(self: DocTestNode): string {.gdsync, description: """
+If both {.description.} and ## description is provided,
+{.description.} will only be used.""".} =
+  ## Descriptions here will be ignored from Godot Editor.
+  ## Though if you do `nim doc`, of course this part will placed on documentation.
+  "doctest"

--- a/testproject/editor/nim/src/classes/gdsignalsubscriber.nim
+++ b/testproject/editor/nim/src/classes/gdsignalsubscriber.nim
@@ -17,6 +17,7 @@ gdexport "publisher",
   hint_string = gdstring className Node)
 
 proc recv*(self: SignalSubscriber; key: int) {.gdsync.} =
+  ## Take a argument and echo it.
   echo "receive: ", key
 
 method ready(self: SignalSubscriber) {.gdsync.} =

--- a/testproject/runtime/nim/config.nims
+++ b/testproject/runtime/nim/config.nims
@@ -1,6 +1,7 @@
 import gdext/buildconf
 
 Extension.name = "NimMain"
+Assistance.genEditorHelp = off
 
 --path: "src"
 --path: "../../../src"


### PR DESCRIPTION
Add an API to describe the description of the descrip tion for classes, functions, etc., and generate editor help at runtime.

This feature can be disabled in config.nims.

```nim
import gdext/buildconf

Assistance.genEditorHelp = off # on is default
```

Example:

```nim
import gdext

type DocTestNode* {.gdsync, description: """
A node defined for documentation testing.
"## comments" are ignored because there is no way to retrieve them.""".} = ptr object of Node
  pragma_param* {.gdexport, description: "This is a description for {.gdexport.}'ed params".}: string = "pragma-param"
  getset_param: string = "getset-param"

gdexport "getset_param",
  proc(self: DocTestNode): string = self.getset_param,
  proc(self: DocTestNode; value: string) = self.getset_param = value,
  description = "This is a description for gdexport(getter, setter)'ed params"

proc signalWithDescription* (self: DoctestNode): Error {.gdsync, signal, description: """
This is a description for Signal.""".}

proc procWithNoDocComments(self: DocTestNode): string {.gdsync.} =
  "doctest"

proc procWithDescription(self: DocTestNode): string {.gdsync, description: """
This is a description for Proc that provided by pragma""".} =
  "doctest"

proc procWithDocComments(self: DocTestNode): string {.gdsync.} =
  ## Just returns String "doctest"
  ## Note that as same as `nim doc`, very first doc-comment is only applied.
  ## Additionally, runnableExamples will also be ignored.
  ## The ability to convert reStructuredText to Godot.RichText is not implemented.
  runnableExamples:
    "doctest"
  result = "doctest"
  ## IGNORED

  ## IGNORED


proc procWithDescriptionAndComment(self: DocTestNode): string {.gdsync, description: """
If both {.description.} and ## description is provided,
{.description.} will only be used.""".} =
  ## Descriptions here will be ignored from Godot Editor.
  ## Though if you do `nim doc`, of course this part will placed on documentation.
  "doctest"
```

![image](https://github.com/user-attachments/assets/24bcb457-3e1b-4a4d-875b-54a15a51a491)
![image](https://github.com/user-attachments/assets/3fd1747a-b292-435a-b3fd-41882fe55c52)
![image](https://github.com/user-attachments/assets/ce4bca42-ed3f-4464-a2f0-c56fb6f04b31)
