### PR TITLE
Rename: variant types' constructors

### DIFF
--- a/coronation/src/coronation/operators/arguments.nim
+++ b/coronation/src/coronation/operators/arguments.nim
@@ -6,6 +6,7 @@ import ./classindex
 import submodules/wordropes
 import submodules/semanticstrings
 import types/json
+import utils
 
 import std/hashes
 import std/strutils
@@ -125,73 +126,87 @@ proc fixDefaultValue(arg: RenderableArgument; value: string) =
       value
 
   else:
+    const withGeneric = [TypeSym"TypedArray"]
+    proc constr(typ: TypeSym): string =
+      $constructorName(typesym) &
+      (if typ in withGeneric: "[" & dbModify(arg.info.metaType) & "]" else: "") &
+      "()"
+    proc constr(typ: TypeSym; expr: string): string =
+      result = $constructorName(typesym) &
+      (if typ in withGeneric: "[" & dbModify(arg.info.metaType) & "]" else: "") &
+      "(" & expr & ")"
+      result = result.multiReplace(("((", "("), ("))", ")"))
+    proc drop(expr: string; typ: TypeSym): string =
+      expr.replace($typ, "")
     case typesym
     of TypeSym"String":
-      if value[0] == '"':
-        "gdstring" & value
+      if value.drop(typesym) == "\"\"":
+        typesym.constr()
+      elif value[0] == '"':
+        typesym.constr(value)
       else:
-        value.replace("String", "gdstring")
+        typesym.constr(value.drop(typesym))
 
     of TypeSym"StringName":
       case value
       of "&\"\"", "\"\"":
         "default(StringName)"
       elif value.startsWith"&":
-        "stringName" & value[1..^1]
+        typesym.constr(value[1..^1])
       else:
         value
 
     of TypeSym"Vector3", TypeSym"Vector3i", TypeSym"Vector2", TypeSym"Vector2i":
-      value.replace("Vector", "vector")
+      typesym.constr(value.drop(typesym))
 
     of TypeSym"Rect2", TypeSym"Rect2i":
-      value.replace("Rect2", "rect2")
+      typesym.constr(value.drop(typesym))
 
     of TypeSym"Transform3D":
       case value
       of "Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)":
-        "transform3D()"
+        typesym.constr()
       else:
-        value.replace("Transform3D", "transform3D")
+        typesym.constr(value.drop(typesym))
 
     of TypeSym"Transform2D":
       case value
       of "Transform2D(1, 0, 0, 1, 0, 0)":
-        "transform2D()"
+        typesym.constr()
       else:
-        value.replace("Transform2D", "transform2D")
+        typesym.constr(value.drop(typesym))
 
     of TypeSym"Color":
-        value.replace("Color", "color")
+        typesym.constr(value.drop(typesym))
 
     of TypeSym"Array":
       case value
       of "[]":
-        "gdarray()"
+        typesym.constr()
       else:
         value
 
     of TypeSym"TypedArray":
-      &"typedArray[{dbModify arg.info.metaType}]()"
+      typesym.constr()
 
     of TypeSym"Dictionary":
       case value
       of "{}":
-        "dictionary()"
+        typesym.constr()
       else:
         value
 
     of TypeSym"Callable":
       case value
       of "Callable()":
-        "callable()"
+        typesym.constr()
       else:
         value
 
     of TypeSym"NodePath":
       case value
       of "NodePath(\"\")":
-        "nodePath()"
+        typesym.constr()
       else:
         value
 

--- a/coronation/src/coronation/operators/classes/methods.nim
+++ b/coronation/src/coronation/operators/classes/methods.nim
@@ -166,7 +166,8 @@ proc weave_native(entry: ClassMethodVirtualEntry): Cloth =
   weave multiline:
     &"proc registerVirtual_{entry.name.dropQuote}*[T: {entry.self.typeSym}](Self: typedesc[T]) ="
     weave cloths.indent:
-      &"Self.vmethods[stringName\"{entry.native_name}\"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {{.gdcall.}} ="
+      const StringName = TypeSym"StringName"
+      &"Self.vmethods[{constructorName StringName}\"{entry.native_name}\"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {{.gdcall.}} ="
       weave cloths.indent >> Join(delim: ""):
         &"errproof: cast[{entry.self.typesym}](p_instance).{entry.name}("
         weave Join(delim: ", "):

--- a/coronation/src/coronation/utils.nim
+++ b/coronation/src/coronation/utils.nim
@@ -24,8 +24,33 @@ method apply(style: Comment; data: Data): Data =
   super[style.enable].apply data
 
 
+const withNew = [
+  TypeSym"Array",
+  TypeSym"TypedArray",
+  TypeSym"PackedByteArray",
+  TypeSym"PackedColorArray",
+  TypeSym"PackedStringArray",
+  TypeSym"PackedInt32Array",
+  TypeSym"PackedInt64Array",
+  TypeSym"PackedFloat32Array",
+  TypeSym"PackedFloat64Array",
+  TypeSym"PackedVector2Array",
+  TypeSym"PackedVector3Array",
+  TypeSym"PackedVector4Array",
+  TypeSym"Dictionary",
+  TYpeSym"String",
+  TYpeSym"StringName",
+  TYpeSym"NodePath",
+]
+const withGd = [
+  TYpeSym"String",
+]
+func uncapitalizeAscii(s: string): string =
+  if s.len == 0: result = ""
+  else: result = toLowerAscii(s[0]) & substr(s, 1)
+
 proc constructorName*(sym: TypeSym): ProcSym =
