### PR TITLE
Refactor library internal

### DIFF
--- a/src/gdext.nim
+++ b/src/gdext.nim
@@ -11,12 +11,11 @@ export InitializationLevel, VariantType, gdcall
 import gdext/gdinterface/exceptions
 export GodotDefect, GodotCallDefect, GodotVariantTypeDefect
 
-import gdext/core/[ builtinindex, geometrics, gdrefs, gdtypedarray ]
-export              builtinindex, geometrics, gdrefs, gdtypedarray
+import gdext/core/[ builtinindex, geometrics, gdrefs ]
+export              builtinindex, geometrics, gdrefs
 
-import gdext/core/[typeshift, gdclass]
+import gdext/core/[typeshift]
 export typeshift.get, typeshift.variant
-export gdclass.Object, gdclass.RefCounted
 
 import gdext/gen/[ builtinclasses, classindex, globalenums, localenums, structs ]
 export             builtinclasses, classindex, globalenums, localenums, structs

--- a/src/gdext/core/builtinindex.nim
+++ b/src/gdext/core/builtinindex.nim
@@ -339,6 +339,9 @@ proc `=copy`*(dest: var Variant; source: Variant) =
   `=destroy` dest
   interface_variantNewCopy(addr dest, addr source)
 
+method onInit*(self: Object) {.base.} = discard
+method onDestroy*(self: Object) {.base.} = discard
+
 proc load* =
   const
     constrs = [

--- a/src/gdext/core/builtinindex.nim
+++ b/src/gdext/core/builtinindex.nim
@@ -94,6 +94,8 @@ type
   Array* {.byref.} = object
     opaque: Opaque[1]
 
+  TypedArray*[T: SomeVariant] = distinct Array
+
   PackedByteArray* = PackedArray[byte]
   PackedInt32Array* = PackedArray[int32]
   PackedInt64Array* = PackedArray[int64]
@@ -105,11 +107,12 @@ type
   PackedVector4Array* = PackedArray[Vector4]
   PackedColorArray* = PackedArray[Color]
 
-template Item*(typ: typedesc[String]): typedesc = Rune
-template Item*(typ: typedesc[Array]): typedesc = Variant
-template Item*(typ: typedesc[Dictionary]): typedesc = Variant
+  Object* = ptr object of RootObj
+    owner: ObjectPtr
+    when Dev.debugCallbacks:
+      debugName: string
+  RefCounted* = ptr object of Object
 
-type
   SomePackedArray* =
     PackedByteArray    |
     PackedInt32Array   |
@@ -158,6 +161,22 @@ type
     Array           |
     SomePackedArray
   SomeBuiltins* = SomePrimitives|SomeGodotUniques
+
+  SomeClass* = Object
+  SomeEngineClass* = concept type t
+    t is SomeClass
+    t.EngineClass is t
+  SomeUserClass* = concept type t
+    t is SomeClass
+    t.EngineClass isnot t
+
+  SomeVariant* = concept type t
+    t is SomeBuiltins | Object
+
+template Item*(typ: typedesc[String]): typedesc = Rune
+template Item*(typ: typedesc[Array]): typedesc = Variant
+template Item*(typ: typedesc[Dictionary]): typedesc = Variant
+
 
 var hook_copy: array[VariantType, PtrConstructor]
 var hook_destroy: array[VariantType, PtrDestructor]

--- a/src/gdext/core/gdclass.nim
+++ b/src/gdext/core/gdclass.nim
@@ -35,9 +35,6 @@ proc owner*(obj: Object): ObjectPtr =
   if unlikely(obj.isNil): nil
   else: obj.owner
 
-method onInit*(self: Object) {.base.} = discard
-method onDestroy*(self: Object) {.base.} = discard
-
 proc createClass*[T: Object](o: ObjectPtr): T =
   privateAccess Object
   result = cast[T](alloc sizeof pointerBase T)
@@ -46,7 +43,6 @@ proc createClass*[T: Object](o: ObjectPtr): T =
   when Dev.debugCallbacks:
     result.debugName = $T
   onInit result
-
 
 proc create_callback[T](p_token: pointer; p_instance: pointer): pointer {.gdcall.} =
   let class = createClass[T](cast[ObjectPtr](p_instance))

--- a/src/gdext/core/gdclass.nim
+++ b/src/gdext/core/gdclass.nim
@@ -26,15 +26,6 @@ type
     className*: StringName
     callbacks*: InstanceBindingCallbacks
 
-proc ownerPtr*(obj: Object): ptr ObjectPtr =
-  privateAccess Object
-  if unlikely(obj.isNil or obj.owner.isNil): nil
-  else: addr obj.owner
-proc owner*(obj: Object): ObjectPtr =
-  privateAccess Object
-  if unlikely(obj.isNil): nil
-  else: obj.owner
-
 proc createClass*[T: Object](o: ObjectPtr): T =
   privateAccess Object
   result = cast[T](alloc sizeof pointerBase T)

--- a/src/gdext/core/gdclass.nim
+++ b/src/gdext/core/gdclass.nim
@@ -3,7 +3,6 @@ import std/[tables, typetraits, importutils]
 import gdext/buildconf
 
 import gdext/gdinterface/[native, extracommands]
-import gdext/gen/globalenums
 import gdext/utils/macros
 
 import gdext/core/builtinindex
@@ -22,14 +21,6 @@ when Dev.debugCallbacks:
     DESTROY          = "SYNC------------DESTROY: "
 
 type
-  HeapPropertyInfo* = object
-    `type`*: VariantType
-    name*: ref StringName
-    className*: ref Stringname
-    hint*: PropertyHint
-    hintString*: ref String
-    usage*: set[PropertyUsageFlags]
-
   GodotClassMeta* = object
     virtualMethods*: Table[StringName, ClassCallVirtual]
     className*: StringName

--- a/src/gdext/core/gdrefs.nim
+++ b/src/gdext/core/gdrefs.nim
@@ -14,10 +14,10 @@ proc `=copy`*[T](dst: var GdRef[T]; src: GdRef[T]) =
   `=destroy` dst
   wasMoved dst
   dst.handle = src.handle
-  discard hook_reference(dst.handle.owner)
+  discard hook_reference(dst.handle)
 proc `=dup`*[T](src: GdRef[T]): GdRef[T] =
   result.handle = src.handle
-  discard hook_reference(result.handle.owner)
+  discard hook_reference(result.handle)
 
 
 proc unwrapped*[T](self: GdRef[T]): T = self.handle
@@ -25,6 +25,6 @@ proc unwrapped*[T](self: GdRef[T]): T = self.handle
 template gdref*[T](Type: typedesc[T]): typedesc = GdRef[Type]
 proc referenced*[T](self: T): GdRef[T] =
   result.handle = self
-  discard hook_reference(self.owner)
+  discard hook_reference(self)
 proc asGdRef*[T](self: T): GdRef[T] =
   result.handle = self

--- a/src/gdext/core/gdrefs.nim
+++ b/src/gdext/core/gdrefs.nim
@@ -1,6 +1,5 @@
 import gdext/gdinterface/native
 import gdext/gdinterface/extracommands
-import gdext/core/gdclass
 
 type
   GdRef*[RefCounted] = object

--- a/src/gdext/core/gdrefs.nim
+++ b/src/gdext/core/gdrefs.nim
@@ -8,17 +8,17 @@ type
 
 proc `=destroy`*[T](self: GdRef[T]) =
   if self.handle.isNil: return
-  let objectptr = CLASS_getObjectPtr self.handle
+  let objectptr = self.handle.owner
   if hook_unreference(objectptr):
     interfaceObjectDestroy objectptr
 proc `=copy`*[T](dst: var GdRef[T]; src: GdRef[T]) =
   `=destroy` dst
   wasMoved dst
   dst.handle = src.handle
-  discard hook_reference(CLASS_getObjectPtr dst.handle)
+  discard hook_reference(dst.handle.owner)
 proc `=dup`*[T](src: GdRef[T]): GdRef[T] =
   result.handle = src.handle
-  discard hook_reference(CLASS_getObjectPtr result.handle)
+  discard hook_reference(result.handle.owner)
 
 
 proc unwrapped*[T](self: GdRef[T]): T = self.handle
@@ -26,6 +26,6 @@ proc unwrapped*[T](self: GdRef[T]): T = self.handle
 template gdref*[T](Type: typedesc[T]): typedesc = GdRef[Type]
 proc referenced*[T](self: T): GdRef[T] =
   result.handle = self
-  discard hook_reference(CLASS_getObjectPtr self)
+  discard hook_reference(self.owner)
 proc asGdRef*[T](self: T): GdRef[T] =
   result.handle = self

--- a/src/gdext/core/gdtypedarray.nim
+++ b/src/gdext/core/gdtypedarray.nim
@@ -1,7 +1,0 @@
-import gdext/core/builtinindex
-import gdext/core/gdclass
-
-type SomeVariant* = concept t
-  t is (SomeClass or SomeBuiltins)
-
-type TypedArray*[T: SomeVariant] = distinct Array

--- a/src/gdext/core/typeshift.nim
+++ b/src/gdext/core/typeshift.nim
@@ -205,11 +205,11 @@ proc get*(v: Variant; T: typedesc[ObjectPtr]): T =
 
 template encoded*[T: Object](_: typedesc[T]): typedesc[ObjectPtr] = ObjectPtr
 template encode*[T: Object](v: T; p: pointer) =
-  encode(CLASS_getObjectPtr v, p)
+  encode(v.owner, p)
 proc decode*[T: Object](p: pointer; _: typedesc[T]): T =
   result = p.decode(ObjectPtr).getInstance(T)
 proc variant*[T: Object](v: T): Variant =
-  variant CLASS_getObjectPtr v
+  variant v.owner
 proc get*[T: Object](v: Variant; _: typedesc[T]): T =
   result = v.get(ObjectPtr).getInstance(T)
 

--- a/src/gdext/core/typeshift.nim
+++ b/src/gdext/core/typeshift.nim
@@ -2,7 +2,6 @@ import gdext/gdinterface/[native, extracommands]
 import gdext/core/builtinindex
 import gdext/core/gdclass
 import gdext/core/gdrefs
-import gdext/core/gdtypedarray
 
 var
   variantFromType: array[Variant_Type, VariantFromTypeConstructorFunc]

--- a/src/gdext/core/userclass/propertyinfo.nim
+++ b/src/gdext/core/userclass/propertyinfo.nim
@@ -5,9 +5,17 @@ import gdext/core/builtinindex
 import gdext/core/gdclass
 import gdext/core/gdrefs
 import gdext/core/typeshift
-import gdext/gen/globalenums except VariantType
+import gdext/gen/globalenums
 
 type
+  HeapPropertyInfo* = object
+    `type`*: VariantType
+    name*: ref StringName
+    className*: ref Stringname
+    hint*: PropertyHint
+    hintString*: ref String
+    usage*: set[PropertyUsageFlags]
+
   GodotEnumMeta* = object
     className*: StringName
     hintString*: String

--- a/src/gdext/core/userclass/tools.nim
+++ b/src/gdext/core/userclass/tools.nim
@@ -2,7 +2,6 @@ import std/[sequtils]
 
 import gdext/buildconf
 import gdext/utils/macros
-import gdext/core/gdclass
 import propertyinfo
 
 proc docComment*(def: NimNode): NimNode =

--- a/src/gdext/coronation/header/builtinclasses.nim
+++ b/src/gdext/coronation/header/builtinclasses.nim
@@ -3,7 +3,6 @@ import gdext/gdinterface/methodtools; export methodtools
 import gdext/gdinterface/extracommands
 import gdext/utils/staticevents; export staticevents
 import gdext/core/builtinindex; export builtinindex
-import gdext/core/gdclass; export gdclass
 
 from std/unicode import Rune; export Rune
 

--- a/src/gdext/coronation/header/builtinclasses/constructors.nim
+++ b/src/gdext/coronation/header/builtinclasses/constructors.nim
@@ -2,4 +2,3 @@ import gdext/gdinterface/native; export native
 import gdext/gdinterface/methodtools; export methodtools
 import gdext/utils/staticevents; export staticevents
 import gdext/core/builtinindex; export builtinindex
-import gdext/core/gdclass; export gdclass

--- a/src/gdext/coronation/header/classes.nim
+++ b/src/gdext/coronation/header/classes.nim
@@ -4,8 +4,8 @@ export                    classDB, methodtools, exceptions
 from gdext/gdinterface/extracommands import gdstring, stringname, classname
 export extracommands.gdstring, extracommands.stringname, extracommands.classname
 
-import gdext/core/[builtinindex, typeshift, gdclass, gdtypedarray, gdrefs ]
-export             builtinindex, typeshift, gdclass, gdtypedarray, gdrefs
+import gdext/core/[builtinindex, typeshift, gdclass, gdrefs ]
+export             builtinindex, typeshift, gdclass, gdrefs
 
 import gdext/gen/[
   builtinclasses, classindex, globalenums, localenums, structs

--- a/src/gdext/coronation/header/classindex.nim
+++ b/src/gdext/coronation/header/classindex.nim
@@ -1,1 +1,1 @@
-import gdext/core/gdclass; export gdclass
+import gdext/core/builtinindex; export builtinindex

--- a/src/gdext/coronation/header/structs.nim
+++ b/src/gdext/coronation/header/structs.nim
@@ -1,2 +1,1 @@
-import gdext/core/gdclass; export gdclass
 import gdext/core/builtinindex; export builtinindex

--- a/src/gdext/coronation/header/utilityfuncs.nim
+++ b/src/gdext/coronation/header/utilityfuncs.nim
@@ -1,8 +1,8 @@
 import gdext/gdinterface/[ native, extracommands, methodtools ]
 export                     native, extracommands, methodtools
 
-import gdext/core/[ builtinindex, gdclass ]
-export              builtinindex, gdclass
+import gdext/core/[ builtinindex]
+export              builtinindex
 
 proc load*(proc_name: string; hash: int): PtrUtilityFunction =
   let name = stringName proc_name

--- a/src/gdext/extclasses/gdextensionmain.nim
+++ b/src/gdext/extclasses/gdextensionmain.nim
@@ -1,4 +1,4 @@
-import gdext/core/[gdclass]
+import gdext/core/[builtinindex, gdclass]
 import gdext/classes/[gdengine]
 import gdext/gen/[classindex]
 import gdext/surface/[userclass, classutils]

--- a/src/gdext/gdinterface/extracommands.nim
+++ b/src/gdext/gdinterface/extracommands.nim
@@ -1,3 +1,4 @@
+import std/[importutils]
 import native
 import gdext/core/builtinindex
 
@@ -5,6 +6,15 @@ var newStringNameFromString: PtrConstructor
 var newStringFromStringName: PtrConstructor
 
 var String_length: PtrBuiltinMethod
+
+proc ownerPtr*(obj: Object): ptr ObjectPtr =
+  privateAccess Object
+  if unlikely(obj.isNil or obj.owner.isNil): nil
+  else: addr obj.owner
+proc owner*(obj: Object): ObjectPtr =
+  privateAccess Object
+  if unlikely(obj.isNil): nil
+  else: obj.owner
 
 proc gdstring*(str: string): String =
   interfaceStringNewWithUtf8Chars(addr result, cstring str)

--- a/src/gdext/gdinterface/extracommands.nim
+++ b/src/gdext/gdinterface/extracommands.nim
@@ -69,6 +69,16 @@ proc hook_getReferenceCount*(o: ObjectPtr): int32 {.raises: [].} =
     return int32 ret
   except: discard
 
+proc hook_reference*(o: RefCounted): Bool {.raises: [].} =
+  if unlikely(o.owner.isNil): return
+  hook_reference o.owner
+proc hook_unreference*(o: RefCounted): Bool {.raises: [].} =
+  if unlikely(o.owner.isNil): return
+  hook_unreference o.owner
+proc hook_getReferenceCount*(o: RefCounted): int32 {.raises: [].} =
+  if unlikely(o.owner.isNil): return
+  hook_getReferenceCount o.owner
+
 proc load* =
   newStringNameFromString = interfaceVariantGetPtrConstructor(VariantType_StringName, 2)
   newStringFromStringName = interfaceVariantGetPtrConstructor(VariantType_String, 2)

--- a/src/gdext/gdinterface/methodtools.nim
+++ b/src/gdext/gdinterface/methodtools.nim
@@ -1,7 +1,6 @@
 import native
 import extracommands
 import gdext/core/builtinindex
-import gdext/core/gdclass
 import gdext/core/gdrefs
 
 export gdcall

--- a/src/gdext/gdinterface/methodtools.nim
+++ b/src/gdext/gdinterface/methodtools.nim
@@ -7,15 +7,15 @@ import gdext/core/gdrefs
 export gdcall
 
 template CLASS_getOwner*(v: Object): ObjectPtr =
-  CLASS_getObjectPtr v
+  owner v
 
 template getPtr*[T](v: T): pointer = cast[pointer](addr v)
 template getPtr*(v: Variant): pointer = cast[pointer](addr v.data)
 template getPtr*[T: Object](v: T): pointer =
-  cast[pointer](CLASS_getObjectPtrPtr v)
+  cast[pointer](v.ownerPtr)
 template getPtr*(v: GdRef): pointer =
   if v.handle != nil:
-    discard hook_reference CLASS_getObjectPtr v.handle
+    discard hook_reference v.handle.owner
   getPtr v.handle
 
 proc getPtr*[I](arr: array[I, Variant]): array[I, pointer] =

--- a/src/gdext/gdinterface/methodtools.nim
+++ b/src/gdext/gdinterface/methodtools.nim
@@ -14,7 +14,7 @@ template getPtr*[T: Object](v: T): pointer =
   cast[pointer](v.ownerPtr)
 template getPtr*(v: GdRef): pointer =
   if v.handle != nil:
-    discard hook_reference v.handle.owner
+    discard hook_reference v.handle
   getPtr v.handle
 
 proc getPtr*[I](arr: array[I, Variant]): array[I, pointer] =

--- a/src/gdext/gdinterface/objects.nim
+++ b/src/gdext/gdinterface/objects.nim
@@ -1,4 +1,4 @@
-import gdext/gdinterface/[native, methodtools, exceptions]
+import gdext/gdinterface/[native, extracommands, methodtools, exceptions]
 import gdext/core/gdclass
 import gdext/core/builtinindex
 

--- a/src/gdext/gdinterface/objects.nim
+++ b/src/gdext/gdinterface/objects.nim
@@ -16,29 +16,29 @@ proc setInstance*(p_o: ObjectPtr; p_classname: StringName; p_instance: Object) =
 
 proc callScriptMethod*(obj: Object; p_method: StringName): Variant =
   var ce: CallError
-  interfaceObjectCallScriptMethod(CLASS_getObjectPtr obj, addr p_method, nil, 0, addr result, addr ce)
+  interfaceObjectCallScriptMethod(obj.owner, addr p_method, nil, 0, addr result, addr ce)
   check ce
 proc callScriptMethod*(obj: Object; p_method: StringName; args: array[0, Variant]): Variant =
   var ce: CallError
-  interfaceObjectCallScriptMethod(CLASS_getObjectPtr obj, addr p_method, nil, 0, addr result, addr ce)
+  interfaceObjectCallScriptMethod(obj.owner, addr p_method, nil, 0, addr result, addr ce)
   check ce
 proc callScriptMethod*[I](obj: Object; p_method: StringName; args: array[I, Variant]): Variant =
   var ce: CallError
   let args = getPtr args
-  interfaceObjectCallScriptMethod(CLASS_getObjectPtr obj, addr p_method, addr args[0], args.len, addr result, addr ce)
+  interfaceObjectCallScriptMethod(obj.owner, addr p_method, addr args[0], args.len, addr result, addr ce)
   check ce
 
 proc hasScriptMethod*(obj: Object; p_method: StringName): bool =
-  interfaceObjectHasScriptMethod(CLASS_getObjectPtr obj, addr p_method)
+  interfaceObjectHasScriptMethod(obj.owner, addr p_method)
 
 proc destroy*(obj: Object) =
-  interfaceObjectDestroy(CLASS_getObjectPtr obj)
+  interfaceObjectDestroy(obj.owner)
 
 proc castTo*(obj: Object; p_class_tag: pointer): ObjectPtr =
-  interfaceObjectCastTo(CLASS_getObjectPtr obj, p_class_tag)
+  interfaceObjectCastTo(obj.owner, p_class_tag)
 
 proc getInstanceID*(self: Object): GDObjectInstanceID =
-  interfaceObjectGetInstanceId CLASS_getObjectPtr self
+  interfaceObjectGetInstanceId self.owner
 
 proc getClassName*(self: Object): StringName =
-  discard interfaceObjectGetClassName(CLASS_getObjectPtr self, environment.library, addr result)
+  discard interfaceObjectGetClassName(self.owner, environment.library, addr result)

--- a/src/gdext/surface/arrayutils.nim
+++ b/src/gdext/surface/arrayutils.nim
@@ -1,5 +1,4 @@
 import gdext/gdinterface/native
-import gdext/core/gdtypedarray
 import gdext/core/builtinindex
 import gdext/core/gdclass
 import gdext/core/typeshift

--- a/src/gdext/surface/classutils.nim
+++ b/src/gdext/surface/classutils.nim
@@ -1,6 +1,6 @@
 import std/[strutils]
 
-import gdext/buildconf
+import gdext/utils/debugging
 import gdext/gdinterface/objects
 import gdext/gdinterface/classDB
 
@@ -22,13 +22,11 @@ proc instantiate_internal*[T: SomeUserClass](Type: typedesc[T]): T =
   objectPtr.setInstanceBinding(result, addr T.callbacks)
 
 proc instantiate*[T: Object and not RefCounted](_: typedesc[T]): T =
-  when Dev.debugCallbacks:
-    echo SYNC.INSTANTIATE, $T
   result = instantiate_internal T
+  debugInstantiate(result)
 proc instantiate*[T: RefCounted](_: typedesc[T]): GdRef[T] =
-  when Dev.debugCallbacks:
-    echo SYNC.INSTANTIATE, $T
   result = instantiate_internal(T).asGdRef
+  debugInstantiate(result.handle)
 
 proc castTo*[T: Object](self: Object; _: typedesc[T]): T =
   if self.isNil: return

--- a/src/gdext/surface/classutils.nim
+++ b/src/gdext/surface/classutils.nim
@@ -66,7 +66,6 @@ proc `$`*[T: Object](self: T): string =
   if self.isNil: return $self.getClassName & "(nil)"
   $self.getClassName & "(ID: 0x" & self.getInstanceID.toHex & ")"
 
-export onInit, onDestroy
 method notification*(self: Object; p_what: int32) {.base.} = discard
 method set*(self: Object; p_name: ConstStringNamePtr; p_value: ConstVariantPtr): Bool {.base.} = discard
 method get*(self: Object; p_name: ConstStringNamePtr; r_ret: VariantPtr): Bool {.base.} = discard

--- a/src/gdext/surface/conversions.nim
+++ b/src/gdext/surface/conversions.nim
@@ -1,5 +1,5 @@
 import gdext/gdinterface/variants
-import gdext/core/[builtinindex, gdclass, gdtypedarray]
+import gdext/core/[builtinindex]
 import gdext/gen/[builtinclasses]
 import gdext/surface/[classutils]
 

--- a/src/gdext/surface/nodeutils.nim
+++ b/src/gdext/surface/nodeutils.nim
@@ -1,6 +1,5 @@
 import std/macros
 
-import gdext/core/gdclass
 import gdext/core/builtinindex
 import gdext/gen/[builtinclasses, classindex]
 import gdext/classes/gdNode

--- a/src/gdext/surface/userclass.nim
+++ b/src/gdext/surface/userclass.nim
@@ -47,10 +47,10 @@ proc to_string_func(p_instance: ClassInstancePtr; r_is_valid: ptr Bool; p_out: S
 
 proc create_instance_func[T: SomeUserClass](p_userdata: pointer): ObjectPtr {.gdcall.} =
   let class = instantiate_internal T
-  result =  CLASS_getObjectPtr class
+  result =  class.owner
   when Dev.debugCallbacks:
     privateAccess Object
-    echo SYNC.CREATE_BIND, class.control.name
+    echo SYNC.CREATE_BIND, class.debugName
 
 proc free_instance_func[T: SomeUserClass](p_userdata: pointer; p_instance: pointer) {.gdcall.} =
   let class = cast[T](p_instance)
@@ -59,7 +59,7 @@ proc free_instance_func[T: SomeUserClass](p_userdata: pointer; p_instance: point
   dealloc class
   when Dev.debugCallbacks:
     privateAccess Object
-    echo SYNC.FREE_BIND, class.control.name
+    echo SYNC.FREE_BIND, class.debugName
 
 proc recreate_instance_func[T: SomeUserClass](p_class_userdata: pointer; p_object: ObjectPtr): ClassInstancePtr {.gdcall.} =
   let class = createClass[T](p_object)
@@ -68,19 +68,19 @@ proc recreate_instance_func[T: SomeUserClass](p_class_userdata: pointer; p_objec
   result = cast[pointer](class)
   when Dev.debugCallbacks:
     privateAccess Object
-    echo SYNC.RECREATE_BIND, class.control.name
+    echo SYNC.RECREATE_BIND, class.debugName
 
 proc reference_func(p_instance: pointer) {.gdcall.} =
   when Dev.debugCallbacks:
     let class = cast[RefCounted](p_instance)
-    let count = hook_getReferenceCount CLASS_getObjectPtr class
-    echo SYNC.REFERENCE_BIND, class.control.name, "(", $count & " UP)"
+    let count = hook_getReferenceCount class.owner
+    echo SYNC.REFERENCE_BIND, class.debugName, "(", $count & " UP)"
 
 proc unreference_func(p_instance: pointer) {.gdcall.} =
   when Dev.debugCallbacks:
     let class = cast[RefCounted](p_instance)
-    let count = hook_getReferenceCount CLASS_getObjectPtr class
-    echo SYNC.UNREFERENCE_BIND, class.control.name, "(", $count & " DOWN)"
+    let count = hook_getReferenceCount class.owner
+    echo SYNC.UNREFERENCE_BIND, class.debugName, "(", $count & " DOWN)"
 
 proc get_virtual_func(p_userdata: pointer; p_name: ConstStringNamePtr): ClassCallVirtual {.gdcall.} =
   cast[ptr GodotClassMeta](p_userdata).virtualMethods.getOrDefault(cast[ptr StringName](p_name)[])

--- a/src/gdext/utils/debugging.nim
+++ b/src/gdext/utils/debugging.nim
@@ -1,0 +1,140 @@
+import gdext/buildconf
+import gdext/core/builtinindex
+
+const DebugEnabled = Dev.debugCallbacks
+
+when DebugEnabled or isMainModule:
+  import std/[importutils, logging, compilesettings, os]
+  import gdext/gdinterface/[native, extracommands]
+
+  type GroupLogger = ref object of Logger
+    handlers: seq[Logger]
+
+  method log(logger: GroupLogger; level: Level; args: varargs[string, `$`]) =
+    for handler in logger.handlers:
+      handler.log(level, args)
+
+  proc addHandler(logger: GroupLogger; handler: Logger) =
+    logger.handlers.add handler
+
+  const projectPath = querySetting(projectPath)
+  const projectName = querySetting(projectName)
+
+  let global = new GroupLogger
+  let console = newConsoleLogger(fmtstr="[$time|$levelid] ")
+  global.addHandler console
+
+  proc debug(logger: Logger; args: varargs[string, `$`]) {.raises: [].} =
+    try:
+      logger.log(lvlDebug, args)
+    except: discard
+  proc error(logger: Logger; args: varargs[string, `$`]) {.raises: [].} =
+    try:
+      logger.log(lvlError, args)
+    except: discard
+  proc fatal(logger: Logger; args: varargs[string, `$`]) {.raises: [].} =
+    try:
+      logger.log(lvlFatal, args)
+    except: discard
+  proc info(logger: Logger; args: varargs[string, `$`]) {.raises: [].} =
+    try:
+      logger.log(lvlInfo, args)
+    except: discard
+  proc notice(logger: Logger; args: varargs[string, `$`]) {.raises: [].} =
+    try:
+      logger.log(lvlNotice, args)
+    except: discard
+  proc warn(logger: Logger; args: varargs[string, `$`]) {.raises: [].} =
+    try:
+      logger.log(lvlWarn, args)
+    except: discard
+
+  proc debug*(args: varargs[string, `$`]) {.raises: [].} =
+    global.debug(args)
+  proc error*(args: varargs[string, `$`]) {.raises: [].} =
+    global.error(args)
+  proc fatal*(args: varargs[string, `$`]) {.raises: [].} =
+    global.fatal(args)
+  proc info*(args: varargs[string, `$`]) {.raises: [].} =
+    global.info(args)
+  proc notice*(args: varargs[string, `$`]) {.raises: [].} =
+    global.notice(args)
+  proc warn*(args: varargs[string, `$`]) {.raises: [].} =
+    global.warn(args)
+
+  proc addDebugInfo*[T: Object](o: T) {.raises: [].} =
+    privateAccess Object
+    o.debugName = $T
+
+  proc debugName(o: Object): string =
+    privateAccess Object
+    o.debugName
+
+
+else:
+  template debug*(args: varargs[string, `$`]) = (discard)
+  template error*(args: varargs[string, `$`]) = (discard)
+  template fatal*(args: varargs[string, `$`]) = (discard)
+  template info*(args: varargs[string, `$`]) = (discard)
+  template notice*(args: varargs[string, `$`]) = (discard)
+  template warn*(args: varargs[string, `$`]) = (discard)
+
+  template addDebugInfo*(o: Object) = (discard)
+
+
+when Dev.debugCallbacks or isMainModule:
+  type SYNC = enum
+    INSTANTIATE = "Instantiate: "
+    CREATE      = "     Create: "
+    FREE        = "       Free: "
+    RECREATE    = "   Recreate: "
+    REFERENCE   = "  Reference: "
+    DESTROY     = "    Destroy: "
+
+  let callbacks = new GroupLogger
+  let callbacksLogger = newFileLogger(projectPath/projectName & ".callbacks.log", fmtstr = "[$time|$levelid] ")
+  global.addHandler callbacksLogger
+  callbacks.addHandler callbacksLogger
+  callbacks.addHandler console
+
+  proc instanceInfo*(o: Object): string =
+    result = o.debugName
+    result.add "("
+    result.add o.owner.classname
+    result.add ":"
+    result.add $interfaceObjectGetInstanceId(o.owner)
+    result.add ")"
+
+  proc debugInstantiate*(o: Object) {.raises: [].} =
+    try:
+      callbacks.notice SYNC.INSTANTIATE, o.instanceInfo
+    except: discard
+
+  proc debugCreate*(o: Object) {.raises: [].} =
+    try:
+      callbacks.notice SYNC.CREATE, o.instanceInfo
+    except: discard
+
+  proc debugRecreate*(o: Object) {.raises: [].} =
+    try:
+      callbacks.notice SYNC.RECREATE, o.instanceInfo
+    except: discard
+
+  proc debugFree*(o: Object) {.raises: [].} =
+    try:
+      callbacks.notice SYNC.FREE, o.instanceInfo
+    except: discard
+
+  proc debugReference*(o: Object; reference: bool) {.raises: [].} =
+    try:
+      let count = hook_getReferenceCount o.owner
+      let status = if reference: "UP" else: "DOWN"
+      callbacks.notice SYNC.REFERENCE, o.instanceInfo, "(", $count, " ", status, ")"
+    except: discard
+
+else:
+  template debugInstantiate*(o: Object) = (discard)
+  template debugCreate*(o: Object) = (discard)
+  template debugRecreate*(o: Object) = (discard)
+  template debugReference*(o: Object; reference: bool) = (discard)
+  template debugFree*(o: Object) = discard

--- a/testproject/runtime/nim/src/cases/use_api_from_toplevel.nim
+++ b/testproject/runtime/nim/src/cases/use_api_from_toplevel.nim
@@ -1,7 +1,7 @@
 import testutils
 
 import gdext
-import gdext/core/gdclass
+import gdext/gdinterface/extracommands
 import classes/gdtestobject
 
 type Test = enum

--- a/testproject/runtime/nim/src/cases/use_api_from_toplevel.nim
+++ b/testproject/runtime/nim/src/cases/use_api_from_toplevel.nim
@@ -39,8 +39,8 @@ runtime: test "instantiate at global":
   let engineclass = instantiate Object
   let extentclass = instantiate TestObject
 
-  check CLASS_getObjectPtr(engineclass) != nil
-  check CLASS_getObjectPtr(extentclass) != nil
+  check engineclass.owner != nil
+  check extentclass.owner != nil
 
   destroy engineclass
   destroy extentclass

--- a/testproject/runtime/nim/src/classes/gdextnode/typedef.nim
+++ b/testproject/runtime/nim/src/classes/gdextnode/typedef.nim
@@ -39,7 +39,7 @@ proc test_Object(self: GDExtNode) =
   suite "Object":
     test "instantiate":
       let obj: Object = instantiate Object
-      check CLASS_getObjectPtr(obj) != nil
+      check obj.owner != nil
       destroy obj
 
     test "singleton":

--- a/testproject/runtime/nim/src/classes/gdextnode/typedef.nim
+++ b/testproject/runtime/nim/src/classes/gdextnode/typedef.nim
@@ -2,7 +2,7 @@ import testutils
 import std/[tables, strutils]
 
 import gdext
-import gdext/gdinterface/native
+import gdext/gdinterface/[native, extracommands]
 import gdext/core/[gdclass, typeshift]
 
 import classes/gdvirtualnode01


### PR DESCRIPTION
* Organize where types and functions are defined and simplify internal module dependencies
* Define the debugger as a separate module and remove debugging code that interferes with readability
* Rename some legacy function names such as CLASS_getObjectPtr