### PR TITLE
Feat: toString (`$`) functions for all builtins

### DIFF
--- a/src/gdext.nim
+++ b/src/gdext.nim
@@ -22,6 +22,7 @@
 ## * `swizzles <gdext/swizzles.html>`_: GLSLang-like swizzling operator
 ## * `utilityfuncs <gdext/utilityfuncs.html>`_: Printing functions + misc
 ## * `conversions <gdext/conversions.html>`_: Utility converters to make easier to convert types
+## * `dollars <gdext/dollars.html>`_: `$` for all engine-builtins
 
 
 {.warning[UnusedImport]: off.}
@@ -59,6 +60,7 @@ import gdext/colortools; export colortools
 import gdext/othertools; export othertools
 import gdext/utilityfuncs; export utilityfuncs
 import gdext/conversions; export conversions
+import gdext/dollars; export dollars
 
 import gdext/classes/[gdengine]
 export gdengine.isEditorHint

--- a/src/gdext/dollars.nim
+++ b/src/gdext/dollars.nim
@@ -1,0 +1,303 @@
+import std/[math, importutils]
+
+import gdext/private/native
+import gdext/builtinindex
+import gdext/stringtools
+
+proc c_snprintf(buf: cstring, n: csize_t, frmt: cstring): cint {.header: "<stdio.h>",
+                                    importc: "snprintf", varargs, noSideEffect.}
+
+proc addNum(s: var string; num: float; decimals: int) =
+  if num.isNaN:
+    s.add "nan"
+    return
+  if num == Inf:
+    s.add "inf"
+    return
+  if num == -Inf:
+    s.add "-inf"
+    return
+
+  var decimals = decimals
+  if decimals < 0:
+    decimals = 14
+    let absNum = abs num
+    if absNum > 10:
+      decimals -= int floor(log10(absNum))
+
+  var fmt: array[7, char]
+  fmt[0] = '%';
+  fmt[1] = '.';
+  if decimals < 0:
+    fmt[1] = 'l'
+    fmt[2] = 'f'
+    fmt[3] = '\0'
+  elif decimals < 10:
+    fmt[2] = char '0'.ord + decimals
+    fmt[3] = 'l'
+    fmt[4] = 'f'
+    fmt[5] = '\0'
+  else:
+    fmt[2] = char '0'.ord + (decimals div 10)
+    fmt[3] = char '0'.ord + (decimals mod 10)
+    fmt[4] = 'l'
+    fmt[5] = 'f'
+    fmt[6] = '\0'
+
+  var buf: array[325, char]
+  discard c_snprintf(cast[cstring](addr buf[0]), 325, cast[cstring](addr fmt[0]), num)
+  buf[324] = '\0'
+
+  block:
+    var period = false
+    var z = 0
+
+    while buf[z] != '\0':
+      if buf[z] == '.':
+        period = true
+      inc z
+
+    if period:
+      dec z
+      while z > 0:
+        if buf[z] == '0':
+          buf[z] = '\0'
+        elif buf[z] == '.':
+          buf[z + 1] = '0'
+          break
+        else:
+          break
+        dec z
+
+  s.add cast[cstring](addr buf[0])
+
+
+proc addNumReal(s: var string; num: float, trailing: bool) =
+  if num.isNaN or num == Inf or num == -Inf:
+    s.addNum(num, 0)
+    return
+
+  if num == float int64 num:
+    s.addInt int num
+    if trailing:
+      s.add ".0"
+    return
+
+  var decimals = 6
+  let absNum = abs num
+  if absNum > 10:
+    decimals -= int floor(log10(absNum))
+  s.addNum(num, decimals)
+
+proc addVector(s: var string; v: VectorR) =
+  s.add "("
+  s.addNumReal v[0], true
+  for i in 1..<v.len:
+    s.add ", "
+    s.addNumReal v[i], true
+  s.add ")"
+
+proc addVector(s: var string; v: VectorI) =
+  s.add "("
+  s.addInt v[0]
+  for i in 1..<v.len:
+    s.add ", "
+    s.addInt v[i]
+  s.add ")"
+
+proc stringify(v: Variant): String =
+  interfaceVariantStringify(addr v, addr result)
+
+proc `$`*(v {.bycopy.}: Variant): string = $v.stringify
+
+proc `$`*(v: Array): string =
+  var variant: Variant
+  variantFromType[VariantType_Array](addr variant, addr v)
+  $variant
+proc `$`*(v: TypedArray): string =
+  $(v.Array)
+
+proc `$`*[T](v: PackedArray[T]): string =
+  var variant: Variant
+  variantFromType[variantType PackedArray[T]](addr variant, addr v)
+  $variant
+
+proc `$`*(v: Dictionary): string =
+  var variant: Variant
+  variantFromType[VariantType_Dictionary](addr variant, addr v)
+  $variant
+
+proc `$`*(v: Callable): string =
+  var variant: Variant
+  variantFromType[VariantType_Callable](addr variant, addr v)
+  $variant
+
+proc `$`*(v: Signal): string =
+  var variant: Variant
+  variantFromType[VariantType_Signal](addr variant, addr v)
+  $variant
+
+proc `$`*(v: Color): string =
+  const sample = "(0.0, 0.0, 0.0, 1.0)"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.add "("
+  result.addNum v.r, 4
+  result.add ", "
+  result.addNum v.g, 4
+  result.add ", "
+  result.addNum v.b, 4
+  result.add ", "
+  result.addNum v.a, 4
+  result.add ")"
+
+proc `$`*(v: AABB): string =
+  const sample = "[P: (0.0, 0.0, 0.0), S: (0.0, 0.0, 0.0)]"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.add "[P: "
+  result.addVector v.position
+  result.add ", S: "
+  result.addVector v.size
+  result.add "]"
+
+proc `$`*(v: Basis): string =
+  const sample = "[X: (1.0, 0.0, 0.0), Y: (0.0, 1.0, 0.0), Z: (0.0, 0.0, 1.0)]"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.add "[X: "
+  result.addVector v.x
+  result.add ", Y: "
+  result.addVector v.y
+  result.add ", Z: "
+  result.addVector v.z
+  result.add "]"
+
+proc `$`*(v: Plane): string =
+  const sample = "[N: (0.0, 0.0, 0.0), D: 0]"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.add "[N: "
+  result.addVector v.normal
+  result.add ", D: "
+  result.addNumReal v.d, false
+  result.add "]"
+
+proc `$`*(v: Projection): string =
+  const sample = "[X: (1.0, 0.0, 0.0, 0.0), Y: (0.0, 1.0, 0.0, 0.0), Z: (0.0, 0.0, 1.0, 0.0), W: (0.0, 0.0, 0.0, 1.0)]"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.add "[X: "
+  result.addVector v.x
+  result.add ", Y: "
+  result.addVector v.y
+  result.add ", Z: "
+  result.addVector v.z
+  result.add ", W: "
+  result.addVector v.w
+  result.add "]"
+
+proc `$`*(v: Quaternion): string =
+  const sample = "(0, 0, 0, 1)"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.add "("
+  result.addNumReal v.x, false
+  result.add ", "
+  result.addNumReal v.y, false
+  result.add ", "
+  result.addNumReal v.z, false
+  result.add ", "
+  result.addNumReal v.w, false
+  result.add ")"
+
+proc `$`*(v: Rect2): string =
+  const sample = "[P: (0.0, 0.0), S: (0.0, 0.0)]"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.add "[P: "
+  result.addVector v.position
+  result.add ", S: "
+  result.addVector v.size
+  result.add "]"
+
+proc `$`*(v: Rect2i): string =
+  const sample = "[P: (0, 0), S: (0, 0)]"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.add "[P: "
+  result.addVector v.position
+  result.add ", S: "
+  result.addVector v.size
+  result.add "]"
+
+proc `$`*(v: Transform2D): string =
+  const sample = "[X: (1.0, 0.0), Y: (0.0, 1.0), O: (0.0, 0.0)]"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.add "[X: "
+  result.addVector v.x
+  result.add ", Y: "
+  result.addVector v.y
+  result.add ", O: "
+  result.addVector v.origin
+  result.add "]"
+
+proc `$`*(v: Transform3D): string =
+  const sample = "[X: (1.0, 0.0, 0.0), Y: (0.0, 1.0, 0.0), Z: (0.0, 0.0, 1.0), O: (0.0, 0.0, 0.0)]"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.add "[X: "
+  result.addVector v.basis.x
+  result.add ", Y: "
+  result.addVector v.basis.y
+  result.add ", Z: "
+  result.addVector v.basis.z
+  result.add ", O: "
+  result.addVector v.origin
+  result.add "]"
+
+proc `$`*(v: Vector2): string =
+  const sample = "(0.0, 0.0)"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.addVector v
+
+proc `$`*(v: Vector2i): string =
+  const sample = "(0, 0)"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.addVector v
+
+proc `$`*(v: Vector3): string =
+  const sample = "(0.0, 0.0, 0.0)"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.addVector v
+
+proc `$`*(v: Vector3i): string =
+  const sample = "(0, 0, 0)"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.addVector v
+
+proc `$`*(v: Vector4): string =
+  const sample = "(0.0, 0.0, 0.0, 0.0)"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.addVector v
+
+proc `$`*(v: Vector4i): string =
+  const sample = "(0, 0, 0, 0)"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.addVector v
+
+proc `$`*(v: RID): string =
+  privateAccess RID
+  const sample = "RID(1000)"
+  const cap = int sample.len * 1.5
+  result = newStringOfCap(cap)
+  result.add "RID("
+  result.addInt v.value
+  result.add ")"