-  case sym
-  of TypeSym"String": ProcSym"gdstring"
-  of TypeSym"Array": ProcSym"gdarray"
-  else: ProcSym variablefy sym
+  ProcSym uncapitalizeAscii do:
+    (if sym in withNew: "New" else: "") &
+    (if sym in withGd: "Gd" else: "") &
+    capitalizeAscii($sym)

--- a/src/gdext/appearances.nim
+++ b/src/gdext/appearances.nim
@@ -98,23 +98,23 @@ proc appearance*[T: Object](_: typedesc[T]): Appearance =
     const hint = propertyHintNone
   Appearance(
     hint: hint,
-    hintstring: gdstring className T)
+    hintstring: newGdString className T)
 proc appearance*[T](_: typedesc[GdRef[T]]): Appearance = T.appearance
 proc appearance*(T: typedesc[enum]): Appearance =
   const hintstring = T.makeDefaultHintStringEnum
   Appearance(
     hint: propertyHintEnum,
-    hintstring: gdstring hintstring)
+    hintstring: newGdString hintstring)
 proc appearance*[T: enum](_: typedesc[set[T]]): Appearance =
   const hintstring = T.makeDefaultHintStringBitField
   Appearance(
     hint: propertyHintFlags,
-    hintstring: gdstring hintstring)
+    hintstring: newGdString hintstring)
 proc appearance*(T: typedesc[range]): Appearance =
   const hintstring = T.makeDefaultHintStringRange
   Appearance(
     hint: propertyHintRange,
-    hintstring: gdstring hintstring)
+    hintstring: newGdString hintstring)
 proc appearance*[T](_: typedesc[TypedArray[T]]): Appearance =
   var elementApp = T.appearance
   let typ = T.variantType.ord
@@ -122,7 +122,7 @@ proc appearance*[T](_: typedesc[TypedArray[T]]): Appearance =
   let str = fmt"{typ}{hint}:{elementApp.hint_string}"
   Appearance(
     hint: propertyHintArrayType,
-    hintstring: gdstring str)
+    hintstring: newGdString str)
 
 template joinArg(s: varargs[string]): string = s.join(",")
 
@@ -164,13 +164,13 @@ proc file*(T: typedesc[Appearance]; filter: varargs[string]): Appearance =
   ## `@export_file <https://docs.godotengine.org/en/stable/classes/class_%40gdscript.html#class-gdscript-annotation-export-file>`_
   Appearance(
     hint: propertyHintFile,
-    hintstring: gdstring filter.joinArg)
+    hintstring: newGdString filter.joinArg)
 
 proc globalFile*(T: typedesc[Appearance]; filter: varargs[string]): Appearance =
   ## `@export_global_file <https://docs.godotengine.org/en/stable/classes/class_%40gdscript.html#class-gdscript-annotation-export-global-file>`_
   Appearance(
     hint: propertyHintGlobalFile,
-    hintstring: gdstring filter.joinArg)
+    hintstring: newGdString filter.joinArg)
 
 proc flags2dNavigation*(T: typedesc[Appearance]): Appearance =
   ## `@export_flags_2d_navigation <https://docs.godotengine.org/en/stable/classes/class_%40gdscript.html#class-gdscript-annotation-export-flags-2d-navigation>`_
@@ -217,28 +217,28 @@ proc `enum`*(T: typedesc[Appearance];
   ## `@export_enum <https://docs.godotengine.org/en/stable/classes/class_%40gdscript.html#class-gdscript-annotation-export-enum>`_
   Appearance(
     hint: propertyHintEnum,
-    hint_string: gdstring enums.joinArg)
+    hint_string: newGdString enums.joinArg)
 
 proc `flags`*(T: typedesc[Appearance];
     flags: varargs[string]): Appearance =
   ## `@export_flags <https://docs.godotengine.org/en/stable/classes/class_%40gdscript.html#class-gdscript-annotation-export-flags>`_
   Appearance(
     hint: propertyHintFlags,
-    hint_string: gdstring flags.joinArg)
+    hint_string: newGdString flags.joinArg)
 
 proc expEasing*(T: typedesc[Appearance];
     extra: varargs[ExpEasingArgument]): Appearance =
   ## `@export_exp_easing <https://docs.godotengine.org/en/stable/classes/class_%40gdscript.html#class-gdscript-annotation-export-exp-easing>`_
   Appearance(
     hint: propertyHintExpEasing,
-    hint_string: gdstring @extra.mapIt($it).joinArg)
+    hint_string: newGdString @extra.mapIt($it).joinArg)
 
 proc nodePath*(T: typedesc[Appearance];
     validTypes: varargs[string]): Appearance =
   ## `@export_node_path <https://docs.godotengine.org/en/stable/classes/class_%40gdscript.html#class-gdscript-annotation-export-node-path>`_
   Appearance(
     hint: propertyHintNodePathValidTypes,
-    hint_string: gdstring @validTypes.joinArg)
+    hint_string: newGdString @validTypes.joinArg)
 
 macro nodePath*(T: typedesc[Appearance];
     validTypes: varargs[typedesc[Node]]): Appearance =

