### PR TITLE
Refactor: private/buildsettings := .nim side of buildconf

### DIFF
--- a/src/gdext.nim
+++ b/src/gdext.nim
@@ -6,6 +6,7 @@
 ## =======
 ## The following modules are automatically imported by gdext. There is no need to import them explicitly.
 ## 
+## * `buildconf <gdext/buildconf.html>`_: It's required to build GDExtension. You **must** import it from your project's config.nims.
 ## * `bridge <gdext/bridge.html>`_: Core functionalities of gdext
 ## * `appearances <gdext/appearances.html>`_: Appearance of properties on the editor inspector
 ## * `objectcallbacks <gdext/objectcallbacks.html>`_: Object callbacks called by the engine
@@ -25,7 +26,7 @@
 
 {.warning[UnusedImport]: off.}
 
-import gdext/buildconf
+import gdext/private/buildsettings
 import gdext/private/gdinterface
 
 import gdext/private/staticevents
@@ -139,6 +140,9 @@ template GDExtension_EntryPoint*: untyped =
       echo "FATAL ERROR: failed to initialize library."
       echo $getCurrentException()
       return false
+
+when defined(docgen):
+  import gdext/buildconf
 
 when isMainModule:
   GDExtension_EntryPoint

--- a/src/gdext/buildconf.nim
+++ b/src/gdext/buildconf.nim
@@ -1,103 +1,81 @@
-when not declared(switch):
-  const
-    Extension_name {.strdefine: "Extension.name".} = ""
-    Extension_entrySymbol {.strdefine: "Extension.entrySymbol".} = "init_library"
-    Extension_decimalPrecision {.strdefine: "Extension.decimalPrecision".} = "float"
+## Note:
+## This is a module for NimScript; do not import from Nim modules.
+## If you want to get the information configured by this module from Nim modules,
+## import `gdext/private/buildsettings` instead.
 