--- a/src/gdext/objecttools.nim
+++ b/src/gdext/objecttools.nim
@@ -1,4 +1,4 @@
-import std/[tables, sets, strutils]
+import std/[tables, sets]
 
 import gdext/builtinindex
 import gdext/stringtools
@@ -56,11 +56,13 @@ proc singleton*[T: SomeClass](_: typedesc[T]): T =
     result = cast[T](cache)
 
 proc `$`*[T: Object](self: T): string =
-  if self.isNil: return $self.getClassName & "(nil)"
-  $self.getClassName & "(ID: 0x" & gdinterface.getInstanceID(self).toHex & ")"
+  if unlikely(self.isNil):
+    "<Object#null>"
+  else:
+    $self.toString
 
-proc `$`*(self: Node): string =
-  $self.name() & " [" & $Object(self) & "]"
+proc `$`*(self: GdRef): string =
+  $self.handle
 
 template `/`*(self: Node; path: NodePath): Node = getNode(self, path)
 template `/`*(self: Node; path: string): Node = self/newNodePath(newGdString path)

--- a/src/gdext/stringtools.nim
+++ b/src/gdext/stringtools.nim
@@ -28,6 +28,8 @@ include gdext/gen/gdstring
 include gdext/gen/gdstringname
 include gdext/gen/gdnodepath
 
