### PR TITLE
Feat: Eliminate the restriction that the container type of the engine must be mutable.

### DIFF
--- a/coronation/src/coronation/operators/arguments.nim
+++ b/coronation/src/coronation/operators/arguments.nim
@@ -18,7 +18,6 @@ type
     ptaNake
     ptaSet
   ParamInfo* = object
-    isMutable*: bool
     isVarargs*: bool
     attribute*: ParamTypeAttr
     metaType*: TypeSym
@@ -74,8 +73,6 @@ proc `type`*(param: RenderableParamBase): string =
   of ptaSet:
     &"set[{name}]"
 
-  if param.info.ismutable:
-    return "var " & result
   if param.info.isVarargs:
     return &"varargs[{result}]"
 
@@ -85,8 +82,6 @@ proc `type`*(param: RenderableArgument): string =
 proc `type`*(param: RenderableSelfArgument): string =
   if param.isStatic:
     result.add "typedesc["
-  elif param.info.ismutable:
-    result.add "var "
   result.add $param.typeSym
 
   if param.isStatic:

--- a/coronation/src/coronation/operators/builtinclasses/methods.nim
+++ b/coronation/src/coronation/operators/builtinclasses/methods.nim
@@ -81,9 +81,6 @@ proc weave_methods*(json: JsonBuiltinClass): Cloth =
   proc extract_self(it: JsonBuiltinClassMethod): RenderableSelfArgument =
     RenderableSelfArgument(
       typeSym: typeSym,
-      info: ParamInfo(
-        ismutable: not it.is_const,
-      ),
       isStatic: it.isStatic,
     )
 

--- a/coronation/src/coronation/operators/builtinclasses/subscripts.nim
+++ b/coronation/src/coronation/operators/builtinclasses/subscripts.nim
@@ -28,14 +28,11 @@ proc weave_subscript*(json: JsonBuiltinClass): Cloth =
     case json.subscription(typename)
     of Never: discard
     of Optimize:
-      &"proc `[]`*(self: {typename}; index: int): {typename}.Item = self.data_unsafe[index]"
-      &"proc `[]`*(self: var {typename}; index: int): var {typename}.Item = self.data_unsafe[index]"
-      &"proc `[]=`*(self: var {typename}; index: int; value: {typename}.Item) = self.data_unsafe[index] = value"
+      &"proc `[]`*(self: {typename}; index: int): var {typename}.Item = self.data_unsafe[index]"
+      &"proc `[]=`*(self: {typename}; index: int; value: {typename}.Item) = self.data_unsafe[index] = value"
     of Indexing:
-      &"proc `[]`*(self: {typename}; index: int): {typename}.Item = cast[ptr {typename}.Item](interface_{typename}_operatorIndexConst(addr self, index))[]"
-      &"proc `[]`*(self: var {typename}; index: int): var {typename}.Item = cast[ptr {typename}.Item](interface_{typename}_operatorIndex(addr self, index))[]"
-      &"proc `[]=`*(self: var {typename}; index: int; value: {typename}.Item) = cast[ptr {typename}.Item](interface_{typename}_operatorIndex(addr self, index))[] = value"
+      &"proc `[]`*(self: {typename}; index: int): var {typename}.Item = cast[ptr {typename}.Item](interface_{typename}_operatorIndex(addr self, index))[]"
+      &"proc `[]=`*(self: {typename}; index: int; value: {typename}.Item) = cast[ptr {typename}.Item](interface_{typename}_operatorIndex(addr self, index))[] = value"
     of Keying:
-      &"proc `[]`*(self: {typename}; key: Variant): {typename}.Item = cast[ptr {typename}.Item](interface_{typename}_operatorIndexConst(addr self, addr key))[]"
-      &"proc `[]`*(self: var {typename}; key: Variant): var {typename}.Item = cast[ptr {typename}.Item](interface_{typename}_operatorIndex(addr self, addr key))[]"
-      &"proc `[]=`*(self: var {typename}; key: Variant; value: {typename}.Item) = cast[ptr {typename}.Item](interface_{typename}_operatorIndex(addr self, addr key))[] = value"
+      &"proc `[]`*(self: {typename}; key: Variant): var {typename}.Item = cast[ptr {typename}.Item](interface_{typename}_operatorIndex(addr self, addr key))[]"
+      &"proc `[]=`*(self: {typename}; key: Variant; value: {typename}.Item) = cast[ptr {typename}.Item](interface_{typename}_operatorIndex(addr self, addr key))[] = value"

--- a/src/gdext/gen/builtinclasses/gdarray.nim
+++ b/src/gdext/gen/builtinclasses/gdarray.nim
@@ -3,9 +3,8 @@
 import ./constructors
 import gdext/coronation/header/builtinclasses
 
-proc `[]`*(self: Array; index: int): Array.Item = cast[ptr Array.Item](interface_Array_operatorIndexConst(addr self, index))[]
-proc `[]`*(self: var Array; index: int): var Array.Item = cast[ptr Array.Item](interface_Array_operatorIndex(addr self, index))[]
-proc `[]=`*(self: var Array; index: int; value: Array.Item) = cast[ptr Array.Item](interface_Array_operatorIndex(addr self, index))[] = value
+proc `[]`*(self: Array; index: int): var Array.Item = cast[ptr Array.Item](interface_Array_operatorIndex(addr self, index))[]
+proc `[]=`*(self: Array; index: int; value: Array.Item) = cast[ptr Array.Item](interface_Array_operatorIndex(addr self, index))[] = value
 
 var `==(Array Variant)`: PtrOperatorEvaluator
 var `!=(Array Variant)`: PtrOperatorEvaluator
@@ -96,38 +95,38 @@ proc size*(self: Array): Int =
   `size(Array)`(addr self, nil, addr result, 0)
 proc isEmpty*(self: Array): bool =
   `isEmpty(Array)`(addr self, nil, addr result, 0)
-proc clear*(self: var Array): void =
+proc clear*(self: Array): void =
   `clear(Array)`(addr self, nil, nil, 0)
 proc hash*(self: Array): Int =
   `hash(Array)`(addr self, nil, addr result, 0)
-proc assign*(self: var Array; array: Array): void =
+proc assign*(self: Array; array: Array): void =
   let argArr = [getPtr array]
   `assign(Array Array)`(addr self, addr argArr[0], nil, 1)
-proc pushBack*(self: var Array; value: Variant): void =
+proc pushBack*(self: Array; value: Variant): void =
   let argArr = [getPtr value]
   `pushBack(Array Variant)`(addr self, addr argArr[0], nil, 1)
-proc pushFront*(self: var Array; value: Variant): void =
+proc pushFront*(self: Array; value: Variant): void =
   let argArr = [getPtr value]
   `pushFront(Array Variant)`(addr self, addr argArr[0], nil, 1)
-proc append*(self: var Array; value: Variant): void =
+proc append*(self: Array; value: Variant): void =
   let argArr = [getPtr value]
   `append(Array Variant)`(addr self, addr argArr[0], nil, 1)
-proc appendArray*(self: var Array; array: Array): void =
+proc appendArray*(self: Array; array: Array): void =
   let argArr = [getPtr array]
   `appendArray(Array Array)`(addr self, addr argArr[0], nil, 1)
-proc resize*(self: var Array; size: Int): Int =
+proc resize*(self: Array; size: Int): Int =
   let argArr = [getPtr size]
   `resize(Array Int)`(addr self, addr argArr[0], addr result, 1)
-proc insert*(self: var Array; position: Int; value: Variant): Int =
+proc insert*(self: Array; position: Int; value: Variant): Int =
   let argArr = [getPtr position, getPtr value]
   `insert(Array Int Variant)`(addr self, addr argArr[0], addr result, 2)
-proc removeAt*(self: var Array; position: Int): void =
+proc removeAt*(self: Array; position: Int): void =
   let argArr = [getPtr position]
   `removeAt(Array Int)`(addr self, addr argArr[0], nil, 1)
-proc fill*(self: var Array; value: Variant): void =
+proc fill*(self: Array; value: Variant): void =
   let argArr = [getPtr value]
   `fill(Array Variant)`(addr self, addr argArr[0], nil, 1)
-proc erase*(self: var Array; value: Variant): void =
+proc erase*(self: Array; value: Variant): void =
   let argArr = [getPtr value]
   `erase(Array Variant)`(addr self, addr argArr[0], nil, 1)
 proc front*(self: Array): Variant =
@@ -148,19 +147,19 @@ proc count*(self: Array; value: Variant): Int =
 proc has*(self: Array; value: Variant): bool =
   let argArr = [getPtr value]
   `has(Array Variant)`(addr self, addr argArr[0], addr result, 1)
-proc popBack*(self: var Array): Variant =
+proc popBack*(self: Array): Variant =
   `popBack(Array)`(addr self, nil, addr result, 0)
-proc popFront*(self: var Array): Variant =
+proc popFront*(self: Array): Variant =
   `popFront(Array)`(addr self, nil, addr result, 0)
-proc popAt*(self: var Array; position: Int): Variant =
+proc popAt*(self: Array; position: Int): Variant =
   let argArr = [getPtr position]
   `popAt(Array Int)`(addr self, addr argArr[0], addr result, 1)
-proc sort*(self: var Array): void =
+proc sort*(self: Array): void =
   `sort(Array)`(addr self, nil, nil, 0)
-proc sortCustom*(self: var Array; `func`: Callable): void =
+proc sortCustom*(self: Array; `func`: Callable): void =
   let argArr = [getPtr `func`]
   `sortCustom(Array Callable)`(addr self, addr argArr[0], nil, 1)
-proc shuffle*(self: var Array): void =
+proc shuffle*(self: Array): void =
   `shuffle(Array)`(addr self, nil, nil, 0)
 proc bsearch*(self: Array; value: Variant; before: bool = true): Int =
   let argArr = [getPtr value, getPtr before]
