### PR TITLE
Fix: Apply overridden methods in parent classes to child classes.

### DIFF
--- a/src/gdext/private/internalbridge.nim
+++ b/src/gdext/private/internalbridge.nim
@@ -208,20 +208,25 @@ var implicitRegistrations* {.compileTime.}: array[InitializationLevel, seq[NimNo
 var registered: seq[StringName]
 var plugins: seq[StringName]
 proc register*(T: typedesc) =
-  let cn = className(T)
-  if cn in registered: return
+  when T is SomeEngineClass:
+    discard
+  else:
+    once:
+      register T.Super
+      let cn = className(T)
+      let info = T.creationInfo(false, false, true)
+      ClassDB.registerExtensionClass(cn, className(T.Super), addr info)
+      processExports T
+      invoke Contract[T]
+      for name, vmethod in T.Super.vmethods.pairs:
+        discard T.vmethods.hasKeyOrPut(name, vmethod)
+      when T is EditorPlugin:
+        interface_Editor_addPlugin addr cn
+        plugins.add cn
+      registered.add cn
 
-  let info = T.creationInfo(false, false, true)
-  ClassDB.registerExtensionClass(cn, className(T.Super), addr info)
-  processExports T
-  invoke Contract[T]
-  when T is EditorPlugin:
-    interface_Editor_addPlugin addr cn
-    plugins.add cn
-  registered.add cn
-
-  when Assistance.genEditorHelp and T.hasCustomPragma(description):
-    docClassDB[T].description = T.getCustomPragmaVal(description).descToEditorHelp
+      when Assistance.genEditorHelp and T.hasCustomPragma(description):
+        docClassDB[T].description = T.getCustomPragmaVal(description).descToEditorHelp
 
 proc unregisterAll* =
   for i in countdown(plugins.high, 0):


### PR DESCRIPTION
### Probrem
```nim
type
  A* {.gdsync.} = ptr object of Node
  B* {.gdsync.} = ptr object of A

method ready*(self: A) {.gdsync.} =
  echo "I am A!"

discard instantiate A # => I am A!
discard instantiate B # => NO OUTPUT
```

For example, in the above situation, ready should be executed when an instance of B is added to the scene, but this has not been the case.