+proc newNodePath*(str: string): NodePath = newNodePath(newGdString(str))
+
 template gdstring*(args: varargs[untyped]): untyped {.deprecated: "use newGdString instead".} = unpackVarargs(newGdString, args)
 template stringname*(args: varargs[untyped]): untyped {.deprecated: "use newStringName instead".} = unpackVarargs(newStringName, args)
 template nodepath*(args: varargs[untyped]): untyped {.deprecated: "use newNodePath instead".} = unpackVarargs(newNodePath, args)
@@ -41,4 +43,5 @@ proc `$`*(s: String): string =
 
 {.push, inline.}
 proc `$`*(s: StringName): string = $newGdString s
+proc `$`*(s: NodePath): string = $newGdString s
 {.pop.}

--- a/src/gdext/varianttools.nim
+++ b/src/gdext/varianttools.nim
@@ -3,9 +3,6 @@ import std/[strformat, hashes, sequtils]
 import gdext/builtinindex
 import gdext/private/[gdinterface, typeshift]
 
-proc stringify(v: Variant): String =
-  interfaceVariantStringify(addr v, addr result)
-
 proc iterInit(self: Variant; r_iter: var Variant; r_valid: var bool): bool =
   interfaceVariantIterInit(addr self, addr r_iter, addr r_valid)
 
@@ -138,8 +135,6 @@ proc clear*(self: Variant) =
   if unlikely(needs_deinit[self.getType]):
     interfaceVariantDestroy(addr self)
   interfaceVariantNewNil(addr self)