@@ -168,7 +167,7 @@ proc bsearch*(self: Array; value: Variant; before: bool = true): Int =
 proc bsearchCustom*(self: Array; value: Variant; `func`: Callable; before: bool = true): Int =
   let argArr = [getPtr value, getPtr `func`, getPtr before]
   `bsearchCustom(Array Variant Callable bool)`(addr self, addr argArr[0], addr result, 3)
-proc reverse*(self: var Array): void =
+proc reverse*(self: Array): void =
   `reverse(Array)`(addr self, nil, nil, 0)
 proc duplicate*(self: Array; deep: bool = false): Array =
   let argArr = [getPtr deep]
@@ -206,7 +205,7 @@ proc getTypedClassName*(self: Array): StringName =
   `getTypedClassName(Array)`(addr self, nil, addr result, 0)
 proc getTypedScript*(self: Array): Variant =
   `getTypedScript(Array)`(addr self, nil, addr result, 0)
-proc makeReadOnly*(self: var Array): void =
+proc makeReadOnly*(self: Array): void =
   `makeReadOnly(Array)`(addr self, nil, nil, 0)
 proc isReadOnly*(self: Array): bool =
   `isReadOnly(Array)`(addr self, nil, addr result, 0)

--- a/src/gdext/gen/builtinclasses/gdcallable.nim
+++ b/src/gdext/gen/builtinclasses/gdcallable.nim
@@ -75,7 +75,7 @@ proc getBoundArguments*(self: Callable): Array =
   `getBoundArguments(Callable)`(addr self, nil, addr result, 0)
 proc hash*(self: Callable): Int =
   `hash(Callable)`(addr self, nil, addr result, 0)
-proc bindv*(self: var Callable; arguments: Array): Callable =
+proc bindv*(self: Callable; arguments: Array): Callable =
   let argArr = [getPtr arguments]
   `bindv(Callable Array)`(addr self, addr argArr[0], addr result, 1)
 proc unbind*(self: Callable; argcount: Int): Callable =

--- a/src/gdext/gen/builtinclasses/gddictionary.nim
+++ b/src/gdext/gen/builtinclasses/gddictionary.nim
@@ -3,9 +3,8 @@
 import ./constructors
 import gdext/coronation/header/builtinclasses
 
-proc `[]`*(self: Dictionary; key: Variant): Dictionary.Item = cast[ptr Dictionary.Item](interface_Dictionary_operatorIndexConst(addr self, addr key))[]
-proc `[]`*(self: var Dictionary; key: Variant): var Dictionary.Item = cast[ptr Dictionary.Item](interface_Dictionary_operatorIndex(addr self, addr key))[]
-proc `[]=`*(self: var Dictionary; key: Variant; value: Dictionary.Item) = cast[ptr Dictionary.Item](interface_Dictionary_operatorIndex(addr self, addr key))[] = value
+proc `[]`*(self: Dictionary; key: Variant): var Dictionary.Item = cast[ptr Dictionary.Item](interface_Dictionary_operatorIndex(addr self, addr key))[]
+proc `[]=`*(self: Dictionary; key: Variant; value: Dictionary.Item) = cast[ptr Dictionary.Item](interface_Dictionary_operatorIndex(addr self, addr key))[] = value
 
 var `==(Dictionary Variant)`: PtrOperatorEvaluator
 var `!=(Dictionary Variant)`: PtrOperatorEvaluator
@@ -53,9 +52,9 @@ proc size*(self: Dictionary): Int =
   `size(Dictionary)`(addr self, nil, addr result, 0)
 proc isEmpty*(self: Dictionary): bool =
   `isEmpty(Dictionary)`(addr self, nil, addr result, 0)
-proc clear*(self: var Dictionary): void =
+proc clear*(self: Dictionary): void =
   `clear(Dictionary)`(addr self, nil, nil, 0)
-proc merge*(self: var Dictionary; dictionary: Dictionary; overwrite: bool = false): void =
+proc merge*(self: Dictionary; dictionary: Dictionary; overwrite: bool = false): void =
   let argArr = [getPtr dictionary, getPtr overwrite]
   `merge(Dictionary Dictionary bool)`(addr self, addr argArr[0], nil, 2)
 proc merged*(self: Dictionary; dictionary: Dictionary; overwrite: bool = false): Dictionary =
@@ -70,7 +69,7 @@ proc hasAll*(self: Dictionary; keys: Array): bool =
 proc findKey*(self: Dictionary; value: Variant): Variant =
   let argArr = [getPtr value]
   `findKey(Dictionary Variant)`(addr self, addr argArr[0], addr result, 1)
-proc erase*(self: var Dictionary; key: Variant): bool =
+proc erase*(self: Dictionary; key: Variant): bool =
   let argArr = [getPtr key]
   `erase(Dictionary Variant)`(addr self, addr argArr[0], addr result, 1)
 proc hash*(self: Dictionary): Int =
@@ -85,10 +84,10 @@ proc duplicate*(self: Dictionary; deep: bool = false): Dictionary =
 proc get*(self: Dictionary; key: Variant; default: Variant = default(Variant)): Variant =
   let argArr = [getPtr key, getPtr default]
   `get(Dictionary Variant Variant)`(addr self, addr argArr[0], addr result, 2)
-proc getOrAdd*(self: var Dictionary; key: Variant; default: Variant = default(Variant)): Variant =
+proc getOrAdd*(self: Dictionary; key: Variant; default: Variant = default(Variant)): Variant =
   let argArr = [getPtr key, getPtr default]
   `getOrAdd(Dictionary Variant Variant)`(addr self, addr argArr[0], addr result, 2)
-proc makeReadOnly*(self: var Dictionary): void =
+proc makeReadOnly*(self: Dictionary): void =
   `makeReadOnly(Dictionary)`(addr self, nil, nil, 0)
 proc isReadOnly*(self: Dictionary): bool =
   `isReadOnly(Dictionary)`(addr self, nil, addr result, 0)

--- a/src/gdext/gen/builtinclasses/gdpackedbytearray.nim
+++ b/src/gdext/gen/builtinclasses/gdpackedbytearray.nim
@@ -3,9 +3,8 @@
 import ./constructors
 import gdext/coronation/header/builtinclasses
 
-proc `[]`*(self: PackedByteArray; index: int): PackedByteArray.Item = self.data_unsafe[index]
-proc `[]`*(self: var PackedByteArray; index: int): var PackedByteArray.Item = self.data_unsafe[index]
-proc `[]=`*(self: var PackedByteArray; index: int; value: PackedByteArray.Item) = self.data_unsafe[index] = value
+proc `[]`*(self: PackedByteArray; index: int): var PackedByteArray.Item = self.data_unsafe[index]
+proc `[]=`*(self: PackedByteArray; index: int; value: PackedByteArray.Item) = self.data_unsafe[index] = value
 
 var `==(PackedByteArray Variant)`: PtrOperatorEvaluator
 var `!=(PackedByteArray Variant)`: PtrOperatorEvaluator
@@ -97,46 +96,46 @@ proc size*(self: PackedByteArray): Int =
   `size(PackedByteArray)`(addr self, nil, addr result, 0)
 proc isEmpty*(self: PackedByteArray): bool =
   `isEmpty(PackedByteArray)`(addr self, nil, addr result, 0)
-proc set*(self: var PackedByteArray; index: Int; value: Int): void =
+proc set*(self: PackedByteArray; index: Int; value: Int): void =
   let argArr = [getPtr index, getPtr value]
   `set(PackedByteArray Int Int)`(addr self, addr argArr[0], nil, 2)
-proc pushBack*(self: var PackedByteArray; value: Int): bool =
+proc pushBack*(self: PackedByteArray; value: Int): bool =
   let argArr = [getPtr value]
   `pushBack(PackedByteArray Int)`(addr self, addr argArr[0], addr result, 1)
-proc append*(self: var PackedByteArray; value: Int): bool =
+proc append*(self: PackedByteArray; value: Int): bool =
   let argArr = [getPtr value]
   `append(PackedByteArray Int)`(addr self, addr argArr[0], addr result, 1)
-proc appendArray*(self: var PackedByteArray; array: PackedByteArray): void =
+proc appendArray*(self: PackedByteArray; array: PackedByteArray): void =
   let argArr = [getPtr array]
   `appendArray(PackedByteArray PackedByteArray)`(addr self, addr argArr[0], nil, 1)
-proc removeAt*(self: var PackedByteArray; index: Int): void =
+proc removeAt*(self: PackedByteArray; index: Int): void =
   let argArr = [getPtr index]
   `removeAt(PackedByteArray Int)`(addr self, addr argArr[0], nil, 1)
-proc insert*(self: var PackedByteArray; atIndex: Int; value: Int): Int =
+proc insert*(self: PackedByteArray; atIndex: Int; value: Int): Int =
   let argArr = [getPtr atIndex, getPtr value]
   `insert(PackedByteArray Int Int)`(addr self, addr argArr[0], addr result, 2)
-proc fill*(self: var PackedByteArray; value: Int): void =
+proc fill*(self: PackedByteArray; value: Int): void =
   let argArr = [getPtr value]
   `fill(PackedByteArray Int)`(addr self, addr argArr[0], nil, 1)
-proc resize*(self: var PackedByteArray; newSize: Int): Int =
+proc resize*(self: PackedByteArray; newSize: Int): Int =
   let argArr = [getPtr newSize]
   `resize(PackedByteArray Int)`(addr self, addr argArr[0], addr result, 1)
-proc clear*(self: var PackedByteArray): void =
+proc clear*(self: PackedByteArray): void =
   `clear(PackedByteArray)`(addr self, nil, nil, 0)
 proc has*(self: PackedByteArray; value: Int): bool =
   let argArr = [getPtr value]
   `has(PackedByteArray Int)`(addr self, addr argArr[0], addr result, 1)
-proc reverse*(self: var PackedByteArray): void =
+proc reverse*(self: PackedByteArray): void =
   `reverse(PackedByteArray)`(addr self, nil, nil, 0)
 proc slice*(self: PackedByteArray; begin: Int; `end`: Int = 2147483647): PackedByteArray =
   let argArr = [getPtr begin, getPtr `end`]
   `slice(PackedByteArray Int Int)`(addr self, addr argArr[0], addr result, 2)
