### PR TITLE
Feat: Add {.icon.} pragma to set custom icons programmatically

### DIFF
--- a/src/gdext/bridge.nim
+++ b/src/gdext/bridge.nim
@@ -53,6 +53,11 @@ template tool* {.pragma.} ## Register the class as a tool class so that processi
 ##     print "You are executing the app."
 ## ```
 
+template icon*(icon_path: string) {.pragma.} ## Specify the class icon on the editor by path.
+## ```nim
+## type MyIconClass {.gdsync, icon: "res://icon.png".} = ptr object of Node
+## ```
+
 var Initialization_Default* {.compileTime.} = Initialization_Scene
 
 proc toLevel(node: NimNode): InitializationLevel =

--- a/src/gdext/private/internalbridge.nim
+++ b/src/gdext/private/internalbridge.nim
@@ -93,14 +93,17 @@ else:
     cast[ClassCallVirtual](p_virtual_call_userdata)(p_instance, p_args, r_ret)
   const get_virtual_func = nil
 
+proc icon_path[T](_: typedesc[T]): String =
+  when T.hasCustomPragma(icon):
+    gdstring T.getCustomPragmaVal(icon)
 
-proc creationInfo(T: typedesc[SomeUserClass]; is_virtual, is_abstract, is_exposed: bool): ClassCreationInfo4 =
+proc creationInfo(T: typedesc[SomeUserClass]; is_virtual, is_abstract, is_exposed: bool; icon_path: String): ClassCreationInfo4 =
   ClassCreationInfo4(
     is_virtual: is_virtual,
     is_abstract: is_abstract,
     is_exposed: is_exposed,
     is_runtime: not T.hasCustomPragma(tool),
-    icon_path: nil,
+    icon_path: addr icon_path,
     set_func: set_func,
     get_func: get_func,
     get_property_list_func: get_property_list_func,
@@ -214,7 +217,7 @@ proc register*(T: typedesc) =
     once:
       register T.Super
       let cn = className(T)
-      let info = T.creationInfo(false, false, true)
+      let info = T.creationInfo(false, false, true, T.icon_path)
       ClassDB.registerExtensionClass(cn, className(T.Super), addr info)
       processExports T
       invoke Contract[T]

--- a/testproject/editor/nim/src/classes/gddoctestnode.nim
+++ b/testproject/editor/nim/src/classes/gddoctestnode.nim
@@ -1,6 +1,6 @@
 import gdext
 
-type DocTestNode* {.gdsync, description: """
+type DocTestNode* {.gdsync, icon: "res://icon.png", description: """
 A node defined for documentation testing.
 "## comments" are ignored because there is no way to retrieve them.""".} = ptr object of Node
   pragma_param* {.gdexport, description: "This is a description for {.gdexport.}'ed params".}: string = "pragma-param"


### PR DESCRIPTION
```nim
type MyNode {.gdsync, icon: "res://icon.png".} = ptr object of Node
```

![image](https://github.com/user-attachments/assets/5844efa8-9a07-48a0-9fa9-1a36a9ef7ecb)