--- a/src/gdext/arraytools.nim
+++ b/src/gdext/arraytools.nim
@@ -1,7 +1,7 @@
 ## Array
 ## =====
 ##
-## A standard collection of Variants provided by Godot that holds values of any type whose conversion to Variant is supported. Create with `gdarray()`.
+## A standard collection of Variants provided by Godot that holds values of any type whose conversion to Variant is supported.
 ##
 ## TypedArray\[SomeVariant\]
 ## =========================
@@ -10,32 +10,31 @@
 ##
 ## A good alternative if you want to use Array's API under a static type system.
 ##
-## Create with `typedArray[T]()`.
-##
 ## PackedArray
 ## ===========
 ##
-## A primitive dynamic array provided by Godot. Create with `packedByteArray()`, and so on.
+## A primitive dynamic array provided by Godot.
 
 import gdext/private/gdinterface
 import gdext/private/staticevents
 import gdext/private/typeshift
+import gdext/private/macros
 import gdext/builtinindex
 import gdext/stringtools
 import gdext/varianttools
 
 import std/sequtils
 
-proc packedByteArray*(): PackedByteArray = (discard)
-proc packedColorArray*(): PackedColorArray = (discard)
-proc packedStringArray*(): PackedStringArray = (discard)
-proc packedInt32Array*(): PackedInt32Array = (discard)
-proc packedInt64Array*(): PackedInt64Array = (discard)
-proc packedFloat32Array*(): PackedFloat32Array = (discard)
-proc packedFloat64Array*(): PackedFloat64Array = (discard)
-proc packedVector2Array*(): PackedVector2Array = (discard)
-proc packedVector3Array*(): PackedVector3Array = (discard)
-proc packedVector4Array*(): PackedVector4Array = (discard)
+proc newPackedByteArray*(): PackedByteArray = (discard)
+proc newPackedColorArray*(): PackedColorArray = (discard)
+proc newPackedStringArray*(): PackedStringArray = (discard)
+proc newPackedInt32Array*(): PackedInt32Array = (discard)
+proc newPackedInt64Array*(): PackedInt64Array = (discard)
+proc newPackedFloat32Array*(): PackedFloat32Array = (discard)
+proc newPackedFloat64Array*(): PackedFloat64Array = (discard)
+proc newPackedVector2Array*(): PackedVector2Array = (discard)
+proc newPackedVector3Array*(): PackedVector3Array = (discard)
+proc newPackedVector4Array*(): PackedVector4Array = (discard)
 
 include gdext/gen/gdarrayconstr
 include gdext/gen/gdpackedbytearrayconstr
@@ -64,8 +63,8 @@ include gdext/gen/gdpackedvector4array
 # Array
 # =====
 
-proc gdarray*(len: Natural): Array =
-  result = gdarray()
+proc newArray*(len: Natural): Array =
+  result = newArray()
   discard result.resize(len)
 
 proc setLen*(arr: Array; newlen: int) =