-proc sort*(self: var PackedByteArray): void =
+proc sort*(self: PackedByteArray): void =
   `sort(PackedByteArray)`(addr self, nil, nil, 0)
-proc bsearch*(self: var PackedByteArray; value: Int; before: bool = true): Int =
+proc bsearch*(self: PackedByteArray; value: Int; before: bool = true): Int =
   let argArr = [getPtr value, getPtr before]
   `bsearch(PackedByteArray Int bool)`(addr self, addr argArr[0], addr result, 2)
-proc duplicate*(self: var PackedByteArray): PackedByteArray =
+proc duplicate*(self: PackedByteArray): PackedByteArray =
   `duplicate(PackedByteArray)`(addr self, nil, addr result, 0)
 proc find*(self: PackedByteArray; value: Int; `from`: Int = 0): Int =
   let argArr = [getPtr value, getPtr `from`]
@@ -218,40 +217,40 @@ proc toFloat32Array*(self: PackedByteArray): PackedFloat32Array =
   `toFloat32Array(PackedByteArray)`(addr self, nil, addr result, 0)
 proc toFloat64Array*(self: PackedByteArray): PackedFloat64Array =
   `toFloat64Array(PackedByteArray)`(addr self, nil, addr result, 0)
-proc encodeU8*(self: var PackedByteArray; byteOffset: Int; value: Int): void =
+proc encodeU8*(self: PackedByteArray; byteOffset: Int; value: Int): void =
   let argArr = [getPtr byteOffset, getPtr value]
   `encodeU8(PackedByteArray Int Int)`(addr self, addr argArr[0], nil, 2)
-proc encodeS8*(self: var PackedByteArray; byteOffset: Int; value: Int): void =
+proc encodeS8*(self: PackedByteArray; byteOffset: Int; value: Int): void =
   let argArr = [getPtr byteOffset, getPtr value]
   `encodeS8(PackedByteArray Int Int)`(addr self, addr argArr[0], nil, 2)
-proc encodeU16*(self: var PackedByteArray; byteOffset: Int; value: Int): void =
+proc encodeU16*(self: PackedByteArray; byteOffset: Int; value: Int): void =
   let argArr = [getPtr byteOffset, getPtr value]
   `encodeU16(PackedByteArray Int Int)`(addr self, addr argArr[0], nil, 2)
-proc encodeS16*(self: var PackedByteArray; byteOffset: Int; value: Int): void =
+proc encodeS16*(self: PackedByteArray; byteOffset: Int; value: Int): void =
   let argArr = [getPtr byteOffset, getPtr value]
   `encodeS16(PackedByteArray Int Int)`(addr self, addr argArr[0], nil, 2)
-proc encodeU32*(self: var PackedByteArray; byteOffset: Int; value: Int): void =
+proc encodeU32*(self: PackedByteArray; byteOffset: Int; value: Int): void =
   let argArr = [getPtr byteOffset, getPtr value]
   `encodeU32(PackedByteArray Int Int)`(addr self, addr argArr[0], nil, 2)
-proc encodeS32*(self: var PackedByteArray; byteOffset: Int; value: Int): void =
+proc encodeS32*(self: PackedByteArray; byteOffset: Int; value: Int): void =
   let argArr = [getPtr byteOffset, getPtr value]
   `encodeS32(PackedByteArray Int Int)`(addr self, addr argArr[0], nil, 2)
-proc encodeU64*(self: var PackedByteArray; byteOffset: Int; value: Int): void =
+proc encodeU64*(self: PackedByteArray; byteOffset: Int; value: Int): void =
   let argArr = [getPtr byteOffset, getPtr value]
   `encodeU64(PackedByteArray Int Int)`(addr self, addr argArr[0], nil, 2)
-proc encodeS64*(self: var PackedByteArray; byteOffset: Int; value: Int): void =
+proc encodeS64*(self: PackedByteArray; byteOffset: Int; value: Int): void =
   let argArr = [getPtr byteOffset, getPtr value]
   `encodeS64(PackedByteArray Int Int)`(addr self, addr argArr[0], nil, 2)
-proc encodeHalf*(self: var PackedByteArray; byteOffset: Int; value: Float): void =
+proc encodeHalf*(self: PackedByteArray; byteOffset: Int; value: Float): void =
   let argArr = [getPtr byteOffset, getPtr value]
   `encodeHalf(PackedByteArray Int Float)`(addr self, addr argArr[0], nil, 2)
-proc encodeFloat*(self: var PackedByteArray; byteOffset: Int; value: Float): void =
+proc encodeFloat*(self: PackedByteArray; byteOffset: Int; value: Float): void =
   let argArr = [getPtr byteOffset, getPtr value]
   `encodeFloat(PackedByteArray Int Float)`(addr self, addr argArr[0], nil, 2)
-proc encodeDouble*(self: var PackedByteArray; byteOffset: Int; value: Float): void =
+proc encodeDouble*(self: PackedByteArray; byteOffset: Int; value: Float): void =
   let argArr = [getPtr byteOffset, getPtr value]
   `encodeDouble(PackedByteArray Int Float)`(addr self, addr argArr[0], nil, 2)
-proc encodeVar*(self: var PackedByteArray; byteOffset: Int; value: Variant; allowObjects: bool = false): Int =
+proc encodeVar*(self: PackedByteArray; byteOffset: Int; value: Variant; allowObjects: bool = false): Int =
   let argArr = [getPtr byteOffset, getPtr value, getPtr allowObjects]
   `encodeVar(PackedByteArray Int Variant bool)`(addr self, addr argArr[0], addr result, 3)
 

--- a/src/gdext/gen/builtinclasses/gdpackedcolorarray.nim
+++ b/src/gdext/gen/builtinclasses/gdpackedcolorarray.nim
@@ -3,9 +3,8 @@
 import ./constructors
 import gdext/coronation/header/builtinclasses
 
-proc `[]`*(self: PackedColorArray; index: int): PackedColorArray.Item = self.data_unsafe[index]
-proc `[]`*(self: var PackedColorArray; index: int): var PackedColorArray.Item = self.data_unsafe[index]
-proc `[]=`*(self: var PackedColorArray; index: int; value: PackedColorArray.Item) = self.data_unsafe[index] = value
+proc `[]`*(self: PackedColorArray; index: int): var PackedColorArray.Item = self.data_unsafe[index]
+proc `[]=`*(self: PackedColorArray; index: int; value: PackedColorArray.Item) = self.data_unsafe[index] = value
 
 var `==(PackedColorArray Variant)`: PtrOperatorEvaluator
 var `!=(PackedColorArray Variant)`: PtrOperatorEvaluator
@@ -59,48 +58,48 @@ proc size*(self: PackedColorArray): Int =
   `size(PackedColorArray)`(addr self, nil, addr result, 0)
 proc isEmpty*(self: PackedColorArray): bool =
   `isEmpty(PackedColorArray)`(addr self, nil, addr result, 0)
-proc set*(self: var PackedColorArray; index: Int; value: Color): void =
+proc set*(self: PackedColorArray; index: Int; value: Color): void =
   let argArr = [getPtr index, getPtr value]
   `set(PackedColorArray Int Color)`(addr self, addr argArr[0], nil, 2)
-proc pushBack*(self: var PackedColorArray; value: Color): bool =
+proc pushBack*(self: PackedColorArray; value: Color): bool =
   let argArr = [getPtr value]
   `pushBack(PackedColorArray Color)`(addr self, addr argArr[0], addr result, 1)
-proc append*(self: var PackedColorArray; value: Color): bool =
+proc append*(self: PackedColorArray; value: Color): bool =
   let argArr = [getPtr value]
   `append(PackedColorArray Color)`(addr self, addr argArr[0], addr result, 1)
-proc appendArray*(self: var PackedColorArray; array: PackedColorArray): void =
+proc appendArray*(self: PackedColorArray; array: PackedColorArray): void =
   let argArr = [getPtr array]
   `appendArray(PackedColorArray PackedColorArray)`(addr self, addr argArr[0], nil, 1)
-proc removeAt*(self: var PackedColorArray; index: Int): void =
+proc removeAt*(self: PackedColorArray; index: Int): void =
   let argArr = [getPtr index]
   `removeAt(PackedColorArray Int)`(addr self, addr argArr[0], nil, 1)
-proc insert*(self: var PackedColorArray; atIndex: Int; value: Color): Int =
+proc insert*(self: PackedColorArray; atIndex: Int; value: Color): Int =
   let argArr = [getPtr atIndex, getPtr value]
   `insert(PackedColorArray Int Color)`(addr self, addr argArr[0], addr result, 2)
-proc fill*(self: var PackedColorArray; value: Color): void =
+proc fill*(self: PackedColorArray; value: Color): void =
   let argArr = [getPtr value]
   `fill(PackedColorArray Color)`(addr self, addr argArr[0], nil, 1)
-proc resize*(self: var PackedColorArray; newSize: Int): Int =
+proc resize*(self: PackedColorArray; newSize: Int): Int =
   let argArr = [getPtr newSize]
   `resize(PackedColorArray Int)`(addr self, addr argArr[0], addr result, 1)
-proc clear*(self: var PackedColorArray): void =
+proc clear*(self: PackedColorArray): void =
   `clear(PackedColorArray)`(addr self, nil, nil, 0)
 proc has*(self: PackedColorArray; value: Color): bool =
   let argArr = [getPtr value]
   `has(PackedColorArray Color)`(addr self, addr argArr[0], addr result, 1)
-proc reverse*(self: var PackedColorArray): void =
+proc reverse*(self: PackedColorArray): void =
   `reverse(PackedColorArray)`(addr self, nil, nil, 0)
 proc slice*(self: PackedColorArray; begin: Int; `end`: Int = 2147483647): PackedColorArray =
   let argArr = [getPtr begin, getPtr `end`]
   `slice(PackedColorArray Int Int)`(addr self, addr argArr[0], addr result, 2)
 proc toByteArray*(self: PackedColorArray): PackedByteArray =
   `toByteArray(PackedColorArray)`(addr self, nil, addr result, 0)
