### PR TITLE
add {.singleton.} pragma

### DIFF
--- a/src/gdext/bridge.nim
+++ b/src/gdext/bridge.nim
@@ -133,6 +133,8 @@ macro gdsync*(body): untyped =
   of nnkTypeDef:
     let level = body.getPragmaVal("initLevel").toLevel
     implicitRegistrations[level].add body.typesym
+    if body.hasPragma("singleton"):
+      implicitRegistrationSingletons.add body.typesym
     body
   else:
     hint "gdsync for " & ($body.kind)[3..^1] & " is not defined; gdsync will do nothing."

--- a/src/gdext/bridge.nim
+++ b/src/gdext/bridge.nim
@@ -58,6 +58,13 @@ template icon*(icon_path: string) {.pragma.} ## Specify the class icon on the ed
 ## type MyIconClass {.gdsync, icon: "res://icon.png".} = ptr object of Node
 ## ```
 
+template singleton* {.pragma.}
+  ## Register the class as a singleton.
+  ## You can refer the unique instance of it as same as Godot's singletons e.g. Input.
+  ## ```nim
+  ## type MySingleton {.gdsync, singleton.} = ptr object of Object
+  ## ```
+
 var Initialization_Default* {.compileTime.} = Initialization_Scene
 
 proc toLevel(node: NimNode): InitializationLevel =

--- a/src/gdext/private/internalbridge.nim
+++ b/src/gdext/private/internalbridge.nim
@@ -12,6 +12,7 @@ import gdext/builtinindex
 import gdext/objectcallbacks
 import gdext/appearances
 import gdext/stringtools
+import gdext/classes/gdEngine
 
 when Assistance.genEditorHelp:
   import gdext/private/doctools
@@ -46,7 +47,7 @@ proc property_get_revert_func(p_instance: ClassInstancePtr; p_name: ConstStringN
   cast[Object](p_instance).property_getRevert(p_name, r_ret)
 
 proc notification_func(p_instance: ClassInstancePtr; p_what: int32, p_reversed: bool) {.gdcall.} =
-  cast[Object](p_instance).notification(p_what)
+  objectcallbacks.notification(cast[Object](p_instance), p_what)
 
 proc to_string_func(p_instance: ClassInstancePtr; r_is_valid: ptr Bool; p_out: StringPtr) {.gdcall.} =
   cast[Object](p_instance).toString(r_is_valid, p_out)
@@ -207,6 +208,7 @@ macro processExports(T: typed): untyped =
         `result`
 
 var implicitRegistrations* {.compileTime.}: array[InitializationLevel, seq[NimNode]]
+var implicitRegistrationSingletons* {.compileTime.}: seq[NimNode]
 
 var registered: seq[StringName]
 var plugins: seq[StringName]
@@ -231,7 +233,16 @@ proc register*(T: typedesc) =
       when Assistance.genEditorHelp and T.hasCustomPragma(description):
         docClassDB[T].description = T.getCustomPragmaVal(description).descToEditorHelp
 
-proc unregisterAll* =
+macro unregister_singletons =
+  let register = bindSym "register"
+  result = newStmtList()
+  for singleton in implicitRegistrationSingletons:
+    result.add quote do:
+      destroy `singleton`.singleton
+      Engine.unregisterSingleton(className `singleton`)
+
+template unregisterAll* =
+  unregister_singletons
   for i in countdown(plugins.high, 0):
     interface_Editor_removePlugin addr plugins[i]
   for i in countdown(registered.high, 0):
@@ -242,3 +253,6 @@ macro register_implicitly*(level: static InitializationLevel) =
   result = newStmtList()
   for registration in implicitRegistrations[level]:
     result.add register.newCall registration
+    if registration in implicitRegistrationSingletons:
+      result.add quote do:
+        Engine.singleton.registerSingleton(className `registration`, instantiate `registration`)

--- a/testproject/runtime/nim/bootstrap.nim
+++ b/testproject/runtime/nim/bootstrap.nim
@@ -9,11 +9,13 @@ import cases/variant
 import cases/image
 import cases/prints
 import cases/issues
+import cases/singletons
 import classes/gdextnode
 import classes/gdvirtualnode01
 import classes/gdvirtualnode02
 import classes/gdtestobject
 import classes/gdextlabel
+import classes/gdsingleton
 
 # ==================================
 

--- a/testproject/runtime/nim/src/cases/singletons.nim
+++ b/testproject/runtime/nim/src/cases/singletons.nim
@@ -1,0 +1,11 @@
+import gdext
+import classes/gdSingleton
+import testutils
+
+runtime: suite "Custom singletons":
+  test "use custom singletons":
+    Singleton.singleton.value1 = 10
+    check Singleton.singleton.value1 == 10
+
+    Singleton.set_value2 10
+    check Singleton.get_value2 == 10

--- a/testproject/runtime/nim/src/classes/gdsingleton.nim
+++ b/testproject/runtime/nim/src/classes/gdsingleton.nim
@@ -1,0 +1,14 @@
+import gdext
+
+type Singleton* {.gdsync, singleton.} = ptr object of Object
+  value1* {.gdexport.}: int
+  value2: int
+
+proc get_value2*(self: Singleton): int {.gdsync.} =
+  self.value2
+proc set_value2*(self: Singleton; val: int) {.gdsync.} =
+  self.value2 = val
+
+gdexport "value2",
+  getter= get_value2,
+  setter= set_value2


### PR DESCRIPTION
motivation: https://github.com/godot-nim/gdext-nim/discussions/233

Provides an easy way to set up singleton.

```nim
import gdext

type Singleton* {.gdsync, singleton.} = ptr object of Object
  value1* {.gdexport.}: int
```
```gdscript
func _ready():
  Singleton.value1 = 10
```