### PR TITLE
Fix: Failure to create some objects such as Label

### DIFF
--- a/src/gdext/private/gdinterface.nim
+++ b/src/gdext/private/gdinterface.nim
@@ -185,7 +185,7 @@ proc getClassName*(self: Object): StringName =
   self.engineInstance.getClassName
 
 proc constructObject*(_: typedesc[ClassDB]; p_classname: StringName): ObjectPtr =
-  interfaceClassdbConstructObject2(addr p_classname)
+  interfaceClassdbConstructObject(addr p_classname)
 
 proc getMethodBind*(_: typedesc[ClassDB]; p_classname: StringName; p_methodname: StringName; p_hash: Int): MethodBindPtr =
   interfaceClassdbGetMethodBind(addr p_classname, addr p_methodname, p_hash)

--- a/testproject/runtime/main.tscn
+++ b/testproject/runtime/main.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=5 format=3 uid="uid://dyswbjsdvglbr"]
+[gd_scene load_steps=6 format=3 uid="uid://dyswbjsdvglbr"]
 
 [ext_resource type="Script" uid="uid://b4m3g7vm27kwg" path="res://main.gd" id="1_x2b6x"]
 [ext_resource type="Texture2D" uid="uid://b5lc5myy1blsf" path="res://icon.png" id="2_x3ep8"]
 [ext_resource type="Script" uid="uid://br2aj64ry7rs1" path="res://inherited_node01.gd" id="3_6ul88"]
 [ext_resource type="Script" uid="uid://7lji1hr8xghd" path="res://inherited_node02.gd" id="4_lmn8h"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_1bvp3"]
+font_size = 64
 
 [node name="Main" type="Node"]
 script = ExtResource("1_x2b6x")
@@ -22,3 +25,12 @@ script = ExtResource("3_6ul88")
 
 [node name="InheritedNode02" type="VirtualNode02" parent="."]
 script = ExtResource("4_lmn8h")
+
+[node name="ExtLabel" type="ExtLabel" parent="."]
+anchors_preset = 10
+anchor_right = 1.0
+offset_bottom = 88.0
+grow_horizontal = 2
+text = "Awesome gdext!"
+label_settings = SubResource("LabelSettings_1bvp3")
+horizontal_alignment = 1

--- a/testproject/runtime/nim/bootstrap.nim
+++ b/testproject/runtime/nim/bootstrap.nim
@@ -13,6 +13,7 @@ import classes/gdextnode
 import classes/gdvirtualnode01
 import classes/gdvirtualnode02
 import classes/gdtestobject
+import classes/gdextlabel
 
 # ==================================
 

--- a/testproject/runtime/nim/src/classes/gdextlabel.nim
+++ b/testproject/runtime/nim/src/classes/gdextlabel.nim
@@ -1,0 +1,3 @@
+import gdext
+
+type ExtLabel* {.gdsync.} = ptr object of Label


### PR DESCRIPTION
Fix a bug that caused constructs of some objects, such as Label, to fail.

It should work with the original code, but since it takes time to deal with this issue, it is reverted as a temporary measure.