-proc sort*(self: var PackedColorArray): void =
+proc sort*(self: PackedColorArray): void =
   `sort(PackedColorArray)`(addr self, nil, nil, 0)
-proc bsearch*(self: var PackedColorArray; value: Color; before: bool = true): Int =
+proc bsearch*(self: PackedColorArray; value: Color; before: bool = true): Int =
   let argArr = [getPtr value, getPtr before]
   `bsearch(PackedColorArray Color bool)`(addr self, addr argArr[0], addr result, 2)
-proc duplicate*(self: var PackedColorArray): PackedColorArray =
+proc duplicate*(self: PackedColorArray): PackedColorArray =
   `duplicate(PackedColorArray)`(addr self, nil, addr result, 0)
 proc find*(self: PackedColorArray; value: Color; `from`: Int = 0): Int =
   let argArr = [getPtr value, getPtr `from`]

--- a/src/gdext/gen/builtinclasses/gdpackedfloat32array.nim
+++ b/src/gdext/gen/builtinclasses/gdpackedfloat32array.nim
@@ -3,9 +3,8 @@
 import ./constructors
 import gdext/coronation/header/builtinclasses
 
-proc `[]`*(self: PackedFloat32Array; index: int): PackedFloat32Array.Item = self.data_unsafe[index]
-proc `[]`*(self: var PackedFloat32Array; index: int): var PackedFloat32Array.Item = self.data_unsafe[index]
-proc `[]=`*(self: var PackedFloat32Array; index: int; value: PackedFloat32Array.Item) = self.data_unsafe[index] = value
+proc `[]`*(self: PackedFloat32Array; index: int): var PackedFloat32Array.Item = self.data_unsafe[index]
+proc `[]=`*(self: PackedFloat32Array; index: int; value: PackedFloat32Array.Item) = self.data_unsafe[index] = value
 
 var `==(PackedFloat32Array Variant)`: PtrOperatorEvaluator
 var `!=(PackedFloat32Array Variant)`: PtrOperatorEvaluator
@@ -59,48 +58,48 @@ proc size*(self: PackedFloat32Array): Int =
   `size(PackedFloat32Array)`(addr self, nil, addr result, 0)
 proc isEmpty*(self: PackedFloat32Array): bool =
   `isEmpty(PackedFloat32Array)`(addr self, nil, addr result, 0)
-proc set*(self: var PackedFloat32Array; index: Int; value: Float): void =
+proc set*(self: PackedFloat32Array; index: Int; value: Float): void =
   let argArr = [getPtr index, getPtr value]
   `set(PackedFloat32Array Int Float)`(addr self, addr argArr[0], nil, 2)
-proc pushBack*(self: var PackedFloat32Array; value: Float): bool =
+proc pushBack*(self: PackedFloat32Array; value: Float): bool =
   let argArr = [getPtr value]
   `pushBack(PackedFloat32Array Float)`(addr self, addr argArr[0], addr result, 1)
-proc append*(self: var PackedFloat32Array; value: Float): bool =
+proc append*(self: PackedFloat32Array; value: Float): bool =
   let argArr = [getPtr value]
   `append(PackedFloat32Array Float)`(addr self, addr argArr[0], addr result, 1)
-proc appendArray*(self: var PackedFloat32Array; array: PackedFloat32Array): void =
+proc appendArray*(self: PackedFloat32Array; array: PackedFloat32Array): void =
   let argArr = [getPtr array]
   `appendArray(PackedFloat32Array PackedFloat32Array)`(addr self, addr argArr[0], nil, 1)
-proc removeAt*(self: var PackedFloat32Array; index: Int): void =
+proc removeAt*(self: PackedFloat32Array; index: Int): void =
   let argArr = [getPtr index]
   `removeAt(PackedFloat32Array Int)`(addr self, addr argArr[0], nil, 1)
-proc insert*(self: var PackedFloat32Array; atIndex: Int; value: Float): Int =
+proc insert*(self: PackedFloat32Array; atIndex: Int; value: Float): Int =
   let argArr = [getPtr atIndex, getPtr value]
   `insert(PackedFloat32Array Int Float)`(addr self, addr argArr[0], addr result, 2)
-proc fill*(self: var PackedFloat32Array; value: Float): void =
+proc fill*(self: PackedFloat32Array; value: Float): void =
   let argArr = [getPtr value]
   `fill(PackedFloat32Array Float)`(addr self, addr argArr[0], nil, 1)
-proc resize*(self: var PackedFloat32Array; newSize: Int): Int =
+proc resize*(self: PackedFloat32Array; newSize: Int): Int =
   let argArr = [getPtr newSize]
   `resize(PackedFloat32Array Int)`(addr self, addr argArr[0], addr result, 1)
-proc clear*(self: var PackedFloat32Array): void =
+proc clear*(self: PackedFloat32Array): void =
   `clear(PackedFloat32Array)`(addr self, nil, nil, 0)
 proc has*(self: PackedFloat32Array; value: Float): bool =
   let argArr = [getPtr value]
   `has(PackedFloat32Array Float)`(addr self, addr argArr[0], addr result, 1)
-proc reverse*(self: var PackedFloat32Array): void =
+proc reverse*(self: PackedFloat32Array): void =
   `reverse(PackedFloat32Array)`(addr self, nil, nil, 0)
 proc slice*(self: PackedFloat32Array; begin: Int; `end`: Int = 2147483647): PackedFloat32Array =
   let argArr = [getPtr begin, getPtr `end`]
   `slice(PackedFloat32Array Int Int)`(addr self, addr argArr[0], addr result, 2)
 proc toByteArray*(self: PackedFloat32Array): PackedByteArray =
   `toByteArray(PackedFloat32Array)`(addr self, nil, addr result, 0)
-proc sort*(self: var PackedFloat32Array): void =
+proc sort*(self: PackedFloat32Array): void =
   `sort(PackedFloat32Array)`(addr self, nil, nil, 0)
-proc bsearch*(self: var PackedFloat32Array; value: Float; before: bool = true): Int =
+proc bsearch*(self: PackedFloat32Array; value: Float; before: bool = true): Int =
   let argArr = [getPtr value, getPtr before]
   `bsearch(PackedFloat32Array Float bool)`(addr self, addr argArr[0], addr result, 2)
-proc duplicate*(self: var PackedFloat32Array): PackedFloat32Array =
+proc duplicate*(self: PackedFloat32Array): PackedFloat32Array =
   `duplicate(PackedFloat32Array)`(addr self, nil, addr result, 0)
 proc find*(self: PackedFloat32Array; value: Float; `from`: Int = 0): Int =
   let argArr = [getPtr value, getPtr `from`]

--- a/src/gdext/gen/builtinclasses/gdpackedfloat64array.nim
+++ b/src/gdext/gen/builtinclasses/gdpackedfloat64array.nim
@@ -3,9 +3,8 @@
 import ./constructors
 import gdext/coronation/header/builtinclasses
 
-proc `[]`*(self: PackedFloat64Array; index: int): PackedFloat64Array.Item = self.data_unsafe[index]
-proc `[]`*(self: var PackedFloat64Array; index: int): var PackedFloat64Array.Item = self.data_unsafe[index]
-proc `[]=`*(self: var PackedFloat64Array; index: int; value: PackedFloat64Array.Item) = self.data_unsafe[index] = value
+proc `[]`*(self: PackedFloat64Array; index: int): var PackedFloat64Array.Item = self.data_unsafe[index]
+proc `[]=`*(self: PackedFloat64Array; index: int; value: PackedFloat64Array.Item) = self.data_unsafe[index] = value
 
 var `==(PackedFloat64Array Variant)`: PtrOperatorEvaluator
 var `!=(PackedFloat64Array Variant)`: PtrOperatorEvaluator
@@ -59,48 +58,48 @@ proc size*(self: PackedFloat64Array): Int =
   `size(PackedFloat64Array)`(addr self, nil, addr result, 0)
 proc isEmpty*(self: PackedFloat64Array): bool =
   `isEmpty(PackedFloat64Array)`(addr self, nil, addr result, 0)
-proc set*(self: var PackedFloat64Array; index: Int; value: Float): void =
+proc set*(self: PackedFloat64Array; index: Int; value: Float): void =
   let argArr = [getPtr index, getPtr value]
   `set(PackedFloat64Array Int Float)`(addr self, addr argArr[0], nil, 2)
-proc pushBack*(self: var PackedFloat64Array; value: Float): bool =
+proc pushBack*(self: PackedFloat64Array; value: Float): bool =
   let argArr = [getPtr value]
   `pushBack(PackedFloat64Array Float)`(addr self, addr argArr[0], addr result, 1)
-proc append*(self: var PackedFloat64Array; value: Float): bool =
+proc append*(self: PackedFloat64Array; value: Float): bool =
   let argArr = [getPtr value]
   `append(PackedFloat64Array Float)`(addr self, addr argArr[0], addr result, 1)
-proc appendArray*(self: var PackedFloat64Array; array: PackedFloat64Array): void =
+proc appendArray*(self: PackedFloat64Array; array: PackedFloat64Array): void =
   let argArr = [getPtr array]
   `appendArray(PackedFloat64Array PackedFloat64Array)`(addr self, addr argArr[0], nil, 1)
-proc removeAt*(self: var PackedFloat64Array; index: Int): void =
+proc removeAt*(self: PackedFloat64Array; index: Int): void =
   let argArr = [getPtr index]
   `removeAt(PackedFloat64Array Int)`(addr self, addr argArr[0], nil, 1)
-proc insert*(self: var PackedFloat64Array; atIndex: Int; value: Float): Int =
+proc insert*(self: PackedFloat64Array; atIndex: Int; value: Float): Int =
   let argArr = [getPtr atIndex, getPtr value]
   `insert(PackedFloat64Array Int Float)`(addr self, addr argArr[0], addr result, 2)
