### PR TITLE
Feat: Support web platform

### DIFF
--- a/src/gdext/buildconf.nim
+++ b/src/gdext/buildconf.nim
@@ -299,6 +299,27 @@ proc switch(setting: BuildSettings) =
     # --passL: "-static"
     --passL: "-static-libgcc"
 
+  of web:
+    if findExe("emcc").len == 0 and findExe("emcc.bat").len == 0:
+      quit """
+emcc binary not found. web export of Nim program depends on emscripten.
+Please install it following the guide below and activate the PATH to emcc.
+
+https://emscripten.org/docs/getting_started/downloads.html
+"""
+    --cpu: wasm32
+    --cc: clang
+
+    when buildOS == "windows":
+      --clang.exe: emcc.bat
+      --clang.linkerexe: emcc.bat
+    else:
+      --clang.exe: emcc
+      --clang.linkerexe: emcc
+
+    --passC: "-s SIDE_MODULE=1 -s SUPPORT_LONGJMP='wasm'"
+    --passL: "-s SIDE_MODULE=1 -s SUPPORT_LONGJMP='wasm' -s WASM_BIGINT"
+
   else:
     discard
 


### PR DESCRIPTION
Incorporate compile presets for the web platform into the build system.
This allows users to simply install emscripten and export to the web.

### Step by step

1. Install emscripten following the [guide](https://emscripten.org/docs/getting_started/downloads.html)
2. Set up export templates following [exporting projects]
(https://docs.godotengine.org/en/stable/tutorials/export/exporting_projects.html#exporting-projects)
3.  Build your extension: `gdextwiz build -d:platform=web` 
4. Check [Extensions Support] and [Thread Support] on
   ![image](https://github.com/user-attachments/assets/249d0807-cb48-4793-bb8b-1a1c9cf357d1)
5. Start HTTP server and have fun!
   ![Peek 2025-04-04 15-30](https://github.com/user-attachments/assets/da8d8ef0-ca97-41fd-b852-38b14a920e97)