-
-proc `$`*(v: Variant): string = $v.stringify
 
 const OpName: array[VariantOperator, string] = [
   "==",

--- a/testproject/runtime/nim/src/cases/primitives.nim
+++ b/testproject/runtime/nim/src/cases/primitives.nim
@@ -1,6 +1,105 @@
 import gdext
 import testutils
-import std/unicode
+import std/[unicode, strutils]
+import gdext/classes/gdnode
+
+runtime: suite "to string":
+  test "Bool":
+    check $true == $variant(true)
+    check $false == $variant(false)
+  test "Int":
+    check $3141592 == $variant(3141592)
+  test "Float":
+    check $Inf == $variant(Inf)
+    check $3.141592 == $variant(3.141592)
+  test "Color":
+    check $AliceBlue == $variant(AliceBlue)
+  test "AABB":
+    check $AABB() == $variant(AABB())
+  test "Basis":
+    check $Basis() == $variant(Basis())
+  test "Plane":
+    check $Plane() == $variant(Plane())
+    let plane1 = plane(vector3(0, 0, 1), 1.5)
+    check $plane1 == $variant(plane1)
+    let plane2 = plane(vector3(0, 0, 1), 1000000.12345)
+    check $plane2 == $variant(plane2)
+  test "Projection":
+    check $Projection() == $variant(Projection())
+  test "Quaternion":
+    check $Quaternion() == $variant(Quaternion())
+  test "Rect2":
+    check $Rect2() == $variant(Rect2())
+  test "Rect2i":
+    check $Rect2i() == $variant(Rect2i())
+  test "Transform2D":
+    check $Transform2D() == $variant(Transform2D())
+  test "Transform3D":
+    check $Transform3D() == $variant(Transform3D())
+  test "Vector2":
+    check $vector2() == $variant(vector2())
+    check $vector2(PI, Inf) == $variant(vector2(PI, Inf))
+  test "Vector2i":
+    check $vector2i() == $variant(vector2i())
+  test "Vector3":
+    check $vector3() == $variant(vector3())
+  test "Vector3i":
+    check $vector3i() == $variant(vector3i())
+  test "Vector4":
+    check $vector4() == $variant(vector4())
+  test "Vector4i":
+    check $vector4i() == $variant(vector4i())
+  test "RID":
+    check $rid() == $variant(rid())
+  test "String":
+    check $newGdString("Hello, world!") == $variant(newGdString("Hello, world!"))
+  test "StringName":
+    check $newStringName("Object") == $variant(newStringName("Object"))
+  test "NodePath":
+    check $newNodePath("path/to/somewhere") == $variant(newNodePath("path/to/somewhere"))
+  test "Array":
+    var arr = newArray(5)
+    for i in 0..<arr.len:
+      arr[i] = variant i
+    check $arr == $variant(arr)
+    check ($arr).startsWith "["
+  test "TypedArray":
+    var arr = newTypedArray[int](5)
+    for i in 0..<arr.len:
+      arr[i] = i
+    check $arr == $variant(arr)
+    check ($arr).startsWith "["
+  test "PackedArray":
+    var arr = newPackedInt64Array()
+    arr.setLen(5)
+    for i in 0..<arr.len:
+      arr[i] = i
+    check $arr == $variant(arr)
+    check ($arr).startsWith "["
+  test "Dictionary":
+    var dict = newDictionary()
+    for i, s in ["a", "b", "c"]:
+      dict[variant s] = variant i
+    check $dict == $variant(dict)
+    check ($dict).startsWith "{"
+  test "Object":
+    var obj = instantiate Object
+    check $obj == $variant(obj)
+    destroy obj
+    var nilobj: Object
+    check $nilobj == $variant(nilobj)
+  test "RefCounted":
+    var refc = instantiate RefCounted
+    check $refc == $variant(refc)
+    check $refc[] == $variant(refc[])
+    var nilrefc: GdRef[RefCounted]
+    check $nilrefc == $variant(nilrefc)
+  test "Node":
+    var node = instantiate(Node, "MyNode")
+    check $node == $variant(node)
+    destroy node
+    var nilnode: Node
+    check $nilnode == $variant(nilnode)
 
 runtime: suite "Array":
   test "construct":

--- a/testproject/runtime/nim/src/classes/gdextnode/typedef.nim
+++ b/testproject/runtime/nim/src/classes/gdextnode/typedef.nim
@@ -1,5 +1,5 @@
 import testutils
-import std/[tables, strutils]
+import std/[tables]
 
 import gdext
 import gdext/private/typeshift
@@ -49,14 +49,6 @@ proc test_Object(self: GDExtNode) =
       check self == Engine.getSingleton(classname GDExtNode).as GDExtNode
       check self == GDExtNode
 
-    test "stringify":
-      let obj1: Object = instantiate Object
-      let obj2: Object = Input.singleton
-      check ($obj1).startsWith "Object"
-      check ($obj2).startsWith "Input"
-
-      destroy obj1
-
 proc test_RefCounted(self: GDExtNode) =
   suite "RefCounted":
     test "reference counting":
@@ -93,9 +85,6 @@ proc test_Node(self: GDExtNode) =
       let node2: Node2D = self/Node2D
 
       check node == node2
-
-    test "stringify":
-      check ($self).startsWith "GDExtNode"
 
 proc test_Resource(self: GDExtNode) =
   suite "Resource":


### PR DESCRIPTION
* Define `$` operators for types that did not support stringification, such as Array and Dictionary
* Ensure that the result of `$` of all built-in types is the same as GDScript's `str(value)`.