-proc fill*(self: var PackedFloat64Array; value: Float): void =
+proc fill*(self: PackedFloat64Array; value: Float): void =
   let argArr = [getPtr value]
   `fill(PackedFloat64Array Float)`(addr self, addr argArr[0], nil, 1)
-proc resize*(self: var PackedFloat64Array; newSize: Int): Int =
+proc resize*(self: PackedFloat64Array; newSize: Int): Int =
   let argArr = [getPtr newSize]
   `resize(PackedFloat64Array Int)`(addr self, addr argArr[0], addr result, 1)
-proc clear*(self: var PackedFloat64Array): void =
+proc clear*(self: PackedFloat64Array): void =
   `clear(PackedFloat64Array)`(addr self, nil, nil, 0)
 proc has*(self: PackedFloat64Array; value: Float): bool =
   let argArr = [getPtr value]
   `has(PackedFloat64Array Float)`(addr self, addr argArr[0], addr result, 1)
-proc reverse*(self: var PackedFloat64Array): void =
+proc reverse*(self: PackedFloat64Array): void =
   `reverse(PackedFloat64Array)`(addr self, nil, nil, 0)
 proc slice*(self: PackedFloat64Array; begin: Int; `end`: Int = 2147483647): PackedFloat64Array =
   let argArr = [getPtr begin, getPtr `end`]
   `slice(PackedFloat64Array Int Int)`(addr self, addr argArr[0], addr result, 2)
 proc toByteArray*(self: PackedFloat64Array): PackedByteArray =
   `toByteArray(PackedFloat64Array)`(addr self, nil, addr result, 0)
-proc sort*(self: var PackedFloat64Array): void =
+proc sort*(self: PackedFloat64Array): void =
   `sort(PackedFloat64Array)`(addr self, nil, nil, 0)
-proc bsearch*(self: var PackedFloat64Array; value: Float; before: bool = true): Int =
+proc bsearch*(self: PackedFloat64Array; value: Float; before: bool = true): Int =
   let argArr = [getPtr value, getPtr before]
   `bsearch(PackedFloat64Array Float bool)`(addr self, addr argArr[0], addr result, 2)
-proc duplicate*(self: var PackedFloat64Array): PackedFloat64Array =
+proc duplicate*(self: PackedFloat64Array): PackedFloat64Array =
   `duplicate(PackedFloat64Array)`(addr self, nil, addr result, 0)
 proc find*(self: PackedFloat64Array; value: Float; `from`: Int = 0): Int =
   let argArr = [getPtr value, getPtr `from`]

--- a/src/gdext/gen/builtinclasses/gdpackedint32array.nim
+++ b/src/gdext/gen/builtinclasses/gdpackedint32array.nim
@@ -3,9 +3,8 @@
 import ./constructors
 import gdext/coronation/header/builtinclasses
 
-proc `[]`*(self: PackedInt32Array; index: int): PackedInt32Array.Item = self.data_unsafe[index]
-proc `[]`*(self: var PackedInt32Array; index: int): var PackedInt32Array.Item = self.data_unsafe[index]
-proc `[]=`*(self: var PackedInt32Array; index: int; value: PackedInt32Array.Item) = self.data_unsafe[index] = value
+proc `[]`*(self: PackedInt32Array; index: int): var PackedInt32Array.Item = self.data_unsafe[index]
+proc `[]=`*(self: PackedInt32Array; index: int; value: PackedInt32Array.Item) = self.data_unsafe[index] = value
 
 var `==(PackedInt32Array Variant)`: PtrOperatorEvaluator
 var `!=(PackedInt32Array Variant)`: PtrOperatorEvaluator
@@ -59,48 +58,48 @@ proc size*(self: PackedInt32Array): Int =
   `size(PackedInt32Array)`(addr self, nil, addr result, 0)
 proc isEmpty*(self: PackedInt32Array): bool =
   `isEmpty(PackedInt32Array)`(addr self, nil, addr result, 0)
-proc set*(self: var PackedInt32Array; index: Int; value: Int): void =
+proc set*(self: PackedInt32Array; index: Int; value: Int): void =
   let argArr = [getPtr index, getPtr value]
   `set(PackedInt32Array Int Int)`(addr self, addr argArr[0], nil, 2)
-proc pushBack*(self: var PackedInt32Array; value: Int): bool =
+proc pushBack*(self: PackedInt32Array; value: Int): bool =
   let argArr = [getPtr value]
   `pushBack(PackedInt32Array Int)`(addr self, addr argArr[0], addr result, 1)
-proc append*(self: var PackedInt32Array; value: Int): bool =
+proc append*(self: PackedInt32Array; value: Int): bool =
   let argArr = [getPtr value]
   `append(PackedInt32Array Int)`(addr self, addr argArr[0], addr result, 1)
-proc appendArray*(self: var PackedInt32Array; array: PackedInt32Array): void =
+proc appendArray*(self: PackedInt32Array; array: PackedInt32Array): void =
   let argArr = [getPtr array]
   `appendArray(PackedInt32Array PackedInt32Array)`(addr self, addr argArr[0], nil, 1)
-proc removeAt*(self: var PackedInt32Array; index: Int): void =
+proc removeAt*(self: PackedInt32Array; index: Int): void =
   let argArr = [getPtr index]
   `removeAt(PackedInt32Array Int)`(addr self, addr argArr[0], nil, 1)
-proc insert*(self: var PackedInt32Array; atIndex: Int; value: Int): Int =
+proc insert*(self: PackedInt32Array; atIndex: Int; value: Int): Int =
   let argArr = [getPtr atIndex, getPtr value]
   `insert(PackedInt32Array Int Int)`(addr self, addr argArr[0], addr result, 2)
-proc fill*(self: var PackedInt32Array; value: Int): void =
+proc fill*(self: PackedInt32Array; value: Int): void =
   let argArr = [getPtr value]
   `fill(PackedInt32Array Int)`(addr self, addr argArr[0], nil, 1)
-proc resize*(self: var PackedInt32Array; newSize: Int): Int =
+proc resize*(self: PackedInt32Array; newSize: Int): Int =
   let argArr = [getPtr newSize]
   `resize(PackedInt32Array Int)`(addr self, addr argArr[0], addr result, 1)
-proc clear*(self: var PackedInt32Array): void =
+proc clear*(self: PackedInt32Array): void =
   `clear(PackedInt32Array)`(addr self, nil, nil, 0)
 proc has*(self: PackedInt32Array; value: Int): bool =
   let argArr = [getPtr value]
   `has(PackedInt32Array Int)`(addr self, addr argArr[0], addr result, 1)
-proc reverse*(self: var PackedInt32Array): void =
+proc reverse*(self: PackedInt32Array): void =
   `reverse(PackedInt32Array)`(addr self, nil, nil, 0)
 proc slice*(self: PackedInt32Array; begin: Int; `end`: Int = 2147483647): PackedInt32Array =
   let argArr = [getPtr begin, getPtr `end`]
   `slice(PackedInt32Array Int Int)`(addr self, addr argArr[0], addr result, 2)
 proc toByteArray*(self: PackedInt32Array): PackedByteArray =
   `toByteArray(PackedInt32Array)`(addr self, nil, addr result, 0)
-proc sort*(self: var PackedInt32Array): void =
+proc sort*(self: PackedInt32Array): void =
   `sort(PackedInt32Array)`(addr self, nil, nil, 0)
-proc bsearch*(self: var PackedInt32Array; value: Int; before: bool = true): Int =
+proc bsearch*(self: PackedInt32Array; value: Int; before: bool = true): Int =
   let argArr = [getPtr value, getPtr before]
   `bsearch(PackedInt32Array Int bool)`(addr self, addr argArr[0], addr result, 2)
-proc duplicate*(self: var PackedInt32Array): PackedInt32Array =
+proc duplicate*(self: PackedInt32Array): PackedInt32Array =
   `duplicate(PackedInt32Array)`(addr self, nil, addr result, 0)
 proc find*(self: PackedInt32Array; value: Int; `from`: Int = 0): Int =
   let argArr = [getPtr value, getPtr `from`]

--- a/src/gdext/gen/builtinclasses/gdpackedint64array.nim
+++ b/src/gdext/gen/builtinclasses/gdpackedint64array.nim
@@ -3,9 +3,8 @@
 import ./constructors
 import gdext/coronation/header/builtinclasses
 
-proc `[]`*(self: PackedInt64Array; index: int): PackedInt64Array.Item = self.data_unsafe[index]
-proc `[]`*(self: var PackedInt64Array; index: int): var PackedInt64Array.Item = self.data_unsafe[index]
-proc `[]=`*(self: var PackedInt64Array; index: int; value: PackedInt64Array.Item) = self.data_unsafe[index] = value
+proc `[]`*(self: PackedInt64Array; index: int): var PackedInt64Array.Item = self.data_unsafe[index]
+proc `[]=`*(self: PackedInt64Array; index: int; value: PackedInt64Array.Item) = self.data_unsafe[index] = value
 
 var `==(PackedInt64Array Variant)`: PtrOperatorEvaluator
 var `!=(PackedInt64Array Variant)`: PtrOperatorEvaluator
@@ -59,48 +58,48 @@ proc size*(self: PackedInt64Array): Int =
   `size(PackedInt64Array)`(addr self, nil, addr result, 0)
 proc isEmpty*(self: PackedInt64Array): bool =
   `isEmpty(PackedInt64Array)`(addr self, nil, addr result, 0)
-proc set*(self: var PackedInt64Array; index: Int; value: Int): void =
+proc set*(self: PackedInt64Array; index: Int; value: Int): void =
   let argArr = [getPtr index, getPtr value]
   `set(PackedInt64Array Int Int)`(addr self, addr argArr[0], nil, 2)
-proc pushBack*(self: var PackedInt64Array; value: Int): bool =
+proc pushBack*(self: PackedInt64Array; value: Int): bool =
   let argArr = [getPtr value]
   `pushBack(PackedInt64Array Int)`(addr self, addr argArr[0], addr result, 1)
