### PR TITLE
Feat: Support 32bit architecture (mainly for web assembly)

### DIFF
--- a/src/gdext/appearances.nim
+++ b/src/gdext/appearances.nim
@@ -23,7 +23,7 @@ type
 
 macro makeDefaultHintStringEnum(Enum): string  =
   var str: string
-  var i: int
+  var i: BiggestInt
   for elem in Enum.enumTy[1..^1]:
     if str != "": str.add ","
     case elem.kind
@@ -42,7 +42,7 @@ macro makeDefaultHintStringEnum(Enum): string  =
 
 macro makeDefaultHintStringBitField(Enum): string  =
   var str: string
-  var i: int
+  var i: BiggestInt
   for elem in Enum.enumTy[1..^1]:
     if str != "": str.add ","
     case elem.kind

--- a/src/gdext/arraytools.nim
+++ b/src/gdext/arraytools.nim
@@ -307,7 +307,7 @@ iterator mpairs*[T](arr: var PackedArray[T]): (int, var T) =
   for i in 0..<arr.size: yield (int i, arr[i])
 
 template toOpenArray*[T](arr: PackedArray[T]): openArray[T] =
-  arr.dataUnsafe.toOpenArray(0, arr.size-1)
+  arr.dataUnsafe.toOpenArray(0, arr.size.int-1)
 proc `@`*[T](arr: PackedArray[T]): seq[T] =
   @(arr.toOpenArray)
 
@@ -381,13 +381,13 @@ proc setLen*(arr: var PackedArray; newlen: int) =
   discard arr.resize(newlen)
 
 # len
-proc len*(arr: Array): int = arr.size
-template len(arr: TypedArray): int = arr.Array.len
-proc len*(arr: PackedArray): int = arr.size
+proc len*(arr: Array): int = int arr.size
+template len(arr: TypedArray): int = int arr.Array.len
+proc len*(arr: PackedArray): int = int arr.size
 
 # high
-proc high*(arr: Array): int = arr.size.pred
-proc high*(arr: PackedArray): int = arr.size.pred
+proc high*(arr: Array): int = int arr.size.pred
+proc high*(arr: PackedArray): int = int arr.size.pred
 
 # low
 proc low*(arr: Array): int = 0

--- a/src/gdext/private/includes/stringtoolsbase.nim
+++ b/src/gdext/private/includes/stringtoolsbase.nim
@@ -10,7 +10,7 @@ template getPtr[T: Object](v: T): pointer =
 template getPtr(v: GdRef): pointer =
   getPtr v.handle
 
-proc load(typ: VariantType; proc_name: string; hash: int): PtrBuiltinMethod =
+proc load(typ: VariantType; proc_name: string; hash: int64): PtrBuiltinMethod =
   let name = newStringName proc_name
   interface_Variant_getPtrBuiltinMethod(typ, addr name, hash)
 proc load(op: Variant_Operator; left, right: VariantType): PtrOperatorEvaluator =

--- a/src/gdext/private/methodinfo.nim
+++ b/src/gdext/private/methodinfo.nim
@@ -113,14 +113,14 @@ proc callFunc(middle: MiddleExp): NimNode =
       let Type = Type[1]
       if Type.repr == "ptr Variant":
         quote do: cast[ptr UncheckedArray[ptr Variant]](p_args)
-          .toOpenArray(`i`, p_argument_count.pred)
+          .toOpenArray(`i`, p_argument_count.int.pred)
       else:
         quote do: retrieve[`Type`](p_args, `i`..<p_argument_count.int)
 
     elif default.kind == nnkEmpty:
       quote do: retrieve[`Type`](p_args[`i`])
     else:
-      quote do: retrieve[`Type`](p_args, p_argument_count, `i`, `default`)
+      quote do: retrieve[`Type`](p_args, p_argument_count.int, `i`, `default`)
 
   result = callFunc_template
   result.body =

--- a/src/gdext/utilityfuncs.nim
+++ b/src/gdext/utilityfuncs.nim
@@ -2,7 +2,7 @@ import gdext/private/gdinterface
 import gdext/builtinindex
 import gdext/stringtools
 
-proc load(proc_name: string; hash: int): PtrUtilityFunction =
+proc load(proc_name: string; hash: int64): PtrUtilityFunction =
   let name = newStringName proc_name
   interface_Variant_getPtrUtilityFunction(addr name, hash)
 

--- a/testproject/editor/nim/src/classes/gdsignalpublisher.nim
+++ b/testproject/editor/nim/src/classes/gdsignalpublisher.nim
@@ -1,14 +1,13 @@
 import gdext
 import gdext/classes/gdNode
-import std/random
-random.randomize()
+randomize()
 
 type SignalPublisher* {.tool.} = ptr object of Node
-  key: int
+  key: Int
 
-proc send*(self: SignalPublisher; key: int): Error {.signal, gdsync.}
+proc send*(self: SignalPublisher; key: Int): Error {.signal, gdsync.}
 
 method process(self: SignalPublisher; delta: float64) {.gdsync.} =
   if self.key == 0:
-    self.key = rand(0..255)
+    self.key = randiRange(0, 255)
   assert self.send(self.key) == ok


### PR DESCRIPTION
In a 64-bit environment, gdext.Int and system.int are identical, but in a 32-bit environment they are different.

The confusion between these two integer types has been sorted out, and the 32-bit environment is now supported.