### PR TITLE
Feat: Easier handling varargs

### DIFF
--- a/coronation/src/coronation/operators/arguments.nim
+++ b/coronation/src/coronation/operators/arguments.nim
@@ -77,7 +77,10 @@ proc `type`*(param: RenderableParamBase): string =
   if param.info.isMutable:
     return "var " & result
   if param.info.isVarargs:
-    return &"varargs[{result}]"
+    if param.typeSym == TypeSym.Variant:
+      return "varargs[Variant, variant]"
+    else:
+      return &"varargs[{result}]"
 
 proc `type`*(param: RenderableArgument): string =
   param.RenderableParamBase.type

--- a/coronation/src/coronation/operators/utilityfuncs.nim
+++ b/coronation/src/coronation/operators/utilityfuncs.nim
@@ -21,11 +21,19 @@ proc extract_args(self: JsonUtilityFunction): seq[RenderableArgument] =
       typeSym: TypeSym.Variant,
       default_value: none string)
 
+proc mergeVarargs(s: var seq[RenderableArgument]): bool =
+  if s.len == 2 and s[0].typeSym == TypeSym.Variant and s[1].info.isVarargs:
+    s = s[1..1]
+    true
+  else:
+    false
+
 type UtilityFunction* = object
   key: ProcKey
   container: ContainerKey
   json: JsonUtilityFunction
   isImplemented: bool