-proc append*(self: var PackedInt64Array; value: Int): bool =
+proc append*(self: PackedInt64Array; value: Int): bool =
   let argArr = [getPtr value]
   `append(PackedInt64Array Int)`(addr self, addr argArr[0], addr result, 1)
-proc appendArray*(self: var PackedInt64Array; array: PackedInt64Array): void =
+proc appendArray*(self: PackedInt64Array; array: PackedInt64Array): void =
   let argArr = [getPtr array]
   `appendArray(PackedInt64Array PackedInt64Array)`(addr self, addr argArr[0], nil, 1)
-proc removeAt*(self: var PackedInt64Array; index: Int): void =
+proc removeAt*(self: PackedInt64Array; index: Int): void =
   let argArr = [getPtr index]
   `removeAt(PackedInt64Array Int)`(addr self, addr argArr[0], nil, 1)
-proc insert*(self: var PackedInt64Array; atIndex: Int; value: Int): Int =
+proc insert*(self: PackedInt64Array; atIndex: Int; value: Int): Int =
   let argArr = [getPtr atIndex, getPtr value]
   `insert(PackedInt64Array Int Int)`(addr self, addr argArr[0], addr result, 2)
-proc fill*(self: var PackedInt64Array; value: Int): void =
+proc fill*(self: PackedInt64Array; value: Int): void =
   let argArr = [getPtr value]
   `fill(PackedInt64Array Int)`(addr self, addr argArr[0], nil, 1)
-proc resize*(self: var PackedInt64Array; newSize: Int): Int =
+proc resize*(self: PackedInt64Array; newSize: Int): Int =
   let argArr = [getPtr newSize]
   `resize(PackedInt64Array Int)`(addr self, addr argArr[0], addr result, 1)
-proc clear*(self: var PackedInt64Array): void =
+proc clear*(self: PackedInt64Array): void =
   `clear(PackedInt64Array)`(addr self, nil, nil, 0)
 proc has*(self: PackedInt64Array; value: Int): bool =
   let argArr = [getPtr value]
   `has(PackedInt64Array Int)`(addr self, addr argArr[0], addr result, 1)
-proc reverse*(self: var PackedInt64Array): void =
+proc reverse*(self: PackedInt64Array): void =
   `reverse(PackedInt64Array)`(addr self, nil, nil, 0)
 proc slice*(self: PackedInt64Array; begin: Int; `end`: Int = 2147483647): PackedInt64Array =
   let argArr = [getPtr begin, getPtr `end`]
   `slice(PackedInt64Array Int Int)`(addr self, addr argArr[0], addr result, 2)
 proc toByteArray*(self: PackedInt64Array): PackedByteArray =
   `toByteArray(PackedInt64Array)`(addr self, nil, addr result, 0)
-proc sort*(self: var PackedInt64Array): void =
+proc sort*(self: PackedInt64Array): void =
   `sort(PackedInt64Array)`(addr self, nil, nil, 0)
-proc bsearch*(self: var PackedInt64Array; value: Int; before: bool = true): Int =
+proc bsearch*(self: PackedInt64Array; value: Int; before: bool = true): Int =
   let argArr = [getPtr value, getPtr before]
   `bsearch(PackedInt64Array Int bool)`(addr self, addr argArr[0], addr result, 2)
-proc duplicate*(self: var PackedInt64Array): PackedInt64Array =
+proc duplicate*(self: PackedInt64Array): PackedInt64Array =
   `duplicate(PackedInt64Array)`(addr self, nil, addr result, 0)
 proc find*(self: PackedInt64Array; value: Int; `from`: Int = 0): Int =
   let argArr = [getPtr value, getPtr `from`]

--- a/src/gdext/gen/builtinclasses/gdpackedstringarray.nim
+++ b/src/gdext/gen/builtinclasses/gdpackedstringarray.nim
@@ -3,9 +3,8 @@
 import ./constructors
 import gdext/coronation/header/builtinclasses
 
-proc `[]`*(self: PackedStringArray; index: int): PackedStringArray.Item = self.data_unsafe[index]
-proc `[]`*(self: var PackedStringArray; index: int): var PackedStringArray.Item = self.data_unsafe[index]
-proc `[]=`*(self: var PackedStringArray; index: int; value: PackedStringArray.Item) = self.data_unsafe[index] = value
+proc `[]`*(self: PackedStringArray; index: int): var PackedStringArray.Item = self.data_unsafe[index]
+proc `[]=`*(self: PackedStringArray; index: int; value: PackedStringArray.Item) = self.data_unsafe[index] = value
 
 var `==(PackedStringArray Variant)`: PtrOperatorEvaluator
 var `!=(PackedStringArray Variant)`: PtrOperatorEvaluator
@@ -59,48 +58,48 @@ proc size*(self: PackedStringArray): Int =
   `size(PackedStringArray)`(addr self, nil, addr result, 0)
 proc isEmpty*(self: PackedStringArray): bool =
   `isEmpty(PackedStringArray)`(addr self, nil, addr result, 0)
-proc set*(self: var PackedStringArray; index: Int; value: String): void =
+proc set*(self: PackedStringArray; index: Int; value: String): void =
   let argArr = [getPtr index, getPtr value]
   `set(PackedStringArray Int String)`(addr self, addr argArr[0], nil, 2)
-proc pushBack*(self: var PackedStringArray; value: String): bool =
+proc pushBack*(self: PackedStringArray; value: String): bool =
   let argArr = [getPtr value]
   `pushBack(PackedStringArray String)`(addr self, addr argArr[0], addr result, 1)
-proc append*(self: var PackedStringArray; value: String): bool =
+proc append*(self: PackedStringArray; value: String): bool =
   let argArr = [getPtr value]
   `append(PackedStringArray String)`(addr self, addr argArr[0], addr result, 1)
-proc appendArray*(self: var PackedStringArray; array: PackedStringArray): void =
+proc appendArray*(self: PackedStringArray; array: PackedStringArray): void =
   let argArr = [getPtr array]
   `appendArray(PackedStringArray PackedStringArray)`(addr self, addr argArr[0], nil, 1)
-proc removeAt*(self: var PackedStringArray; index: Int): void =
+proc removeAt*(self: PackedStringArray; index: Int): void =
   let argArr = [getPtr index]
   `removeAt(PackedStringArray Int)`(addr self, addr argArr[0], nil, 1)
-proc insert*(self: var PackedStringArray; atIndex: Int; value: String): Int =
+proc insert*(self: PackedStringArray; atIndex: Int; value: String): Int =
   let argArr = [getPtr atIndex, getPtr value]
   `insert(PackedStringArray Int String)`(addr self, addr argArr[0], addr result, 2)
-proc fill*(self: var PackedStringArray; value: String): void =
+proc fill*(self: PackedStringArray; value: String): void =
   let argArr = [getPtr value]
   `fill(PackedStringArray String)`(addr self, addr argArr[0], nil, 1)
-proc resize*(self: var PackedStringArray; newSize: Int): Int =
+proc resize*(self: PackedStringArray; newSize: Int): Int =
   let argArr = [getPtr newSize]
   `resize(PackedStringArray Int)`(addr self, addr argArr[0], addr result, 1)
-proc clear*(self: var PackedStringArray): void =
+proc clear*(self: PackedStringArray): void =
   `clear(PackedStringArray)`(addr self, nil, nil, 0)
 proc has*(self: PackedStringArray; value: String): bool =
   let argArr = [getPtr value]
   `has(PackedStringArray String)`(addr self, addr argArr[0], addr result, 1)
-proc reverse*(self: var PackedStringArray): void =
+proc reverse*(self: PackedStringArray): void =
   `reverse(PackedStringArray)`(addr self, nil, nil, 0)
 proc slice*(self: PackedStringArray; begin: Int; `end`: Int = 2147483647): PackedStringArray =
   let argArr = [getPtr begin, getPtr `end`]
   `slice(PackedStringArray Int Int)`(addr self, addr argArr[0], addr result, 2)
 proc toByteArray*(self: PackedStringArray): PackedByteArray =
   `toByteArray(PackedStringArray)`(addr self, nil, addr result, 0)
-proc sort*(self: var PackedStringArray): void =
+proc sort*(self: PackedStringArray): void =
   `sort(PackedStringArray)`(addr self, nil, nil, 0)
-proc bsearch*(self: var PackedStringArray; value: String; before: bool = true): Int =
+proc bsearch*(self: PackedStringArray; value: String; before: bool = true): Int =
   let argArr = [getPtr value, getPtr before]
   `bsearch(PackedStringArray String bool)`(addr self, addr argArr[0], addr result, 2)
-proc duplicate*(self: var PackedStringArray): PackedStringArray =
+proc duplicate*(self: PackedStringArray): PackedStringArray =
   `duplicate(PackedStringArray)`(addr self, nil, addr result, 0)
 proc find*(self: PackedStringArray; value: String; `from`: Int = 0): Int =
   let argArr = [getPtr value, getPtr `from`]

--- a/src/gdext/gen/builtinclasses/gdpackedvector2array.nim
+++ b/src/gdext/gen/builtinclasses/gdpackedvector2array.nim
@@ -3,9 +3,8 @@
 import ./constructors
 import gdext/coronation/header/builtinclasses
 
-proc `[]`*(self: PackedVector2Array; index: int): PackedVector2Array.Item = self.data_unsafe[index]
-proc `[]`*(self: var PackedVector2Array; index: int): var PackedVector2Array.Item = self.data_unsafe[index]
-proc `[]=`*(self: var PackedVector2Array; index: int; value: PackedVector2Array.Item) = self.data_unsafe[index] = value
+proc `[]`*(self: PackedVector2Array; index: int): var PackedVector2Array.Item = self.data_unsafe[index]
+proc `[]=`*(self: PackedVector2Array; index: int; value: PackedVector2Array.Item) = self.data_unsafe[index] = value
 
 var `==(PackedVector2Array Variant)`: PtrOperatorEvaluator
 var `!=(PackedVector2Array Variant)`: PtrOperatorEvaluator