-    Assistance_checkEnv {.booldefine: "Assistance.checkenv".} = on
-    Assistance_genEditorHelp {.booldefine: "Assistance.genEditorHelp".} = on
-
-    Dev_debugCallbacks {.booldefine: "Dev.debugCallbacks".} = off
-    Dev_debugEvents {.booldefine: "Dev.debugEvents".} = off
-
-    Extension* = (
-      name: Extension_name,
-      entrySymbol: Extension_entrySymbol,
-      decimalPrecision: Extension_decimalPrecision,
-    )
-    Assistance* = (
-      checkEnv: Assistance_checkEnv,
-      genEditorHelp: Assistance_genEditorHelp,
-    )
-    Dev* = (
-      debugCallbacks: Dev_debugCallbacks,
-      debugEvents: Dev_debugEvents,
-    )
-
-  when Assistance.checkEnv:
-    when appType != "lib": {.error: """
-This project must be compiled as a dynamic library.
-Instead, run `nimble build --app:lib` or append `--app: lib` to the config.nims file.""".}
-    when Extension.name == "": {.error: """
-name of the extension is not declared; try to describe in config.nims:
-  import gdext/buildconf
-  Extension.name = "MyExtensionName"
+when not declared(switch) and not defined(docgen):
+  {.error: """
+This is a module for NimScript; do not import from Nim modules.
+If you want to get the information configured by this module from Nim modules,
+import `gdext/private/buildsettings` instead.
 """.}
 
-else:
-  from std/os import `/`, splitFile
+when not declared(switch):
+  import system/nimscript
 
-  type Godot* = object
-  type Extension* = object
-  type Assistance* = object
+from std/os import `/`, splitFile
 
-  const RunningSystem* = case hostOS
-  of "windows":
-    "windows"
-  of "linux":
-    "linux"
-  of "macosx":
-    "macos"
-  of "netbsd", "freebsd", "openbsd":
-    "bsd"
-  else: ""
+type Godot* = object
+type Extension* = object
+type Assistance* = object
 
-  const Build* =
-    when defined(release):
-      "release"
-    else:
-      "debug"
+const RunningSystem* = case hostOS
+of "windows":
+  "windows"
+of "linux":
+  "linux"
+of "macosx":
+  "macos"
+of "netbsd", "freebsd", "openbsd":
+  "bsd"
+else: ""
 
-  proc `libdir=`*(_: typedesc[Extension]; path: string) =
-    switch("outdir", path)
+const Build* =
+  when defined(release):
+    "release"
+  else:
+    "debug"
 
-  proc `entrySymbol=`*(_: typedesc[Extension]; name: string) =
-    switch("define", "Extension.entrySymbol:" & name)
+proc `libdir=`*(_: typedesc[Extension]; path: string) =
+  switch("outdir", path)
 
-  proc `name=`*(_: typedesc[Extension]; name: string) =
-    switch("define", "Extension.name:" & name)
-    # Due to the directory structure that gdext requires, the cache path is
-    # always bootstrap_d/ by default. This means that for projects that use
-    # multiple extensions across the board, each time an extension is built,
-    # the cache is overwritten and the cc is performed from scratch,
-    # resulting in slower build speeds.
-    switch("nimcache", nimCacheDir()/RunningSystem/Build/name)
+proc `entrySymbol=`*(_: typedesc[Extension]; name: string) =
+  switch("define", "Extension.entrySymbol:" & name)
 
-  proc `genEditorHelp=`*(_: typedesc[Assistance]; b: bool) =
-    switch("define", "Assistance.genEditorHelp:" & $b)
+proc `name=`*(_: typedesc[Extension]; name: string) =
+  switch("define", "Extension.name:" & name)
+  # Due to the directory structure that gdext requires, the cache path is
+  # always bootstrap_d/ by default. This means that for projects that use
+  # multiple extensions across the board, each time an extension is built,
+  # the cache is overwritten and the cc is performed from scratch,
+  # resulting in slower build speeds.
+  switch("nimcache", nimCacheDir()/RunningSystem/Build/name)
 
-  # GDExtension is loaded into the engine as a DLL.
-  --app: lib
+proc `genEditorHelp=`*(_: typedesc[Assistance]; b: bool) =
+  switch("define", "Assistance.genEditorHelp:" & $b)
 
-  # This library tries to load the engine API before the main process of
-  # Nim (the process described at the top level of the file, which does
-  # not belong to a function). For this reason, this option tells the
-  # compiler not to run the main process when loading the DLL.
-  --noMain: on
+# GDExtension is loaded into the engine as a DLL.
+--app: lib
 
-  # This library provides swizzle methods like GLslang. This method is
-  # used in the format `vector.*xyz`. The --nimPreviewDotLikeOps option
-  # is required to activate this `. *` operator.
-  --define: nimPreviewDotLikeOps
+# This library tries to load the engine API before the main process of
+# Nim (the process described at the top level of the file, which does
+# not belong to a function). For this reason, this option tells the
+# compiler not to run the main process when loading the DLL.
+--noMain: on
 
-  when hostOS == "windows":
-    # When using mingw32-gcc bundled with choosenim, it fails to load the linked
-    # dependent dynamic libraries. The solution is to link the libraries statically.
+# This library provides swizzle methods like GLslang. This method is
+# used in the format `vector.*xyz`. The --nimPreviewDotLikeOps option
+# is required to activate this `. *` operator.
+--define: nimPreviewDotLikeOps
 
-    # TODO: This block is irrelevant depending on vcc and the gcc used, and requires
-    #       a mechanism to be able to disable it.
+when hostOS == "windows":
+  # When using mingw32-gcc bundled with choosenim, it fails to load the linked
+  # dependent dynamic libraries. The solution is to link the libraries statically.
 
-    # --passL: "-static"
-    --passL: "-static-libgcc"
+  # TODO: This block is irrelevant depending on vcc and the gcc used, and requires
+  #       a mechanism to be able to disable it.
 
-  Extension.libdir = "$projectdir/lib"/RunningSystem/Build
+  # --passL: "-static"
+  --passL: "-static-libgcc"
+
+Extension.libdir = "$projectdir/lib"/RunningSystem/Build

--- a/src/gdext/builtinindex.nim
+++ b/src/gdext/builtinindex.nim
@@ -1,8 +1,7 @@
 import std/tables
 
+import gdext/private/buildsettings
 import gdext/private/native
-
-import gdext/buildconf
 
 when Extension.decimalPrecision == "double":
   type real_elem* = float64

--- a/src/gdext/extclasses/gdextensionmain.nim
+++ b/src/gdext/extclasses/gdextensionmain.nim
@@ -1,8 +1,8 @@
+import gdext/private/buildsettings
 import gdext/private/gdinterface
 import gdext/builtinindex
 import gdext/classes/[gdengine]
 import gdext/objecttools
-import gdext/buildconf
 
 import std/macros
 

--- a/src/gdext/private/buildsettings.nim
+++ b/src/gdext/private/buildsettings.nim
@@ -1,0 +1,34 @@
+const
+  Extension_name {.strdefine: "Extension.name".} = ""
+  Extension_entrySymbol {.strdefine: "Extension.entrySymbol".} = "init_library"
+  Extension_decimalPrecision {.strdefine: "Extension.decimalPrecision".} = "float"
+
+  Assistance_checkEnv {.booldefine: "Assistance.checkenv".} = on
+  Assistance_genEditorHelp {.booldefine: "Assistance.genEditorHelp".} = on
+
+  Dev_debugCallbacks {.booldefine: "Dev.debugCallbacks".} = off
+  Dev_debugEvents {.booldefine: "Dev.debugEvents".} = off
+
+  Extension* = (
+    name: Extension_name,
+    entrySymbol: Extension_entrySymbol,
+    decimalPrecision: Extension_decimalPrecision,
+  )
+  Assistance* = (
+    checkEnv: Assistance_checkEnv,
+    genEditorHelp: Assistance_genEditorHelp,
+  )
+  Dev* = (
+    debugCallbacks: Dev_debugCallbacks,
+    debugEvents: Dev_debugEvents,
+  )
+
+when Assistance.checkEnv:
+  when appType != "lib": {.error: """
+This project must be compiled as a dynamic library.
+Instead, run `nimble build --app:lib` or append `--app: lib` to the config.nims file.""".}
+  when Extension.name == "": {.error: """
+name of the extension is not declared; try to describe in config.nims:
+  import gdext/private/buildsettings
+  Extension.name = "MyExtensionName"
+""".}

--- a/src/gdext/private/debugging.nim
+++ b/src/gdext/private/debugging.nim
@@ -1,4 +1,4 @@
-import gdext/buildconf
+import gdext/private/buildsettings
 import gdext/builtinindex
 
 const DebugEnabled = Dev.debugCallbacks

--- a/src/gdext/private/doctools.nim
+++ b/src/gdext/private/doctools.nim
@@ -1,4 +1,4 @@
-import gdext/buildconf
+import gdext/private/buildsettings
 
 when Assistance.genEditorHelp:
   import gdext/private/gdinterface

--- a/src/gdext/private/gdinterface.nim
+++ b/src/gdext/private/gdinterface.nim
@@ -1,8 +1,8 @@
 import std/[tables, typetraits, importutils]
+import gdext/private/buildsettings
 import gdext/private/native
 import gdext/private/macros
 import gdext/private/debugging
-import gdext/buildconf
 import gdext/builtinindex {.all.}
 import gdext/stringtools
 import gdext/objectcallbacks

--- a/src/gdext/private/internalbridge.nim
+++ b/src/gdext/private/internalbridge.nim
@@ -1,6 +1,6 @@
 import std/tables
 
-import gdext/buildconf
+import gdext/private/buildsettings
 import gdext/private/gdinterface
 import gdext/private/staticevents
 import gdext/private/macros

--- a/src/gdext/private/staticevents.nim
+++ b/src/gdext/private/staticevents.nim
@@ -1,5 +1,5 @@
 import std/[macros, macrocache, sets, hashes]
-import gdext/buildconf
+import gdext/private/buildsettings
 
 type
   Event* = CacheSeq

--- a/src/gdext/private/userclass/procs.nim
+++ b/src/gdext/private/userclass/procs.nim
@@ -1,6 +1,6 @@
 import std/[sequtils, strutils, sets, tables]
 
-import gdext/buildconf
+import gdext/private/buildsettings
 import gdext/private/macros
 import gdext/private/gdinterface
 import gdext/private/staticevents

--- a/src/gdext/private/userclass/signals.nim
+++ b/src/gdext/private/userclass/signals.nim
@@ -1,10 +1,10 @@
 import std/[tables, sets]
 
+import gdext/private/buildsettings
 import gdext/private/gdinterface
 import gdext/private/staticevents
 import gdext/private/typeshift
 import gdext/private/propertyinfo
-import gdext/buildconf
 import gdext/builtinindex
 
 import gdext/classes/gdobject

--- a/src/gdext/private/userclass/tools.nim
+++ b/src/gdext/private/userclass/tools.nim
@@ -1,6 +1,6 @@
 import std/[sequtils]
 
-import gdext/buildconf
+import gdext/private/buildsettings
 import gdext/private/macros
 
 proc docComment*(def: NimNode): NimNode =


### PR DESCRIPTION
Split buildconf, which had been written for both NimScript and Nim processing, and define a new private/buildsettings module to retrieve settings.