### PR TITLE
Feat: TypedArray functions

### DIFF
--- a/src/gdext/surface/arrayutils.nim
+++ b/src/gdext/surface/arrayutils.nim
@@ -1,6 +1,5 @@
 import gdext/gdinterface/native
 import gdext/core/builtinindex
-import gdext/core/gdclass
 import gdext/core/typeshift
 import gdext/gen/[builtinclasses]
 
@@ -9,10 +8,7 @@ import std/sequtils
 {.push, inline.}
 proc setLen*(arr: Array; newlen: int) =
   discard arr.resize(newlen)
-proc setLen*(arr: var TypedArray; newlen: int) =
-  arr.Array.setlen(newlen)
 proc len*(arr: Array): int = arr.size
-proc len*(arr: TypedArray): int = arr.Array.len
 
 proc setLen*(arr: PackedArray; newlen: int) =
   discard arr.resize(newlen)
@@ -22,6 +18,11 @@ proc len*(arr: PackedArray): int = arr.size
 iterator items*(arr: Array): Variant =
   for i in 0..<arr.len: yield arr[i]
 iterator pairs*(arr: Array): (int, Variant) =
+  for i in 0..<arr.len: yield (int i, arr[i])
+
+iterator items*[T](arr: TypedArray[T]): T =
+  for i in 0..<arr.len: yield arr[i].get(T)
+iterator pairs*[T](arr: TypedArray[T]): (int, T) =
   for i in 0..<arr.len: yield (int i, arr[i])
 
 iterator items*[T](arr: PackedArray[T]): T =
@@ -34,24 +35,34 @@ iterator mitems*(arr: Array): var Variant =
 iterator mpairs*(arr: Array): (int, var Variant) =
   for i in 0..<arr.len: yield (int i, arr[i])
 
-iterator mitems*[T](arr: var PackedArray[T]): var T =
+iterator mitems*(arr: TypedArray): var Variant =
+  for v in arr.Array.mitems: yield v
+iterator mpairs*(arr: TypedArray): (int, var Variant) =
+  for i, v in arr.Array.mpairs: yield (i, v)
+
+iterator mitems*[T](arr: PackedArray[T]): var T =
   for i in 0..<arr.len: yield arr[i]
 iterator mpairs*[T](arr: PackedArray[T]): (int, var T) =
   for i in 0..<arr.len: yield (int i, arr[i])
 
+proc gdarray*(len: Natural): Array =
+  result = gdarray()
+  discard result.resize(len)
+
 proc typedArray*[T: SomeVariant](arr: Array): TypedArray[T] =
-  when T is SomeBuiltins:
-    TypedArray[T] gdarray(arr, Int T.variantType, stringName(), variant())
-  elif T is SomeClass:
-    TypedArray[T] gdarray(arr, Int VariantTypeObject, className T, variant())
+  TypedArray[T] gdarray(arr, Int T.variantType, stringName(), variant())
 
-proc typedArray*[T: SomeVariant](len: Natural = 0): TypedArray[T] =
-  when T is SomeBuiltins:
-    result = TypedArray[T] gdarray(gdarray(), Int T.variantType, stringName(), variant())
-  elif T is SomeClass:
-    result = TypedArray[T] gdarray(gdarray(), Int VariantTypeObject, className T, variant())
+proc typedArray*[T: SomeVariant](): TypedArray[T] =
+  typedArray[T](gdarray())
 
-  result.setLen len
+proc typedArray*[T: SomeVariant](len: Natural): TypedArray[T] =
+  result = typedArray[T]()
+  discard result.Array.resize(len)
+
+proc `[]`*[T: SomeVariant](arr: TypedArray[T]; i: int): T =
+  arr.Array[i].get(T)
+proc `[]=`*[T: SomeVariant](arr: TypedArray[T]; i: int; value: T) =
+  arr.Array[i] = variant(value)
 
 proc toSeq*[T](arr: PackedArray[T]): seq[T] =
   arr.dataUnsafe.toOpenArray(0, arr.size-1).toSeq

--- a/testproject/runtime/nim/src/cases/primitives.nim
+++ b/testproject/runtime/nim/src/cases/primitives.nim
@@ -2,6 +2,28 @@ import gdext
 import testutils
 import std/unicode
 
+runtime: suite "Array":
+  test "construct":
+    var arr = gdarray(10)
+    check not arr.isTyped
+    check arr.len == 10
+    for i, val in arr:
+      check val == variant()
+  test "mutable iter":
+    var arr = gdarray(10)
+    for i, val in arr.mpairs:
+      val = variant(i)
+    for i, val in arr:
+      check val.get(int) == i
+  test "subscript":
+    var arr = gdarray(10)
+    for i in 0..<arr.len:
+      check arr[i] == variant()
+    for i in 0..<arr.len:
+      arr[i] = variant i
+    for i in 0..<arr.len:
+      check arr[i].get(int) == i
+
 runtime: suite "TypedArray":
   test "construct":
     var arr = typedArray[String](10)
@@ -9,8 +31,21 @@ runtime: suite "TypedArray":
     check cast[VariantType](arr.getTypedBuiltin) == VariantTypeString
     check arr.len == 10
     for i, val in arr:
-      check val.getType == VariantTypeString
-      check ($val.get String).len == 0
+      check val.length == 0
+  test "mutable iter":
+    var arr = typedArray[String](10)
+    for i, val in arr.mpairs:
+      val = variant($i)
+    for i, val in arr:
+      check $val == $i
+  test "subscript":
+    var arr = typedArray[String](10)
+    for i in 0..<arr.len:
+      check arr[i] == gdstring""
+    for i in 0..<arr.len:
+      arr[i] = gdstring $i
+    for i in 0..<arr.len:
+      check arr[i] == gdstring $i
 
 runtime: suite "PackedArray":
   var bytes: PackedByteArray = packedByteArray()


### PR DESCRIPTION
Add the following generic functions:

```nim
iterator items*[T](arr: TypedArray[T]): T 
iterator pairs*[T](arr: TypedArray[T]): (int, T)
iterator mitems*(arr: TypedArray): var Variant
iterator mpairs*(arr: TypedArray): (int, var Variant)
proc gdarray*(len: Natural): Array
proc typedArray*[T: SomeVariant](): TypedArray[T]
proc typedArray*[T: SomeVariant](len: Natural): TypedArray[T]
proc `[]`*[T: SomeVariant](arr: TypedArray[T]; i: int): T
proc `[]=`*[T: SomeVariant](arr: TypedArray[T]; i: int; value: T)
```

This makes it easier to iterate and initialize TypedArrays.