@@ -62,48 +61,48 @@ proc size*(self: PackedVector2Array): Int =
   `size(PackedVector2Array)`(addr self, nil, addr result, 0)
 proc isEmpty*(self: PackedVector2Array): bool =
   `isEmpty(PackedVector2Array)`(addr self, nil, addr result, 0)
-proc set*(self: var PackedVector2Array; index: Int; value: Vector2): void =
+proc set*(self: PackedVector2Array; index: Int; value: Vector2): void =
   let argArr = [getPtr index, getPtr value]
   `set(PackedVector2Array Int Vector2)`(addr self, addr argArr[0], nil, 2)
-proc pushBack*(self: var PackedVector2Array; value: Vector2): bool =
+proc pushBack*(self: PackedVector2Array; value: Vector2): bool =
   let argArr = [getPtr value]
   `pushBack(PackedVector2Array Vector2)`(addr self, addr argArr[0], addr result, 1)
-proc append*(self: var PackedVector2Array; value: Vector2): bool =
+proc append*(self: PackedVector2Array; value: Vector2): bool =
   let argArr = [getPtr value]
   `append(PackedVector2Array Vector2)`(addr self, addr argArr[0], addr result, 1)
-proc appendArray*(self: var PackedVector2Array; array: PackedVector2Array): void =
+proc appendArray*(self: PackedVector2Array; array: PackedVector2Array): void =
   let argArr = [getPtr array]
   `appendArray(PackedVector2Array PackedVector2Array)`(addr self, addr argArr[0], nil, 1)
-proc removeAt*(self: var PackedVector2Array; index: Int): void =
+proc removeAt*(self: PackedVector2Array; index: Int): void =
   let argArr = [getPtr index]
   `removeAt(PackedVector2Array Int)`(addr self, addr argArr[0], nil, 1)
-proc insert*(self: var PackedVector2Array; atIndex: Int; value: Vector2): Int =
+proc insert*(self: PackedVector2Array; atIndex: Int; value: Vector2): Int =
   let argArr = [getPtr atIndex, getPtr value]
   `insert(PackedVector2Array Int Vector2)`(addr self, addr argArr[0], addr result, 2)
-proc fill*(self: var PackedVector2Array; value: Vector2): void =
+proc fill*(self: PackedVector2Array; value: Vector2): void =
   let argArr = [getPtr value]
   `fill(PackedVector2Array Vector2)`(addr self, addr argArr[0], nil, 1)
-proc resize*(self: var PackedVector2Array; newSize: Int): Int =
+proc resize*(self: PackedVector2Array; newSize: Int): Int =
   let argArr = [getPtr newSize]
   `resize(PackedVector2Array Int)`(addr self, addr argArr[0], addr result, 1)
-proc clear*(self: var PackedVector2Array): void =
+proc clear*(self: PackedVector2Array): void =
   `clear(PackedVector2Array)`(addr self, nil, nil, 0)
 proc has*(self: PackedVector2Array; value: Vector2): bool =
   let argArr = [getPtr value]
   `has(PackedVector2Array Vector2)`(addr self, addr argArr[0], addr result, 1)
-proc reverse*(self: var PackedVector2Array): void =
+proc reverse*(self: PackedVector2Array): void =
   `reverse(PackedVector2Array)`(addr self, nil, nil, 0)
 proc slice*(self: PackedVector2Array; begin: Int; `end`: Int = 2147483647): PackedVector2Array =
   let argArr = [getPtr begin, getPtr `end`]
   `slice(PackedVector2Array Int Int)`(addr self, addr argArr[0], addr result, 2)
 proc toByteArray*(self: PackedVector2Array): PackedByteArray =
   `toByteArray(PackedVector2Array)`(addr self, nil, addr result, 0)
-proc sort*(self: var PackedVector2Array): void =
+proc sort*(self: PackedVector2Array): void =
   `sort(PackedVector2Array)`(addr self, nil, nil, 0)
-proc bsearch*(self: var PackedVector2Array; value: Vector2; before: bool = true): Int =
+proc bsearch*(self: PackedVector2Array; value: Vector2; before: bool = true): Int =
   let argArr = [getPtr value, getPtr before]
   `bsearch(PackedVector2Array Vector2 bool)`(addr self, addr argArr[0], addr result, 2)
-proc duplicate*(self: var PackedVector2Array): PackedVector2Array =
+proc duplicate*(self: PackedVector2Array): PackedVector2Array =
   `duplicate(PackedVector2Array)`(addr self, nil, addr result, 0)
 proc find*(self: PackedVector2Array; value: Vector2; `from`: Int = 0): Int =
   let argArr = [getPtr value, getPtr `from`]

--- a/src/gdext/gen/builtinclasses/gdpackedvector3array.nim
+++ b/src/gdext/gen/builtinclasses/gdpackedvector3array.nim
@@ -3,9 +3,8 @@
 import ./constructors
 import gdext/coronation/header/builtinclasses
 
-proc `[]`*(self: PackedVector3Array; index: int): PackedVector3Array.Item = self.data_unsafe[index]
-proc `[]`*(self: var PackedVector3Array; index: int): var PackedVector3Array.Item = self.data_unsafe[index]
-proc `[]=`*(self: var PackedVector3Array; index: int; value: PackedVector3Array.Item) = self.data_unsafe[index] = value
+proc `[]`*(self: PackedVector3Array; index: int): var PackedVector3Array.Item = self.data_unsafe[index]
+proc `[]=`*(self: PackedVector3Array; index: int; value: PackedVector3Array.Item) = self.data_unsafe[index] = value
 
 var `==(PackedVector3Array Variant)`: PtrOperatorEvaluator
 var `!=(PackedVector3Array Variant)`: PtrOperatorEvaluator
@@ -62,48 +61,48 @@ proc size*(self: PackedVector3Array): Int =
   `size(PackedVector3Array)`(addr self, nil, addr result, 0)
 proc isEmpty*(self: PackedVector3Array): bool =
   `isEmpty(PackedVector3Array)`(addr self, nil, addr result, 0)
-proc set*(self: var PackedVector3Array; index: Int; value: Vector3): void =
+proc set*(self: PackedVector3Array; index: Int; value: Vector3): void =
   let argArr = [getPtr index, getPtr value]
   `set(PackedVector3Array Int Vector3)`(addr self, addr argArr[0], nil, 2)
-proc pushBack*(self: var PackedVector3Array; value: Vector3): bool =
+proc pushBack*(self: PackedVector3Array; value: Vector3): bool =
   let argArr = [getPtr value]
   `pushBack(PackedVector3Array Vector3)`(addr self, addr argArr[0], addr result, 1)
-proc append*(self: var PackedVector3Array; value: Vector3): bool =
+proc append*(self: PackedVector3Array; value: Vector3): bool =
   let argArr = [getPtr value]
   `append(PackedVector3Array Vector3)`(addr self, addr argArr[0], addr result, 1)
-proc appendArray*(self: var PackedVector3Array; array: PackedVector3Array): void =
+proc appendArray*(self: PackedVector3Array; array: PackedVector3Array): void =
   let argArr = [getPtr array]
   `appendArray(PackedVector3Array PackedVector3Array)`(addr self, addr argArr[0], nil, 1)
-proc removeAt*(self: var PackedVector3Array; index: Int): void =
+proc removeAt*(self: PackedVector3Array; index: Int): void =
   let argArr = [getPtr index]
   `removeAt(PackedVector3Array Int)`(addr self, addr argArr[0], nil, 1)
-proc insert*(self: var PackedVector3Array; atIndex: Int; value: Vector3): Int =
+proc insert*(self: PackedVector3Array; atIndex: Int; value: Vector3): Int =
   let argArr = [getPtr atIndex, getPtr value]
   `insert(PackedVector3Array Int Vector3)`(addr self, addr argArr[0], addr result, 2)
-proc fill*(self: var PackedVector3Array; value: Vector3): void =
+proc fill*(self: PackedVector3Array; value: Vector3): void =
   let argArr = [getPtr value]
   `fill(PackedVector3Array Vector3)`(addr self, addr argArr[0], nil, 1)
-proc resize*(self: var PackedVector3Array; newSize: Int): Int =
+proc resize*(self: PackedVector3Array; newSize: Int): Int =
   let argArr = [getPtr newSize]
   `resize(PackedVector3Array Int)`(addr self, addr argArr[0], addr result, 1)
-proc clear*(self: var PackedVector3Array): void =
+proc clear*(self: PackedVector3Array): void =
   `clear(PackedVector3Array)`(addr self, nil, nil, 0)
 proc has*(self: PackedVector3Array; value: Vector3): bool =
   let argArr = [getPtr value]
   `has(PackedVector3Array Vector3)`(addr self, addr argArr[0], addr result, 1)
-proc reverse*(self: var PackedVector3Array): void =
+proc reverse*(self: PackedVector3Array): void =
   `reverse(PackedVector3Array)`(addr self, nil, nil, 0)
 proc slice*(self: PackedVector3Array; begin: Int; `end`: Int = 2147483647): PackedVector3Array =
   let argArr = [getPtr begin, getPtr `end`]
   `slice(PackedVector3Array Int Int)`(addr self, addr argArr[0], addr result, 2)
 proc toByteArray*(self: PackedVector3Array): PackedByteArray =
   `toByteArray(PackedVector3Array)`(addr self, nil, addr result, 0)
-proc sort*(self: var PackedVector3Array): void =
+proc sort*(self: PackedVector3Array): void =
   `sort(PackedVector3Array)`(addr self, nil, nil, 0)
-proc bsearch*(self: var PackedVector3Array; value: Vector3; before: bool = true): Int =
+proc bsearch*(self: PackedVector3Array; value: Vector3; before: bool = true): Int =
   let argArr = [getPtr value, getPtr before]
   `bsearch(PackedVector3Array Vector3 bool)`(addr self, addr argArr[0], addr result, 2)
-proc duplicate*(self: var PackedVector3Array): PackedVector3Array =
+proc duplicate*(self: PackedVector3Array): PackedVector3Array =
   `duplicate(PackedVector3Array)`(addr self, nil, addr result, 0)
 proc find*(self: PackedVector3Array; value: Vector3; `from`: Int = 0): Int =
   let argArr = [getPtr value, getPtr `from`]

