### PR TITLE
Fix: reference counting related to Variant

### DIFF
--- a/src/gdext/private/typeshift.nim
+++ b/src/gdext/private/typeshift.nim
@@ -1,5 +1,5 @@
 import gdext/private/gdinterface
-import gdext/builtinindex
+import gdext/builtinindex {.all.}
 import gdext/stringtools
 
 # General
@@ -144,6 +144,7 @@ template encode*[T: RefCounted](v: GdRef[T]; p: pointer) =
 proc decode*[T: RefCounted](p: pointer; Result: typedesc[GdRef[T]]): Result =
   p.decode(T).referenced
 proc variant*[T: RefCounted](v: GdRef[T]): Variant =
+  discard hook_reference v.handle.engineInstance
   v.handle.variant
 proc get*[T: RefCounted](v: Variant; Result: typedesc[GdRef[T]]): Result =
   v.get(T).referenced


### PR DESCRIPTION
Fixes a bug where reference counts were not increasing when varianting RefCounted (resulting in references being released even though they existed).

may fixes #164 