@@ -87,15 +86,22 @@ proc contains*[T: SomeProperty](arr: Array; value: T): bool = arr.find(variant v
 # TypedArray
 # ==========
 
-proc typedArray*[T](arr: Array): TypedArray[T] =
-  TypedArray[T] gdarray(arr, Int T.variantType, stringName(), variant())
+proc newTypedArray*[T](arr: Array): TypedArray[T] =
+  TypedArray[T] newArray(arr, Int T.variantType, newStringName(), variant())
 
-proc typedArray*[T](): TypedArray[T] =
-  typedArray[T](gdarray())
+proc newTypedArray*[T](): TypedArray[T] =
+  newTypedArray[T](newArray())
 
-proc typedArray*[T](len: Natural): TypedArray[T] =
-  result = typedArray[T]()
+proc newTypedArray*[T](len: Natural): TypedArray[T] =
+  result = newTypedArray[T]()
   discard result.Array.resize(len)
+
+template typedArray*[T](arr: Array): TypedArray[T] {.deprecated: "use newTypedArray instead".} =
+  newTypedArray[T](arr)
+template typedArray*[T](): TypedArray[T] {.deprecated: "use newTypedArray instead".} =
+  newTypedArray[T]()
+template typedArray*[T](len: Natural): TypedArray[T] {.deprecated: "use newTypedArray instead".} =
+  newTypedArray[T](len)
 
 iterator items*[T](arr: TypedArray[T]): T =
   for i in 0..<arr.len: yield arr[i].get(T)
@@ -104,11 +110,11 @@ iterator pairs*[T](arr: TypedArray[T]): (int, T) =
 
 iterator mitems*[T](arr: TypedArray[T]): var T =
   when T is Object or T is GdRef:
-    {.error: "mutable items for " & $T & " is unavailable; use items instead.".}
+    {.error: "mutable items for " & $T & " is unavailable; use items instead".}
   for v in arr.Array.mitems: yield v.getAddr(T)[]
 iterator mpairs*[T](arr: TypedArray[T]): (int, var T) =
   when T is Object or T is GdRef:
-    {.error: "mutable pairs for " & $T & " is unavailable; use pairs instead.".}
+    {.error: "mutable pairs for " & $T & " is unavailable; use pairs instead".}
   for i, v in arr.Array.mpairs: yield (i, v.getAddr(T)[])
 
 proc `[]`*[T](arr: TypedArray[T]; i: int): T =
@@ -201,3 +207,15 @@ proc toSeq*[T](arr: PackedArray[T]): seq[T] =
 
 proc contains*[T](arr: PackedArray[T]; item: T): bool =
   arr.toOpenArray.contains item
+
+template gdArray*(args: varargs[untyped]): untyped {.deprecated: "use newArray instead".} = unpackVarargs(newArray, args)
+template packedByteArray*(args: varargs[untyped]): untyped {.deprecated: "use newPackedByteArray instead".} = unpackVarargs(newPackedByteArray, args)
+template packedColorArray*(args: varargs[untyped]): untyped {.deprecated: "use newPackedColorArray instead".} = unpackVarargs(newPackedColorArray, args)
+template packedStringArray*(args: varargs[untyped]): untyped {.deprecated: "use newPackedStringArray instead".} = unpackVarargs(newPackedStringArray, args)
+template packedInt32Array*(args: varargs[untyped]): untyped {.deprecated: "use newPackedInt32Array instead".} = unpackVarargs(newPackedInt32Array, args)
+template packedInt64Array*(args: varargs[untyped]): untyped {.deprecated: "use newPackedInt64Array instead".} = unpackVarargs(newPackedInt64Array, args)
+template packedFloat32Array*(args: varargs[untyped]): untyped {.deprecated: "use newPackedFloat32Array instead".} = unpackVarargs(newPackedFloat32Array, args)
+template packedFloat64Array*(args: varargs[untyped]): untyped {.deprecated: "use newPackedFloat64Array instead".} = unpackVarargs(newPackedFloat64Array, args)
+template packedVector2Array*(args: varargs[untyped]): untyped {.deprecated: "use newPackedVector2Array instead".} = unpackVarargs(newPackedVector2Array, args)
+template packedVector3Array*(args: varargs[untyped]): untyped {.deprecated: "use newPackedVector3Array instead".} = unpackVarargs(newPackedVector3Array, args)
+template packedVector4Array*(args: varargs[untyped]): untyped {.deprecated: "use newPackedVector4Array instead".} = unpackVarargs(newPackedVector4Array, args)

--- a/src/gdext/bridge.nim
+++ b/src/gdext/bridge.nim
@@ -154,7 +154,7 @@ macro registerEnumInternal(Class, Enum; isBitField: static bool) =
 
   let call = bindSym"registerEnumFields".newCall(
     Class,
-    bindSym"stringName".newCall enumName,
+    bindSym"newStringName".newCall enumName,
   )
   for field in def[2][1..^1]:
     let fieldsym = case field.kind
@@ -164,9 +164,9 @@ macro registerEnumInternal(Class, Enum; isBitField: static bool) =
     let fieldName = newlit $fieldsym
     call.add case isBitField
     of true:
-      quote do: (stringName `fieldName`, Int 1 shl int `fieldsym`)
+      quote do: (newStringName `fieldName`, Int 1 shl int `fieldsym`)
     of false:
-      quote do: (stringName `fieldName`, Int `fieldsym`)
+      quote do: (newStringName `fieldName`, Int `fieldsym`)
 
   call.add newlit isBitField
   result = quote do:
@@ -234,7 +234,7 @@ template gdexport*[T: SomeUserClass](
   ## gdexport[Actor] "Base Params", Appearance.category
   ## ```
   proc `name` {.execon: Contract[T].property.} =
-    gdexport_internal(propertyInfo(stringName name, appearance), className typedesc T)
+    gdexport_internal(propertyInfo(newStringName name, appearance), className typedesc T)
 
 template gdexport*(
       name: string;

--- a/src/gdext/conversions.nim
+++ b/src/gdext/conversions.nim
@@ -5,9 +5,9 @@ import gdext/varianttools
 
 {.push, inline.}
 
-converter convertToString*(str: string): String = gdstring str
-converter convertToStringName*(str: string): StringName = stringName str
-converter convertToNodePath*(str: string): NodePath = nodePath gdstring str
+converter convertToString*(str: string): String = newGdString str
+converter convertToStringName*(str: string): StringName = newStringName str
+converter convertToNodePath*(str: string): NodePath = newNodePath newGdString str
 
 converter convertToArray*(arr: TypedArray): Array = Array arr
 

--- a/src/gdext/dicttools.nim
+++ b/src/gdext/dicttools.nim
@@ -1,9 +1,12 @@
 import gdext/private/gdinterface
 import gdext/private/staticevents
 import gdext/private/typeshift
+import gdext/private/macros
 import gdext/builtinindex
 
 include gdext/gen/gddictionaryconstr
 include gdext/gen/gddictionary
 
 proc contains*[T: SomeProperty](dict: Dictionary; value: T): bool = dict.has(variant value)
+
+template dictionary*(args: varargs[untyped]): untyped {.deprecated: "use newDictionary instead".} = unpackVarargs(newDictionary, args)

--- a/src/gdext/objecttools.nim
+++ b/src/gdext/objecttools.nim
@@ -23,7 +23,7 @@ proc instantiate*[T: RefCounted](_: typedesc[T]): GdRef[T] =
 proc instantiate*[T_Node: Node](T: typedesc[T_Node]; name: string): T =
   result = instantiate_internal T
   debugInstantiate(result)
-  result.name = gdstring name
+  result.name = newGdString name
 
 proc castTo*[T: Object](self: Object; _: typedesc[T]): T =
   if self.isNil: return
@@ -63,6 +63,6 @@ proc `$`*(self: Node): string =
   $self.name() & " [" & $Object(self) & "]"
 
 template `/`*(self: Node; path: NodePath): Node = getNode(self, path)
-template `/`*(self: Node; path: string): Node = self/nodepath(gdstring path)
+template `/`*(self: Node; path: string): Node = self/newNodePath(newGdString path)
 
 template `/`*[T: Node](self: Node; sub: typedesc[T]): T = self/($sub) as sub

--- a/src/gdext/private/gdinterface.nim
+++ b/src/gdext/private/gdinterface.nim
@@ -118,7 +118,7 @@ proc Meta*(T: typedesc[SomeClass]): var GodotClassMeta =
   var instance {.global.} : GodotClassMeta
   once:
     instance = GodotClassMeta(
-      className: stringName $T,
+      className: newStringName $T,
     )
     when T is SomeEngineClass:
       instance.callbacks = InstanceBindingCallbacks(
@@ -186,7 +186,7 @@ proc constructObject*(_: typedesc[ClassDB]; p_classname: StringName): ObjectPtr 
 proc getMethodBind*(_: typedesc[ClassDB]; p_classname: StringName; p_methodname: StringName; p_hash: Int): MethodBindPtr =
   interfaceClassdbGetMethodBind(addr p_classname, addr p_methodname, p_hash)
 proc getMethodBind*(_: typedesc[ClassDB]; p_classname: StringName; p_methodname: string; p_hash: Int): MethodBindPtr =
-  ClassDB.getMethodBind(p_classname, stringName p_methodname, p_hash)
+  ClassDB.getMethodBind(p_classname, newStringName p_methodname, p_hash)
 
 proc getClassTag*(_: typedesc[ClassDB]; p_classname: StringName): pointer =
   interfaceClassdbGetClassTag(addr p_classname)

--- a/src/gdext/private/includes/stringtoolsbase.nim
+++ b/src/gdext/private/includes/stringtoolsbase.nim
@@ -11,7 +11,7 @@ template getPtr(v: GdRef): pointer =
   getPtr v.handle
 
 proc load(typ: VariantType; proc_name: string; hash: int): PtrBuiltinMethod =
-  let name = stringName proc_name
+  let name = newStringName proc_name
   interface_Variant_getPtrBuiltinMethod(typ, addr name, hash)
 proc load(op: Variant_Operator; left, right: VariantType): PtrOperatorEvaluator =
   interfaceVariantGetPtrOperatorEvaluator(cuint op.ord, left, right)

--- a/src/gdext/private/internalbridge.nim
+++ b/src/gdext/private/internalbridge.nim
@@ -95,7 +95,7 @@ else:
 
 proc icon_path[T](_: typedesc[T]): String =
   when T.hasCustomPragma(icon):
-    gdstring T.getCustomPragmaVal(icon)
+    newGdString T.getCustomPragmaVal(icon)
 
 proc creationInfo(T: typedesc[SomeUserClass]; is_virtual, is_abstract, is_exposed: bool; icon_path: String): ClassCreationInfo4 =
   ClassCreationInfo4(
@@ -162,7 +162,7 @@ proc gdexport_internal*(
     appearance: Appearance;
     description: string) =
   gdexport_internal(
-    propertyInfo(stringName name, proptyp, appearance),
+    propertyInfo(newStringName name, proptyp, appearance),
     className typ, getter, setter)
   when Assistance.genEditorHelp:
     docClassDB[typ].members.add DocMember(
@@ -199,7 +199,7 @@ macro processExports(T: typed): untyped =
         registerProc `getterdef`
         registerProc `setterdef`
         gdexport_internal(`name`, typedesc `classIdent`, typedesc `classIdent`.`fieldIdent`,
-          stringName `gettername`, stringName `settername`, `editorhint`, `desc`)
+          newStringName `gettername`, newStringName `settername`, `editorhint`, `desc`)
 
   if result.len != 0:
     result = quote do:

--- a/src/gdext/private/methodinfo.nim
+++ b/src/gdext/private/methodinfo.nim
@@ -64,7 +64,7 @@ proc argumentsInfo(middle: MiddleExp): NimNode =
   result = newNimNode nnkBracket
   for (name, Type, default) in middle.args:
     result.add quote("@") do:
-      propertyInfo(typedesc @Type, stringName @(name.toStrLit)).unheap
+      propertyInfo(typedesc @Type, newStringName @(name.toStrLit)).unheap
 
 proc argumentsMeta(middle: MiddleExp): NimNode =
   result = newNimNode nnkBracket
@@ -213,7 +213,7 @@ proc classMethodInfo(
 proc classMethodInfo(middle: MiddleExp; gdname: NimNode): NimNode =
   result = quote("@") do:
     classMethodInfo(
-      stringName @gdname,
+      newStringName @gdname,
       @(middle.callFunc),
       @(middle.ptrCallFunc),
       @(middle.method_flags),
@@ -264,7 +264,7 @@ proc classVirtualMethodInfo(
 proc virtualMethodInfo*(middle: MiddleExp): NimNode =
   quote"@" do:
     classVirtualMethodInfo(
-      stringName @(middle.name.toStrLit),
+      newStringName @(middle.name.toStrLit),
       @(middle.returnValue),
       @(middle.returnValueMeta),
       @(middle.argumentsInfo),

--- a/src/gdext/private/propertyinfo.nim
+++ b/src/gdext/private/propertyinfo.nim
@@ -26,13 +26,13 @@ proc className*(E: typedesc[enum]): StringName =
   once:
     Meta(E).className =
       when compiles(E.EnumOwner):
-        stringName $className(E.EnumOwner) & "." & $E
+        newStringName $className(E.EnumOwner) & "." & $E
       else:
         let s = ($E).split("_")
         if s.len == 2 and s[0][0].isUpperAscii and s[1][0].isUpperAscii:
-          stringName s.join(".")
+          newStringName s.join(".")
         else:
-          stringName $E
+          newStringName $E
   Meta(E).className
 
 # Metadata

--- a/src/gdext/private/typeshift.nim
+++ b/src/gdext/private/typeshift.nim
@@ -69,7 +69,7 @@ template convert_generic_params_forcecast(Decoded, Encoded): untyped =
     cast[Decoded[T]](v.get(Encoded))
 
 
-convert_alternative AltString, String, gdstring, `$`
+convert_alternative AltString, String, newGdString, `$`
 
 convert_alternative_autocast AltInt, Int
 

--- a/src/gdext/private/userclass/signals.nim
+++ b/src/gdext/private/userclass/signals.nim
@@ -31,7 +31,7 @@ proc makebody (params, gdname, self: NimNode): NimNode =
   quote do:
     var signalName {.global.}: Variant
     once:
-      signalName = variant stringName `gdname`
+      signalName = variant newStringName `gdname`
     let variantArr = `variantArrDef`
     `self`.emitSignal(signalName, variantArr)
 
@@ -42,7 +42,7 @@ macro parseParams (params): seq[PropertyInfo] =
     if i == 0: continue
     let namelit = name.toStrLit
     arguments.add quote do:
-      propertyInfo(typedesc `typ`, stringName `namelit`).unheap
+      propertyInfo(typedesc `typ`, newStringName `namelit`).unheap
 
   quote do: @`arguments`
 

--- a/src/gdext/private/userclass/virtuals.nim
+++ b/src/gdext/private/userclass/virtuals.nim
@@ -32,7 +32,7 @@ proc emitterdef(middle: MiddleExp; procdef: NimNode): NimNode =
 
   result.body = genAst(namesym, namelit = middle.name.toStrLit, sentence, body):
     try:
-      let namesym {.global.} = stringName namelit
+      let namesym {.global.} = newStringName namelit
       if self.hasScriptMethod(namesym):
         sentence
       else:

--- a/src/gdext/stringtools.nim
+++ b/src/gdext/stringtools.nim
@@ -1,16 +1,16 @@
 import std/[unicode, importutils]
 import gdext/builtinindex
-import gdext/private/[native, staticevents]
+import gdext/private/[native, staticevents, macros]
 
-proc gdstring*(): String = discard
-proc gdstring*(str: string): String =
+proc newGdString*(): String = discard
+proc newGdString*(str: string): String =
   interfaceStringNewWithUtf8Chars(addr result, cstring str)
 
-proc stringName*(): StringName = discard
-proc stringName*(str: string): StringName =
+proc newStringName*(): StringName = discard
+proc newStringName*(str: string): StringName =
   interfaceStringNameNewWithUtf8Chars(addr result, cstring str)
 
-proc nodePath*(): NodePath = discard
+proc newNodePath*(): NodePath = discard
 
 include gdext/private/includes/stringtoolsbase
 
@@ -21,6 +21,10 @@ include gdext/gen/gdstring
 include gdext/gen/gdstringname
 include gdext/gen/gdnodepath
 
+template gdstring*(args: varargs[untyped]): untyped {.deprecated: "use newGdString instead".} = unpackVarargs(newGdString, args)
+template stringname*(args: varargs[untyped]): untyped {.deprecated: "use newStringName instead".} = unpackVarargs(newStringName, args)
+template nodepath*(args: varargs[untyped]): untyped {.deprecated: "use newNodePath instead".} = unpackVarargs(newNodePath, args)
+
 proc `$`*(s: String): string =
   var buffer {.global.}: string
   let length = s.length
@@ -29,5 +33,5 @@ proc `$`*(s: String): string =
   buffer[0..<actualSize]
 
 {.push, inline.}
-proc `$`*(s: StringName): string = $gdstring s
+proc `$`*(s: StringName): string = $newGdString s
 {.pop.}

--- a/src/gdext/utilityfuncs.nim
+++ b/src/gdext/utilityfuncs.nim
@@ -3,7 +3,7 @@ import gdext/builtinindex
 import gdext/stringtools
 
 proc load(proc_name: string; hash: int): PtrUtilityFunction =
-  let name = stringName proc_name
+  let name = newStringName proc_name
   interface_Variant_getPtrUtilityFunction(addr name, hash)
 
 include gdext/gen/utilityfuncs

--- a/src/gdext/wizard/subcommands/extension/template/config.nims
+++ b/src/gdext/wizard/subcommands/extension/template/config.nims
@@ -1,7 +1,7 @@
 # Buildconf, default settings (includes a few required settings) is in.
 # Every settings you want can overwrite in a general way.
 # All functions defined here are simply wrappers for the switch function,
-# so raw switch can be used instead.
+# so raw switch can be used instead
 import gdext/buildconf
 import std/strutils
 

--- a/testproject/editor/nim/src/classes/gdproptestnode.nim
+++ b/testproject/editor/nim/src/classes/gdproptestnode.nim
@@ -41,8 +41,8 @@ MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT"""
   color_with_export_no_alpha*: Color = color(1, 1, 1)
 
 method onInit(self: PropTestNode) =
-  self.StringArray_with_export_multiline = typedArray[String](1)
-  self.PackedStringArray_with_export_multiline = packedStringArray()
+  self.StringArray_with_export_multiline = newTypedArray[String](1)
+  self.PackedStringArray_with_export_multiline = newPackedStringArray()
   assert self.PackedStringArray_with_export_multiline.resize(1) == 0
 
 method enterTree(self: PropTestNode) {.gdsync.} =

--- a/testproject/editor/nim/src/classes/gdproptestnode_pragmas.nim
+++ b/testproject/editor/nim/src/classes/gdproptestnode_pragmas.nim
@@ -59,9 +59,9 @@ MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT"""
 PropTestNodePragmas.bind PropTestPragmasEnum
 
 method onInit(self: PropTestNodePragmas) =
-  self.StringArray_with_export_multiline = typedArray[String](1)
-  self.string_array = typedArray[String]()
-  self.texture2D_array = typedArray[Texture2D]()
+  self.StringArray_with_export_multiline = newTypedArray[String](1)
+  self.string_array = newTypedArray[String]()
+  self.texture2D_array = newTypedArray[Texture2D]()
 
 method enterTree(self: PropTestNodePragmas) {.gdsync.} =
   self.icon = ResourceLoader.load("res://icon.png") as gdref Texture2D

--- a/testproject/editor/nim/src/classes/gdsignalsubscriber.nim
+++ b/testproject/editor/nim/src/classes/gdsignalsubscriber.nim
@@ -14,7 +14,7 @@ gdexport "publisher",
     self.publisher = value,
   Appearance.custom(
   hint = propertyHintNodeType,
-  hint_string = gdstring className Node)
+  hint_string = newGdString className Node)
 
 proc recv*(self: SignalSubscriber; key: int) {.gdsync.} =
   ## Take a argument and echo it.

--- a/testproject/runtime/nim/src/cases/primitives.nim
+++ b/testproject/runtime/nim/src/cases/primitives.nim
@@ -4,19 +4,19 @@ import std/unicode
 
 runtime: suite "Array":
   test "construct":
-    var arr = gdarray(10)
+    var arr = newArray(10)
     check not arr.isTyped
     check arr.len == 10
     for i, val in arr:
       check val == variant()
   test "mutable iter":
-    var arr = gdarray(10)
+    var arr = newArray(10)
     for i, val in arr.mpairs:
       val = variant(i)
     for i, val in arr:
       check val.get(int) == i
   test "subscript":
-    var arr = gdarray(10)
+    var arr = newArray(10)
     for i in 0..<arr.len:
       check arr[i] == variant()
     for i in 0..<arr.len:
@@ -26,34 +26,34 @@ runtime: suite "Array":
 
 runtime: suite "TypedArray":
   test "construct":
-    var arr = typedArray[String](10)
+    var arr = newTypedArray[String](10)
     check arr.isTyped
     check cast[VariantType](arr.getTypedBuiltin) == VariantTypeString
     check arr.len == 10
     for i, val in arr:
       check val.length == 0
   test "mutable iter":
-    var arr = typedArray[String](10)
+    var arr = newTypedArray[String](10)
     for i, val in arr.mpairs:
       val = $i
     for i, val in arr:
       check $val == $i
 
-    var arr2 = typedArray[Object](10)
+    var arr2 = newTypedArray[Object](10)
     check not compiles(
       for i, val in arr2.mpairs: discard
     )
 
   test "subscript":
-    var arr = typedArray[String](10)
+    var arr = newTypedArray[String](10)
     for i in 0..<arr.len:
-      check arr[i] == gdstring""
+      check arr[i] == newGdString""
     for i in 0..<arr.len:
-      arr[i] = gdstring $i
+      arr[i] = newGdString $i
     for i in 0..<arr.len:
-      check arr[i] == gdstring $i
+      check arr[i] == newGdString $i
   test "typed functions":
-    var arr = typedArray[String](2)
+    var arr = newTypedArray[String](2)
     arr.fill "Hello, "
     arr.pushBack "world!"
     check $arr.popFront == "Hello, "
@@ -61,8 +61,8 @@ runtime: suite "TypedArray":
     check $arr[1] == "world!"
 
 
-runtime: suite "PackedArray":
-  var strs: PackedStringArray = packedStringArray()
+runtime: suite "newPackedArray":
+  var strs: PackedStringArray = newPackedStringArray()
 
   test "resizing":
     check strs.size == 0
@@ -70,38 +70,38 @@ runtime: suite "PackedArray":
     check strs.size == 8
 
     for i in 0..<strs.size:
-      check strs[i] == gdstring()
+      check strs[i] == newGdString()
 
   test "assignment":
     for i in 0..<strs.size:
-      strs[i] = gdstring $i
+      strs[i] = newGdString $i
     for i in 0..<strs.size:
-      check strs[i] == gdstring $i
+      check strs[i] == newGdString $i
 
   test "to seq":
     let s: seq[String] = strs.toSeq
-    check s == @[gdstring"0", gdstring"1", gdstring"2", gdstring"3", gdstring"4", gdstring"5", gdstring"6", gdstring"7"]
+    check s == @[newGdString"0", newGdString"1", newGdString"2", newGdString"3", newGdString"4", newGdString"5", newGdString"6", newGdString"7"]
 
   test "mutable iteration":
     for b in strs.mitems:
-      b = gdstring "Hello, world!"
-      check b == gdstring "Hello, world!"
+      b = newGdString "Hello, world!"
+      check b == newGdString "Hello, world!"
 
     for i, b in strs.mpairs:
-      b = gdstring $i
-      check b == gdstring $i
+      b = newGdString $i
+      check b == newGdString $i
 
   test "immutable iteration":
     for i, b in strs:
-      check b == gdstring $i
+      check b == newGdString $i
 
     var i: int
     for b in strs:
-      check b == gdstring $i
+      check b == newGdString $i
       inc i
 
-  test "contains(PackedInt32Array)":
-    var arr = packedInt32Array()
+  test "contains(newPackedInt32Array)":
+    var arr = newPackedInt32Array()
     discard arr.resize(10)
     for i, v in arr.mpairs:
       v = int32 i
@@ -109,11 +109,11 @@ runtime: suite "PackedArray":
     check 1 in arr
     check 11 notin arr
 
-  test "contains(PackedStringArray)":
-    var arr = packedStringArray()
+  test "contains(newPackedStringArray)":
+    var arr = newPackedStringArray()
     discard arr.resize(10)
     for i, v in arr.mpairs:
-      v = gdstring $i
+      v = newGdString $i
     check arr.contains "9"
     check "1" in arr
     check "hello" notin arr

--- a/testproject/runtime/nim/src/cases/variant.nim
+++ b/testproject/runtime/nim/src/cases/variant.nim
@@ -10,7 +10,7 @@ runtime: suite "Variant":
     check hasMember(VariantTypeColor, "r")
 
   test "call error":
-    var vdict = variant dictionary()
+    var vdict = variant newDictionary()
     check vdict.call("size").get(int) == 0
     expect GodotCallDefect: discard vdict.call("nonexistence")
     expect GodotCallDefect: discard vdict.call("size", "Extra Argument")
@@ -39,10 +39,10 @@ runtime: suite "Variant":
     check not variant 0
     check variant "String"
     check not variant ""
-    check not variant gdarray()
+    check not variant newArray()
 
   test "Dictionary in Variant":
-    var vdict = variant dictionary()
+    var vdict = variant newDictionary()
     check vdict.call("size").get(int) == 0
     vdict[variant"Key1"] = variant 1
     check vdict.call("size").get(int) == 1
@@ -63,7 +63,7 @@ runtime: suite "Variant":
 
 
   test "Array in Variant":
-    var varr = variant gdarray()
+    var varr = variant newArray()
     check varr.call("size").get(int) == 0
     varr.call("append", "Value1")
     check varr.call("size").get(int) == 1


### PR DESCRIPTION
The constructors of variant types (String, Signal, Vector2, etc.) were uniformly assumed to be camelCase type names, but we have decided to prefix them with new for those of them that cause memory allocation.

Since this change has a large impact on users, the existing constructors are still available. (You will still get a deprecated warning.)

Here is the list of constructors that have been changed:

*   `gdArray()` -> `newArray()` (Not `newGdArray()`) 
* `typedArray()` -> `newTypedArray()`
* `packedXXXArray()` -> `newPackedXXXArray()`
* `dictionary()` -> `newDictionary()`
* `gdstring()` -> `newGdString()`
* `stringName()` -> `newStringName()`
* `nodePath()` -> `newNodePath()`