--- a/src/gdext/gen/builtinclasses/gdpackedvector4array.nim
+++ b/src/gdext/gen/builtinclasses/gdpackedvector4array.nim
@@ -3,9 +3,8 @@
 import ./constructors
 import gdext/coronation/header/builtinclasses
 
-proc `[]`*(self: PackedVector4Array; index: int): PackedVector4Array.Item = self.data_unsafe[index]
-proc `[]`*(self: var PackedVector4Array; index: int): var PackedVector4Array.Item = self.data_unsafe[index]
-proc `[]=`*(self: var PackedVector4Array; index: int; value: PackedVector4Array.Item) = self.data_unsafe[index] = value
+proc `[]`*(self: PackedVector4Array; index: int): var PackedVector4Array.Item = self.data_unsafe[index]
+proc `[]=`*(self: PackedVector4Array; index: int; value: PackedVector4Array.Item) = self.data_unsafe[index] = value
 
 var `==(PackedVector4Array Variant)`: PtrOperatorEvaluator
 var `!=(PackedVector4Array Variant)`: PtrOperatorEvaluator
@@ -59,48 +58,48 @@ proc size*(self: PackedVector4Array): Int =
   `size(PackedVector4Array)`(addr self, nil, addr result, 0)
 proc isEmpty*(self: PackedVector4Array): bool =
   `isEmpty(PackedVector4Array)`(addr self, nil, addr result, 0)
-proc set*(self: var PackedVector4Array; index: Int; value: Vector4): void =
+proc set*(self: PackedVector4Array; index: Int; value: Vector4): void =
   let argArr = [getPtr index, getPtr value]
   `set(PackedVector4Array Int Vector4)`(addr self, addr argArr[0], nil, 2)
-proc pushBack*(self: var PackedVector4Array; value: Vector4): bool =
+proc pushBack*(self: PackedVector4Array; value: Vector4): bool =
   let argArr = [getPtr value]
   `pushBack(PackedVector4Array Vector4)`(addr self, addr argArr[0], addr result, 1)
-proc append*(self: var PackedVector4Array; value: Vector4): bool =
+proc append*(self: PackedVector4Array; value: Vector4): bool =
   let argArr = [getPtr value]
   `append(PackedVector4Array Vector4)`(addr self, addr argArr[0], addr result, 1)
-proc appendArray*(self: var PackedVector4Array; array: PackedVector4Array): void =
+proc appendArray*(self: PackedVector4Array; array: PackedVector4Array): void =
   let argArr = [getPtr array]
   `appendArray(PackedVector4Array PackedVector4Array)`(addr self, addr argArr[0], nil, 1)
-proc removeAt*(self: var PackedVector4Array; index: Int): void =
+proc removeAt*(self: PackedVector4Array; index: Int): void =
   let argArr = [getPtr index]
   `removeAt(PackedVector4Array Int)`(addr self, addr argArr[0], nil, 1)
-proc insert*(self: var PackedVector4Array; atIndex: Int; value: Vector4): Int =
+proc insert*(self: PackedVector4Array; atIndex: Int; value: Vector4): Int =
   let argArr = [getPtr atIndex, getPtr value]
   `insert(PackedVector4Array Int Vector4)`(addr self, addr argArr[0], addr result, 2)
-proc fill*(self: var PackedVector4Array; value: Vector4): void =
+proc fill*(self: PackedVector4Array; value: Vector4): void =
   let argArr = [getPtr value]
   `fill(PackedVector4Array Vector4)`(addr self, addr argArr[0], nil, 1)
-proc resize*(self: var PackedVector4Array; newSize: Int): Int =
+proc resize*(self: PackedVector4Array; newSize: Int): Int =
   let argArr = [getPtr newSize]
   `resize(PackedVector4Array Int)`(addr self, addr argArr[0], addr result, 1)
-proc clear*(self: var PackedVector4Array): void =
+proc clear*(self: PackedVector4Array): void =
   `clear(PackedVector4Array)`(addr self, nil, nil, 0)
 proc has*(self: PackedVector4Array; value: Vector4): bool =
   let argArr = [getPtr value]
   `has(PackedVector4Array Vector4)`(addr self, addr argArr[0], addr result, 1)
-proc reverse*(self: var PackedVector4Array): void =
+proc reverse*(self: PackedVector4Array): void =
   `reverse(PackedVector4Array)`(addr self, nil, nil, 0)
 proc slice*(self: PackedVector4Array; begin: Int; `end`: Int = 2147483647): PackedVector4Array =
   let argArr = [getPtr begin, getPtr `end`]
   `slice(PackedVector4Array Int Int)`(addr self, addr argArr[0], addr result, 2)
 proc toByteArray*(self: PackedVector4Array): PackedByteArray =
   `toByteArray(PackedVector4Array)`(addr self, nil, addr result, 0)
-proc sort*(self: var PackedVector4Array): void =
+proc sort*(self: PackedVector4Array): void =
   `sort(PackedVector4Array)`(addr self, nil, nil, 0)
-proc bsearch*(self: var PackedVector4Array; value: Vector4; before: bool = true): Int =
+proc bsearch*(self: PackedVector4Array; value: Vector4; before: bool = true): Int =
   let argArr = [getPtr value, getPtr before]
   `bsearch(PackedVector4Array Vector4 bool)`(addr self, addr argArr[0], addr result, 2)
-proc duplicate*(self: var PackedVector4Array): PackedVector4Array =
+proc duplicate*(self: PackedVector4Array): PackedVector4Array =
   `duplicate(PackedVector4Array)`(addr self, nil, addr result, 0)
 proc find*(self: PackedVector4Array; value: Vector4; `from`: Int = 0): Int =
   let argArr = [getPtr value, getPtr `from`]

--- a/src/gdext/gen/builtinclasses/gdsignal.nim
+++ b/src/gdext/gen/builtinclasses/gdsignal.nim
@@ -44,10 +44,10 @@ proc getObjectId*(self: Signal): Int =
   `getObjectId(Signal)`(addr self, nil, addr result, 0)
 proc getName*(self: Signal): StringName =
   `getName(Signal)`(addr self, nil, addr result, 0)
-proc connect*(self: var Signal; callable: Callable; flags: Int = 0): Int =
+proc connect*(self: Signal; callable: Callable; flags: Int = 0): Int =
   let argArr = [getPtr callable, getPtr flags]
   `connect(Signal Callable Int)`(addr self, addr argArr[0], addr result, 2)
-proc disconnect*(self: var Signal; callable: Callable): void =
+proc disconnect*(self: Signal; callable: Callable): void =
   let argArr = [getPtr callable]
   `disconnect(Signal Callable)`(addr self, addr argArr[0], nil, 1)
 proc isConnected*(self: Signal; callable: Callable): bool =

--- a/src/gdext/gen/builtinclasses/gdstring.nim
+++ b/src/gdext/gen/builtinclasses/gdstring.nim
@@ -3,9 +3,8 @@
 import ./constructors
 import gdext/coronation/header/builtinclasses
 
-proc `[]`*(self: String; index: int): String.Item = cast[ptr String.Item](interface_String_operatorIndexConst(addr self, index))[]
-proc `[]`*(self: var String; index: int): var String.Item = cast[ptr String.Item](interface_String_operatorIndex(addr self, index))[]
-proc `[]=`*(self: var String; index: int; value: String.Item) = cast[ptr String.Item](interface_String_operatorIndex(addr self, index))[] = value
+proc `[]`*(self: String; index: int): var String.Item = cast[ptr String.Item](interface_String_operatorIndex(addr self, index))[]
+proc `[]=`*(self: String; index: int; value: String.Item) = cast[ptr String.Item](interface_String_operatorIndex(addr self, index))[] = value
 
 var `==(String Variant)`: PtrOperatorEvaluator
 var `!=(String Variant)`: PtrOperatorEvaluator

--- a/src/gdext/surface/arrayutils.nim
+++ b/src/gdext/surface/arrayutils.nim
@@ -7,14 +7,14 @@ import gdext/gen/[builtinclasses]
 import std/sequtils
 
 {.push, inline.}
-proc setLen*(arr: var Array; newlen: int) =
+proc setLen*(arr: Array; newlen: int) =
   discard arr.resize(newlen)
 proc setLen*(arr: var TypedArray; newlen: int) =
   arr.Array.setlen(newlen)
 proc len*(arr: Array): int = arr.size
 proc len*(arr: TypedArray): int = arr.Array.len
 
-proc setLen*(arr: var PackedArray; newlen: int) =
+proc setLen*(arr: PackedArray; newlen: int) =
   discard arr.resize(newlen)
 proc len*(arr: PackedArray): int = arr.size
 {.pop.}
@@ -29,14 +29,14 @@ iterator items*[T](arr: PackedArray[T]): T =
 iterator pairs*[T](arr: PackedArray[T]): (int, T) =
   for i in 0..<arr.len: yield (int i, arr[i])
 
-iterator mitems*(arr: var Array): var Variant =
+iterator mitems*(arr: Array): var Variant =
   for i in 0..<arr.len: yield arr[i]
-iterator mpairs*(arr: var Array): (int, var Variant) =
+iterator mpairs*(arr: Array): (int, var Variant) =
   for i in 0..<arr.len: yield (int i, arr[i])
 
 iterator mitems*[T](arr: var PackedArray[T]): var T =
   for i in 0..<arr.len: yield arr[i]
-iterator mpairs*[T](arr: var PackedArray[T]): (int, var T) =
+iterator mpairs*[T](arr: PackedArray[T]): (int, var T) =
   for i in 0..<arr.len: yield (int i, arr[i])
 
 proc typedArray*[T: SomeVariant](arr: Array): TypedArray[T] =


### PR DESCRIPTION
Previously, all functions that make changes to a container, such as Array.push_back, had to be passed a mutable container, but this restriction will be removed.

Now, as with seq and others, modifiable operations can be performed without the need for a var modifier.