### PR TITLE
[Destructive] Feat: Add {.tool.} pragma that the same as @tool annotation in GDScript

### DIFF
--- a/src/gdext/bridge.nim
+++ b/src/gdext/bridge.nim
@@ -43,6 +43,16 @@ template description*(desc: string) {.pragma.} ## By attaching it to a class, pr
 ##   "hello, world!"
 ## ```
 
+template tool* {.pragma.} ## Register the class as a tool class so that processing will be executed even while the editor is running.
+## ```nim
+## type MyTool {.gdsync, tool.} = ptr object of Node
+## method ready(self: MyTool) {.gdsync.} =
+##   if Engine.isEditorHint:
+##     print "You are in the editor."
+##   else:
+##     print "You are executing the app."
+## ```
+
 var Initialization_Default* {.compileTime.} = Initialization_Scene
 
 proc toLevel(node: NimNode): InitializationLevel =

--- a/src/gdext/private/internalbridge.nim
+++ b/src/gdext/private/internalbridge.nim
@@ -99,7 +99,7 @@ proc creationInfo(T: typedesc[SomeUserClass]; is_virtual, is_abstract, is_expose
     is_virtual: is_virtual,
     is_abstract: is_abstract,
     is_exposed: is_exposed,
-    is_runtime: false,
+    is_runtime: not T.hasCustomPragma(tool),
     icon_path: nil,
     set_func: set_func,
     get_func: get_func,

--- a/testproject/editor/nim/src/classes/gdsignalpublisher.nim
+++ b/testproject/editor/nim/src/classes/gdsignalpublisher.nim
@@ -3,7 +3,7 @@ import gdext/classes/gdNode
 import std/random
 random.randomize()
 
-type SignalPublisher* = ptr object of Node
+type SignalPublisher* {.tool.} = ptr object of Node
   key: int
 
 proc send*(self: SignalPublisher; key: int): Error {.signal, gdsync.}

--- a/testproject/editor/nim/src/classes/gdsignalsubscriber.nim
+++ b/testproject/editor/nim/src/classes/gdsignalsubscriber.nim
@@ -4,7 +4,7 @@ import gdext/classes/gdNode
 
 import ./gdsignalpublisher
 
-type SignalSubscriber* = ptr object of Node
+type SignalSubscriber* {.tool.} = ptr object of Node
   publisher*: SignalPublisher
 
 gdexport "publisher",

--- a/testproject/runtime/nim/src/cases/prints.nim
+++ b/testproject/runtime/nim/src/cases/prints.nim
@@ -1,7 +1,7 @@
 import gdext
 import testutils
 
-suite "print":
+runtime: suite "print":
   test "print":
     print("print: ", "1 = ", 1, ", instantiate RefCounted = ", instantiate RefCounted)
     printRich("printRich: ", "[b]1[/b] = ", 1, ", [b]instantiate RefCounted[/b] = ", instantiate RefCounted)

--- a/testproject/runtime/nim/src/classes/gdextnode/typedef.nim
+++ b/testproject/runtime/nim/src/classes/gdextnode/typedef.nim
@@ -170,11 +170,10 @@ proc test_VirtualMethod(self: GDExtNode) =
 # No specific pragma is needed.
 # based on Node.ready()
 method ready(self: GDExtNode) {.gdsync.} =
-  if not Engine.isEditorHint:
-    self.test_UserClass()
-    self.test_Object()
-    self.test_RefCounted()
-    self.test_Node()
-    self.test_Resource()
-    self.test_FirstclassFunction()
-    self.test_VirtualMethod()
+  self.test_UserClass()
+  self.test_Object()
+  self.test_RefCounted()
+  self.test_Node()
+  self.test_Resource()
+  self.test_FirstclassFunction()
+  self.test_VirtualMethod()


### PR DESCRIPTION
Added `{.tool.}` pragma which has the same meaning as `@tool` in GDScript. Accordingly, non-tool classes will not be called ready, process, etc. on the editor. (You can turn off the `Engine.isEditorHint: return` line.) If you need the same specification as before, attach `{.tool.}` to the class definition.

```nim
type MyTool {.gdsync, tool.} = ptr object of Node
type MyGameNode {.gdsync.} = ptr object of Node

method ready(self: MyTool) {.gdsync.} =
  if Engine.isEditorHint:
    print "You are in the editor."
  else:
    print "You are executing the app."

method ready(self: MyGameNode) {.gdsync.} =
  print "You are executing the app."
 ```