### PR TITLE
Fix error messages related to virtual functions

### DIFF
--- a/src/gdext/private/userclass/virtuals.nim
+++ b/src/gdext/private/userclass/virtuals.nim
@@ -48,7 +48,7 @@ proc callwithEmitter*(procdef: NimNode): NimNode =
   let errormsg = newlit "The " & $procdef.name & " method of the parent class cannot be called. Verify that the method exists, that the name is correct, and that the class module declaring the method is imported."
   let error = bindSym"lineerror".newCall(errormsg, procdef.name)
   quote do:
-    when compiles(`call`):
+    when declared(`emitter`):
       `call`
     else:
       `error`


### PR DESCRIPTION
If a method fails to override a Godot-provided virtual function, it has the ability to output an error to that effect.

However, this error message was so crude that it would override any other compile error that might have occurred in the method.

This PR fixes the above message so that it is only printed in appropriate circumstances and does nothing in other cases.