+  isVarargsMerged: bool
 
 proc convert*(json: JsonUtilityFunction): UtilityFunction =
   result.key = ProcKey(
@@ -37,6 +45,7 @@ proc convert*(json: JsonUtilityFunction): UtilityFunction =
   result.container = gen_containerKey result.key
   result.json = json
   result.isImplemented = result.container in manualImplemented.functions
+  result.isVarargsMerged = result.key.args.mergeVarargs()
 
 proc weave_container*(utilfunc: UtilityFunction): Cloth =
   if utilfunc.isImplemented:
@@ -65,10 +74,16 @@ proc weave_procdef*(utilfunc: UtilityFunction): Cloth =
     weave cloths.indent:
       if utilfunc.key.args.len != 0:
         let args = nonvarargs.mapIt("getPtr " & $it.name).join(", ")
-        if utilfunc.key.args[^1].info.isVarargs:
-          &"let argslen = cint({utilfunc.key.args.high} + {utilfunc.key.args[^1].name}.len)"
-          &"var ptrargs = newSeqOfCap[pointer](argslen)"
-          &"ptrargs.add [{args}]"
+        if utilfunc.json.is_vararg:
+          let vararg = utilfunc.key.args[^1]
+          if nonvarargs.len == 0:
+            if utilfunc.isVarargsMerged:
+              &"if unlikely({vararg.name}.len < 1): return"
+            &"var ptrargs = newSeqOfCap[pointer]({vararg.name}.len)"
+          else:
+            &"let argslen = cint({nonvarargs.len} + {vararg.name}.len)"
+            &"var ptrargs = newSeqOfCap[pointer](argslen)"
+            &"ptrargs.add [{args}]"
           &"for arg in {utilfunc.key.args[^1].name}:"
           &"  ptrargs.add getPtr arg"
         else:

--- a/src/gdext/classes/gdclassdb.nim
+++ b/src/gdext/classes/gdclassdb.nim
@@ -124,12 +124,12 @@ proc classGetMethodList*(self: ClassDB; class: StringName; noInheritance: bool =
   methodbind.ptrcall(self, [getPtr class, getPtr noInheritance], addr ret)
   (addr ret).decode_result(TypedArray[Dictionary])
 
-proc classCallStatic*(self: ClassDB; class: Variant; `method`: Variant; args: varargs[Variant]): Variant =
+proc classCallStatic*(self: ClassDB; class: Variant; `method`: Variant; args: varargs[Variant, variant]): Variant =
   expandMethodBind(className ClassDB, "class_call_static", 3344196419)
   var `?param` = newSeqOfCap[VariantPtr](2+args.len)
   `?param`.add [getTypedPtr class, getTypedPtr `method`]
   methodbind.call(self, `?param`, args).get(Variant)
-template classCallStatic*(self: ClassDB; class: StringName; `method`: StringName; args: varargs[Variant]): Variant =
+template classCallStatic*(self: ClassDB; class: StringName; `method`: StringName; args: varargs[Variant, variant]): Variant =
   classCallStatic(self, variant class, variant `method`, args)
 
 proc classGetIntegerConstantList*(self: ClassDB; class: StringName; noInheritance: bool = false): PackedStringArray =

--- a/src/gdext/classes/gdeditorundoredomanager.nim
+++ b/src/gdext/classes/gdeditorundoredomanager.nim
@@ -22,20 +22,20 @@ proc forceFixedHistory*(self: EditorUndoRedoManager): void =
   expandMethodBind(className EditorUndoRedoManager, "force_fixed_history", 3218959716)
   methodbind.ptrcall(self, [])
 
-proc addDoMethod*(self: EditorUndoRedoManager; `object`: Variant; `method`: Variant; args: varargs[Variant]): void =
+proc addDoMethod*(self: EditorUndoRedoManager; `object`: Variant; `method`: Variant; args: varargs[Variant, variant]): void =
   expandMethodBind(className EditorUndoRedoManager, "add_do_method", 1517810467)
   var `?param` = newSeqOfCap[VariantPtr](2+args.len)
   `?param`.add [getTypedPtr `object`, getTypedPtr `method`]
   discard methodbind.call(self, `?param`, args)
-template addDoMethod*(self: EditorUndoRedoManager; `object`: Object; `method`: StringName; args: varargs[Variant]): void =
+template addDoMethod*(self: EditorUndoRedoManager; `object`: Object; `method`: StringName; args: varargs[Variant, variant]): void =
   addDoMethod(self, variant `object`, variant `method`, args)
 
-proc addUndoMethod*(self: EditorUndoRedoManager; `object`: Variant; `method`: Variant; args: varargs[Variant]): void =
+proc addUndoMethod*(self: EditorUndoRedoManager; `object`: Variant; `method`: Variant; args: varargs[Variant, variant]): void =
   expandMethodBind(className EditorUndoRedoManager, "add_undo_method", 1517810467)
   var `?param` = newSeqOfCap[VariantPtr](2+args.len)
   `?param`.add [getTypedPtr `object`, getTypedPtr `method`]
   discard methodbind.call(self, `?param`, args)
-template addUndoMethod*(self: EditorUndoRedoManager; `object`: Object; `method`: StringName; args: varargs[Variant]): void =
+template addUndoMethod*(self: EditorUndoRedoManager; `object`: Object; `method`: StringName; args: varargs[Variant, variant]): void =
   addUndoMethod(self, variant `object`, variant `method`, args)
 
 proc addDoProperty*(self: EditorUndoRedoManager; `object`: Object; property: StringName; value: Variant): void =

--- a/src/gdext/classes/gdgdscript.nim
+++ b/src/gdext/classes/gdgdscript.nim
@@ -4,10 +4,10 @@ import gdext/coronation/header/classes
 
 import gdscript; export gdscript
 
-proc new*(self: GDScript; args: varargs[Variant]): Variant =
+proc new*(self: GDScript; args: varargs[Variant, variant]): Variant =
   expandMethodBind(className GDScript, "new", 1545262638)
   var `?param` = newSeqOfCap[VariantPtr](0+args.len)
   `?param`.add []
   methodbind.call(self, `?param`, args).get(Variant)
-template new*(self: GDScript; args: varargs[Variant]): Variant =
+template new*(self: GDScript; args: varargs[Variant, variant]): Variant =
   new(self, args)

--- a/src/gdext/classes/gdjavascriptbridge.nim
+++ b/src/gdext/classes/gdjavascriptbridge.nim
@@ -34,12 +34,12 @@ proc jsBufferToPackedByteArray*(self: JavaScriptBridge; javascriptBuffer: gdref 
   methodbind.ptrcall(self, [getPtr javascriptBuffer], addr ret)
   (addr ret).decode_result(PackedByteArray)
 
-proc createObject*(self: JavaScriptBridge; `object`: Variant; args: varargs[Variant]): Variant =
+proc createObject*(self: JavaScriptBridge; `object`: Variant; args: varargs[Variant, variant]): Variant =
   expandMethodBind(className JavaScriptBridge, "create_object", 3093893586)
   var `?param` = newSeqOfCap[VariantPtr](1+args.len)
   `?param`.add [getTypedPtr `object`]
   methodbind.call(self, `?param`, args).get(Variant)
-template createObject*(self: JavaScriptBridge; `object`: String; args: varargs[Variant]): Variant =
+template createObject*(self: JavaScriptBridge; `object`: String; args: varargs[Variant, variant]): Variant =
   createObject(self, variant `object`, args)
 
 proc downloadBuffer*(self: JavaScriptBridge; buffer: PackedByteArray; name: String; mime: String = newGdString("application/octet-stream")): void =

--- a/src/gdext/classes/gdnode.nim
+++ b/src/gdext/classes/gdnode.nim
@@ -660,32 +660,32 @@ proc atrN*(self: Node; message: String; pluralMessage: StringName; n: int32; con
   methodbind.ptrcall(self, [getPtr message, getPtr pluralMessage, getPtr n, getPtr context], addr ret)
   (addr ret).decode_result(String)
 
-proc rpc*(self: Node; `method`: Variant; args: varargs[Variant]): Error =
+proc rpc*(self: Node; `method`: Variant; args: varargs[Variant, variant]): Error =
   expandMethodBind(className Node, "rpc", 4047867050)
   var `?param` = newSeqOfCap[VariantPtr](1+args.len)
   `?param`.add [getTypedPtr `method`]
   methodbind.call(self, `?param`, args).get(Error)
-template rpc*(self: Node; `method`: StringName; args: varargs[Variant]): Error =
+template rpc*(self: Node; `method`: StringName; args: varargs[Variant, variant]): Error =
   rpc(self, variant `method`, args)
 
-proc rpcId*(self: Node; peerId: Variant; `method`: Variant; args: varargs[Variant]): Error =
+proc rpcId*(self: Node; peerId: Variant; `method`: Variant; args: varargs[Variant, variant]): Error =
   expandMethodBind(className Node, "rpc_id", 361499283)
   var `?param` = newSeqOfCap[VariantPtr](2+args.len)
   `?param`.add [getTypedPtr peerId, getTypedPtr `method`]
   methodbind.call(self, `?param`, args).get(Error)
-template rpcId*(self: Node; peerId: Int; `method`: StringName; args: varargs[Variant]): Error =
+template rpcId*(self: Node; peerId: Int; `method`: StringName; args: varargs[Variant, variant]): Error =
   rpcId(self, variant peerId, variant `method`, args)
 
 proc updateConfigurationWarnings*(self: Node): void =
   expandMethodBind(className Node, "update_configuration_warnings", 3218959716)
   methodbind.ptrcall(self, [])
 
-proc callDeferredThreadGroup*(self: Node; `method`: Variant; args: varargs[Variant]): Variant =
+proc callDeferredThreadGroup*(self: Node; `method`: Variant; args: varargs[Variant, variant]): Variant =
   expandMethodBind(className Node, "call_deferred_thread_group", 3400424181)
   var `?param` = newSeqOfCap[VariantPtr](1+args.len)
   `?param`.add [getTypedPtr `method`]
   methodbind.call(self, `?param`, args).get(Variant)
-template callDeferredThreadGroup*(self: Node; `method`: StringName; args: varargs[Variant]): Variant =
+template callDeferredThreadGroup*(self: Node; `method`: StringName; args: varargs[Variant, variant]): Variant =
   callDeferredThreadGroup(self, variant `method`, args)
 
 proc setDeferredThreadGroup*(self: Node; property: StringName; value: Variant): void =
@@ -696,12 +696,12 @@ proc notifyDeferredThreadGroup*(self: Node; what: int32): void =
   expandMethodBind(className Node, "notify_deferred_thread_group", 1286410249)
   methodbind.ptrcall(self, [getPtr what])
 
-proc callThreadSafe*(self: Node; `method`: Variant; args: varargs[Variant]): Variant =
+proc callThreadSafe*(self: Node; `method`: Variant; args: varargs[Variant, variant]): Variant =
   expandMethodBind(className Node, "call_thread_safe", 3400424181)
   var `?param` = newSeqOfCap[VariantPtr](1+args.len)
   `?param`.add [getTypedPtr `method`]
   methodbind.call(self, `?param`, args).get(Variant)
-template callThreadSafe*(self: Node; `method`: StringName; args: varargs[Variant]): Variant =
+template callThreadSafe*(self: Node; `method`: StringName; args: varargs[Variant, variant]): Variant =
   callThreadSafe(self, variant `method`, args)
 
 proc setThreadSafe*(self: Node; property: StringName; value: Variant): void =

--- a/src/gdext/classes/gdobject.nim
+++ b/src/gdext/classes/gdobject.nim
@@ -128,28 +128,28 @@ proc removeUserSignal*(self: Object; signal: StringName): void =
   expandMethodBind(className Object, "remove_user_signal", 3304788590)
   methodbind.ptrcall(self, [getPtr signal])
 
-proc emitSignal*(self: Object; signal: Variant; args: varargs[Variant]): Error =
+proc emitSignal*(self: Object; signal: Variant; args: varargs[Variant, variant]): Error =
   expandMethodBind(className Object, "emit_signal", 4047867050)
   var `?param` = newSeqOfCap[VariantPtr](1+args.len)
   `?param`.add [getTypedPtr signal]
   methodbind.call(self, `?param`, args).get(Error)
-template emitSignal*(self: Object; signal: StringName; args: varargs[Variant]): Error =
+template emitSignal*(self: Object; signal: StringName; args: varargs[Variant, variant]): Error =
   emitSignal(self, variant signal, args)
 
-proc call*(self: Object; `method`: Variant; args: varargs[Variant]): Variant =
+proc call*(self: Object; `method`: Variant; args: varargs[Variant, variant]): Variant =
   expandMethodBind(className Object, "call", 3400424181)
   var `?param` = newSeqOfCap[VariantPtr](1+args.len)
   `?param`.add [getTypedPtr `method`]
   methodbind.call(self, `?param`, args).get(Variant)
-template call*(self: Object; `method`: StringName; args: varargs[Variant]): Variant =
+template call*(self: Object; `method`: StringName; args: varargs[Variant, variant]): Variant =
   call(self, variant `method`, args)
 
-proc callDeferred*(self: Object; `method`: Variant; args: varargs[Variant]): Variant =
+proc callDeferred*(self: Object; `method`: Variant; args: varargs[Variant, variant]): Variant =
   expandMethodBind(className Object, "call_deferred", 3400424181)
   var `?param` = newSeqOfCap[VariantPtr](1+args.len)
   `?param`.add [getTypedPtr `method`]
   methodbind.call(self, `?param`, args).get(Variant)
-template callDeferred*(self: Object; `method`: StringName; args: varargs[Variant]): Variant =
+template callDeferred*(self: Object; `method`: StringName; args: varargs[Variant, variant]): Variant =
   callDeferred(self, variant `method`, args)
 
 proc setDeferred*(self: Object; property: StringName; value: Variant): void =

--- a/src/gdext/classes/gdscenetree.nim
+++ b/src/gdext/classes/gdscenetree.nim
@@ -134,12 +134,12 @@ proc queueDelete*(self: SceneTree; obj: Object): void =
   expandMethodBind(className SceneTree, "queue_delete", 3975164845)
   methodbind.ptrcall(self, [getPtr obj])
 
-proc callGroupFlags*(self: SceneTree; flags: Variant; group: Variant; `method`: Variant; args: varargs[Variant]): void =
+proc callGroupFlags*(self: SceneTree; flags: Variant; group: Variant; `method`: Variant; args: varargs[Variant, variant]): void =
   expandMethodBind(className SceneTree, "call_group_flags", 1527739229)
   var `?param` = newSeqOfCap[VariantPtr](3+args.len)
   `?param`.add [getTypedPtr flags, getTypedPtr group, getTypedPtr `method`]
   discard methodbind.call(self, `?param`, args)
-template callGroupFlags*(self: SceneTree; flags: Int; group: StringName; `method`: StringName; args: varargs[Variant]): void =
+template callGroupFlags*(self: SceneTree; flags: Int; group: StringName; `method`: StringName; args: varargs[Variant, variant]): void =
   callGroupFlags(self, variant flags, variant group, variant `method`, args)
 
 proc notifyGroupFlags*(self: SceneTree; callFlags: uint32; group: StringName; notification: int32): void =
@@ -150,12 +150,12 @@ proc setGroupFlags*(self: SceneTree; callFlags: uint32; group: StringName; prope
   expandMethodBind(className SceneTree, "set_group_flags", 3497599527)
   methodbind.ptrcall(self, [getPtr callFlags, getPtr group, getPtr property, getPtr value])
 
-proc callGroup*(self: SceneTree; group: Variant; `method`: Variant; args: varargs[Variant]): void =
+proc callGroup*(self: SceneTree; group: Variant; `method`: Variant; args: varargs[Variant, variant]): void =
   expandMethodBind(className SceneTree, "call_group", 1257962832)
   var `?param` = newSeqOfCap[VariantPtr](2+args.len)
   `?param`.add [getTypedPtr group, getTypedPtr `method`]
   discard methodbind.call(self, `?param`, args)
-template callGroup*(self: SceneTree; group: StringName; `method`: StringName; args: varargs[Variant]): void =
+template callGroup*(self: SceneTree; group: StringName; `method`: StringName; args: varargs[Variant, variant]): void =
   callGroup(self, variant group, variant `method`, args)
 
 proc notifyGroup*(self: SceneTree; group: StringName; notification: int32): void =

--- a/src/gdext/classes/gdtreeitem.nim
+++ b/src/gdext/classes/gdtreeitem.nim
@@ -584,12 +584,12 @@ proc moveAfter*(self: TreeItem; item: TreeItem): void =
   expandMethodBind(className TreeItem, "move_after", 1819951137)
   methodbind.ptrcall(self, [getPtr item])
 
-proc callRecursive*(self: TreeItem; `method`: Variant; args: varargs[Variant]): void =
+proc callRecursive*(self: TreeItem; `method`: Variant; args: varargs[Variant, variant]): void =
   expandMethodBind(className TreeItem, "call_recursive", 2866548813)
   var `?param` = newSeqOfCap[VariantPtr](1+args.len)
   `?param`.add [getTypedPtr `method`]
   discard methodbind.call(self, `?param`, args)
-template callRecursive*(self: TreeItem; `method`: StringName; args: varargs[Variant]): void =
+template callRecursive*(self: TreeItem; `method`: StringName; args: varargs[Variant, variant]): void =
   callRecursive(self, variant `method`, args)
 
 template collapsed*(self: TreeItem): untyped = self.isCollapsed()

--- a/src/gdext/gen/gdcallable.nim
+++ b/src/gdext/gen/gdcallable.nim
@@ -69,25 +69,25 @@ proc bindv*(self: var Callable; arguments: Array): Callable =
 proc unbind*(self: Callable; argcount: Int): Callable =
   let argArr = [getPtr argcount]
   `unbind(Callable Int)`(addr self, addr argArr[0], addr result, 1)
-proc call*(self: Callable; args: varargs[Variant]): Variant =
+proc call*(self: Callable; args: varargs[Variant, variant]): Variant =
   if args.len == 0:
     `call(Callable Variant)`(addr self, nil, addr result, 0)
   else:
     let argArr = getptr args
     `call(Callable Variant)`(addr self, addr argArr[0], addr result, cint args.len)
-proc callDeferred*(self: Callable; args: varargs[Variant]): void =
+proc callDeferred*(self: Callable; args: varargs[Variant, variant]): void =
   if args.len == 0:
     `callDeferred(Callable Variant)`(addr self, nil, nil, 0)
   else:
     let argArr = getptr args
     `callDeferred(Callable Variant)`(addr self, addr argArr[0], nil, cint args.len)
-proc rpc*(self: Callable; args: varargs[Variant]): void =
+proc rpc*(self: Callable; args: varargs[Variant, variant]): void =
   if args.len == 0:
     `rpc(Callable Variant)`(addr self, nil, nil, 0)
   else:
     let argArr = getptr args
     `rpc(Callable Variant)`(addr self, addr argArr[0], nil, cint args.len)
-proc rpcId*(self: Callable; peerId: Int; args: varargs[Variant]): void =
+proc rpcId*(self: Callable; peerId: Int; args: varargs[Variant, variant]): void =
   if args.len == 0:
     let argArr = [getPtr peerId]
     `rpcId(Callable Int Variant)`(addr self, addr argArr[0], nil, 1)
@@ -95,7 +95,7 @@ proc rpcId*(self: Callable; peerId: Int; args: varargs[Variant]): void =
     var argArr = @[getPtr peerId]
     argArr.add args.getptr
     `rpcId(Callable Int Variant)`(addr self, addr argArr[0], nil, cint argArr.len)
-proc `bind`*(self: Callable; args: varargs[Variant]): Callable =
+proc `bind`*(self: Callable; args: varargs[Variant, variant]): Callable =
   if args.len == 0:
     `bind(Callable Variant)`(addr self, nil, addr result, 0)
   else:

--- a/src/gdext/gen/gdsignal.nim
+++ b/src/gdext/gen/gdsignal.nim
@@ -43,7 +43,7 @@ proc getConnections*(self: Signal): Array =
   `getConnections(Signal)`(addr self, nil, addr result, 0)
 proc hasConnections*(self: Signal): bool =
   `hasConnections(Signal)`(addr self, nil, addr result, 0)
-proc emit*(self: Signal; args: varargs[Variant]): void =
+proc emit*(self: Signal; args: varargs[Variant, variant]): void =
   if args.len == 0:
     `emit(Signal Variant)`(addr self, nil, nil, 0)
   else:

--- a/src/gdext/gen/utilityfuncs.nim
+++ b/src/gdext/gen/utilityfuncs.nim
@@ -268,7 +268,7 @@ proc wrap*(value: Variant; min: Variant; max: Variant): Variant =
   let ptrargs = [getPtr value, getPtr min, getPtr max]
   `wrap(Variant Variant Variant)`(getPtr result, addr ptrargs[0], argslen)
 
-proc max*(arg1: Variant; arg2: Variant; args: varargs[Variant]): Variant =
+proc max*(arg1: Variant; arg2: Variant; args: varargs[Variant, variant]): Variant =
   let argslen = cint(2 + args.len)
   var ptrargs = newSeqOfCap[pointer](argslen)
   ptrargs.add [getPtr arg1, getPtr arg2]
@@ -276,7 +276,7 @@ proc max*(arg1: Variant; arg2: Variant; args: varargs[Variant]): Variant =
     ptrargs.add getPtr arg
   `max(Variant Variant Variant)`(getPtr result, addr ptrargs[0], argslen)
 
-proc min*(arg1: Variant; arg2: Variant; args: varargs[Variant]): Variant =
+proc min*(arg1: Variant; arg2: Variant; args: varargs[Variant, variant]): Variant =
   let argslen = cint(2 + args.len)
   var ptrargs = newSeqOfCap[pointer](argslen)
   ptrargs.add [getPtr arg1, getPtr arg2]
@@ -351,10 +351,9 @@ proc typeConvert*(variant: Variant; `type`: Int): Variant =
   let ptrargs = [getPtr variant, getPtr `type`]
   `typeConvert(Variant Int)`(getPtr result, addr ptrargs[0], argslen)
 
-proc str*(arg1: Variant; args: varargs[Variant]): String =
-  let argslen = cint(1 + args.len)
-  var ptrargs = newSeqOfCap[pointer](argslen)
-  ptrargs.add [getPtr arg1]
+proc str*(args: varargs[Variant, variant]): String =
+  if unlikely(args.len < 1): return
+  var ptrargs = newSeqOfCap[pointer](args.len)
   for arg in args:
     ptrargs.add getPtr arg
   `str(Variant Variant)`(getPtr result, addr ptrargs[0], argslen)
@@ -369,74 +368,65 @@ proc typeString*(`type`: Int): String =
   let ptrargs = [getPtr `type`]
   `typeString(Int)`(getPtr result, addr ptrargs[0], argslen)
 
-proc print*(arg1: Variant; args: varargs[Variant]): void =
-  let argslen = cint(1 + args.len)
-  var ptrargs = newSeqOfCap[pointer](argslen)
-  ptrargs.add [getPtr arg1]
+proc print*(args: varargs[Variant, variant]): void =
+  if unlikely(args.len < 1): return
+  var ptrargs = newSeqOfCap[pointer](args.len)
   for arg in args:
     ptrargs.add getPtr arg
   `print(Variant Variant)`(nil, addr ptrargs[0], argslen)
 
-proc printRich*(arg1: Variant; args: varargs[Variant]): void =
-  let argslen = cint(1 + args.len)
-  var ptrargs = newSeqOfCap[pointer](argslen)
-  ptrargs.add [getPtr arg1]
+proc printRich*(args: varargs[Variant, variant]): void =
+  if unlikely(args.len < 1): return
+  var ptrargs = newSeqOfCap[pointer](args.len)
   for arg in args:
     ptrargs.add getPtr arg
   `printRich(Variant Variant)`(nil, addr ptrargs[0], argslen)
 
-proc printerr*(arg1: Variant; args: varargs[Variant]): void =
-  let argslen = cint(1 + args.len)
-  var ptrargs = newSeqOfCap[pointer](argslen)
-  ptrargs.add [getPtr arg1]
+proc printerr*(args: varargs[Variant, variant]): void =
+  if unlikely(args.len < 1): return
+  var ptrargs = newSeqOfCap[pointer](args.len)
   for arg in args:
     ptrargs.add getPtr arg
   `printerr(Variant Variant)`(nil, addr ptrargs[0], argslen)
 
-proc printt*(arg1: Variant; args: varargs[Variant]): void =
-  let argslen = cint(1 + args.len)
-  var ptrargs = newSeqOfCap[pointer](argslen)
-  ptrargs.add [getPtr arg1]
+proc printt*(args: varargs[Variant, variant]): void =
+  if unlikely(args.len < 1): return
+  var ptrargs = newSeqOfCap[pointer](args.len)
   for arg in args:
     ptrargs.add getPtr arg
   `printt(Variant Variant)`(nil, addr ptrargs[0], argslen)
 
-proc prints*(arg1: Variant; args: varargs[Variant]): void =
-  let argslen = cint(1 + args.len)
-  var ptrargs = newSeqOfCap[pointer](argslen)
-  ptrargs.add [getPtr arg1]
+proc prints*(args: varargs[Variant, variant]): void =
+  if unlikely(args.len < 1): return
+  var ptrargs = newSeqOfCap[pointer](args.len)
   for arg in args:
     ptrargs.add getPtr arg
   `prints(Variant Variant)`(nil, addr ptrargs[0], argslen)
 
-proc printraw*(arg1: Variant; args: varargs[Variant]): void =
-  let argslen = cint(1 + args.len)
-  var ptrargs = newSeqOfCap[pointer](argslen)
-  ptrargs.add [getPtr arg1]
+proc printraw*(args: varargs[Variant, variant]): void =
+  if unlikely(args.len < 1): return
+  var ptrargs = newSeqOfCap[pointer](args.len)
   for arg in args:
     ptrargs.add getPtr arg
   `printraw(Variant Variant)`(nil, addr ptrargs[0], argslen)
 
-proc printVerbose*(arg1: Variant; args: varargs[Variant]): void =
-  let argslen = cint(1 + args.len)
-  var ptrargs = newSeqOfCap[pointer](argslen)
-  ptrargs.add [getPtr arg1]
+proc printVerbose*(args: varargs[Variant, variant]): void =
+  if unlikely(args.len < 1): return
+  var ptrargs = newSeqOfCap[pointer](args.len)
   for arg in args:
     ptrargs.add getPtr arg
   `printVerbose(Variant Variant)`(nil, addr ptrargs[0], argslen)
 
-proc pushError*(arg1: Variant; args: varargs[Variant]): void =
-  let argslen = cint(1 + args.len)
-  var ptrargs = newSeqOfCap[pointer](argslen)
-  ptrargs.add [getPtr arg1]
+proc pushError*(args: varargs[Variant, variant]): void =
+  if unlikely(args.len < 1): return
+  var ptrargs = newSeqOfCap[pointer](args.len)
   for arg in args:
     ptrargs.add getPtr arg
   `pushError(Variant Variant)`(nil, addr ptrargs[0], argslen)
 
-proc pushWarning*(arg1: Variant; args: varargs[Variant]): void =
-  let argslen = cint(1 + args.len)
-  var ptrargs = newSeqOfCap[pointer](argslen)
-  ptrargs.add [getPtr arg1]
+proc pushWarning*(args: varargs[Variant, variant]): void =
+  if unlikely(args.len < 1): return
+  var ptrargs = newSeqOfCap[pointer](args.len)
   for arg in args:
     ptrargs.add getPtr arg
   `pushWarning(Variant Variant)`(nil, addr ptrargs[0], argslen)

--- a/src/gdext/utilityfuncs.nim
+++ b/src/gdext/utilityfuncs.nim
@@ -7,15 +7,3 @@ proc load(proc_name: string; hash: int): PtrUtilityFunction =
   interface_Variant_getPtrUtilityFunction(addr name, hash)
 
 include gdext/gen/utilityfuncs
-
-proc print*(args: varargs[Variant, variant]) =
-  if unlikely(args.len == 0): return
-  print(args[0], args[1..^1])
-
-proc printRich*(args: varargs[Variant, variant]) =
-  if unlikely(args.len == 0): return
-  printRich(args[0], args[1..^1])
-
-proc printerr*(args: varargs[Variant, variant]) =
-  if unlikely(args.len == 0): return
-  printerr(args[0], args[1..^1])


### PR DESCRIPTION
Fixes #207 

The following two improvements will be made to make it easier to handle varargs functions.

* `varargs[Variant]` -> `varargs[Variant, variant]`
  It eliminates the need to manually convert arguments to Variants.

* `arg1: Variant; args: varargs[Variant]` -> `args: varargs[Variant]`
  This allows automatic conversion by varargs to be applied to the first argument as well.

Before:

```nim
prints(variant(1), variant("+"), variant(2), variant("="), variant(1+2))
```

After:

```nim
prints(1, "+", 2, "=", 1+2)
```
