### PR TITLE
Feat: `()`(Signal, varargs[Variant, variant])

### DIFF
--- a/coronation/src/coronation/operators/utilityfuncs.nim
+++ b/coronation/src/coronation/operators/utilityfuncs.nim
@@ -50,13 +50,21 @@ proc weave_loadstmt*(utilfunc: UtilityFunction): Cloth =
 
 proc weave_procdef*(utilfunc: UtilityFunction): Cloth =
   if utilfunc.isImplemented: return
+  let nonvarargs =
+    if utilfunc.json.is_vararg: utilfunc.key.args[0..^2]
+    else: utilfunc.key.args
+  let argsaddr =
+    if utilfunc.key.args.len == 0: "nil"
+    else: "addr ptrargs[0]"
+  let resaddr =
+    if utilfunc.key.result.typeSym == TypeSym.Void: "nil"
+    else: "getPtr result"
+
   weave multiline:
     weave utilfunc.key
     weave cloths.indent:
       if utilfunc.key.args.len != 0:
-        let args = utilfunc.key.args
-          .filterIt(not it.info.isVarargs)
-          .mapIt("getPtr " & $it.name).join(", ")
+        let args = nonvarargs.mapIt("getPtr " & $it.name).join(", ")
         if utilfunc.key.args[^1].info.isVarargs:
           &"let argslen = cint({utilfunc.key.args.high} + {utilfunc.key.args[^1].name}.len)"
           &"var ptrargs = newSeqOfCap[pointer](argslen)"
@@ -68,10 +76,4 @@ proc weave_procdef*(utilfunc: UtilityFunction): Cloth =
           &"let ptrargs = [{args}]"
       else:
         "const argslen = cint 0"
-      let argsaddr =
-        if utilfunc.key.args.len == 0: "nil"
-        else: "addr ptrargs[0]"
-      let resaddr =
-        if utilfunc.key.result.typeSym == TypeSym.Void: "nil"
-        else: "getPtr result"
       &"{utilfunc.container}({resaddr}, {argsaddr}, argslen)"

--- a/src/gdext/othertools.nim
+++ b/src/gdext/othertools.nim
@@ -1,3 +1,5 @@
+{.experimental: "callOperator".}
+
 import gdext/private/gdinterface
 import gdext/private/staticevents
 import gdext/builtinindex
@@ -18,3 +20,8 @@ include gdext/gen/gdrid
 include gdext/gen/gdint
 include gdext/gen/gdfloat
 include gdext/gen/gdbool
+
+{.push, inline.}
+proc `()`*(signal: Signal; args: varargs[Variant, variant]) =
+  signal.emit(args)
+{.pop.}

--- a/testproject/runtime/nim/src/classes/gdextnode/typedef.nim
+++ b/testproject/runtime/nim/src/classes/gdextnode/typedef.nim
@@ -124,12 +124,11 @@ proc test_Resource(self: GDExtNode) =
 proc signal_arg0*(self: GDExtNode): Error {.gdsync, signal.}
 proc signal_arg1*(self: GDExtNode; what: string): Error {.gdsync, signal.}
 
-var listen_0_result: seq[bool]
-var listen_1_result: seq[string]
+var listen_result: (bool, string)
 proc listen_0*(self: GDExtNode) {.gdsync.} =
-  listen_0_result.add true
+  listen_result[0] = true
 proc listen_1*(self: GDExtNode; what: string) {.gdsync.} =
-  listen_1_result.add what
+  listen_result[1] = what
 
 var result_call_group: bool
 proc lesten_call_group(self: GDExtNode, str: string) {.gdsync.} =
@@ -139,7 +138,6 @@ proc test_FirstClassFunction(self: GDExtNode) =
   suite "First-class function":
     test "connect to signal":
       check self.connect("signal_arg0", self.callable"listen_0") == ok
-      check self.connect("signal_arg0", self.callable"listen_1") == ok
       check self.connect("signal_arg1", self.callable"listen_0") == ok
       check self.connect("signal_arg1", self.callable"listen_1") == ok
 
@@ -148,11 +146,20 @@ proc test_FirstClassFunction(self: GDExtNode) =
       check result_call_group
     test "send Signal":
       check self.signal_arg0() == ok
-      check listen_0_result[0]
-      check listen_1_result[0].len != 0
+      check listen_result[0]
+      reset listen_result
       check self.signal_arg1("SIGNAL") == ok
-      check listen_0_result[1]
-      check listen_1_result[1] == "SIGNAL"
+      check listen_result[0]
+      check listen_result[1] == "SIGNAL"
+      reset listen_result
+    test "send Signal with emit":
+      self.signal"signal_arg0"()
+      check listen_result[0]
+      reset listen_result
+      self.signal"signal_arg1"("SIGNAL")
+      check listen_result[0]
+      check listen_result[1] == "SIGNAL"
+      reset listen_result
 
 proc test_VirtualMethod(self: GDExtNode) =
   suite "virtuals":


### PR DESCRIPTION
Implement a call operator for Signal type.

This allows you to treat Signal like a real function.

```nim
mynode.signal"my_signal"() # => mynode.signal"my_signal".emit() 
mynode.signal"my_signal"(arg1, arg2) # also ok
```