### PR TITLE
Fix: compile error "mapType: tyGenericInvocation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ nimble uninstall gdext
 
 * OS: Linux (Arch)
 * Engine: Godot 4.3.stable.arch_linux
-* Nim: 2.0.12, 2.0.14, 2.2.0, 2.2.2
+* Nim: 2.0.12, 2.0.14, 2.2.0, 2.2.4
 * CC: gcc version 14.2.1 20240910 (GCC)
 
 ---

--- a/coronation/src/coronation/operators/variantHook.nim
+++ b/coronation/src/coronation/operators/variantHook.nim
@@ -36,7 +36,7 @@ proc parse(variant: JsonBuiltinClass): VariantHook =
 proc prototype(v: VariantHook): Cloth = weave multiline:
   if v.kind in {All, WithOutDestructor}:
     &"proc `=copy`(dst: var {v.typename}; src: {v.typename})"
-    &"proc `=dup`(src: {v.typename}): {v.typename}"
+    &"proc dup(src: {v.typename}): {v.typename}"
   if v.kind in {All}:
     &"proc `=destroy`(val: {v.typename})"
 
@@ -51,7 +51,7 @@ proc define(v: VariantHook): Cloth = weave multiline:
     &"  `=destroy` dst"
     &"  wasMoved dst"
     &"  dst = {copyhook}(src)"
-    &"proc `=dup`(src: {v.typename}): {v.typename} ="
+    &"proc dup(src: {v.typename}): {v.typename} ="
     &"  {copyhook}(src)"
   if v.kind in {All}:
     &"var {v.ptrdestr}: PtrDestructor"

--- a/gdext.nimble
+++ b/gdext.nimble
@@ -31,7 +31,7 @@ proc report(version, script: string) =
     quit &"[Nim {version}] \"{script}\" failed."
 
 task compatibilityTest, "Compile with a supported range of Nims and check for compatibility.":
-  const versions = ["2.0.12", "2.0.14", "2.2.0", "2.2.2"]
+  const versions = ["2.0.12", "2.0.14", "2.2.0", "2.2.4"]
   for version in versions:
     report version, &"choosenim {version}"
     report version, "nim c tests/importall"

--- a/src/gdext/builtinindex.nim
+++ b/src/gdext/builtinindex.nim
@@ -263,7 +263,7 @@ template variantType*(Type: typedesc[ptr Variant]): Variant_Type = VariantType_N
 
 include gdext/gen/[classindex]
 
-proc `=dup`*(src: String): String =
+proc dup*(src: String): String =
   let argPtr = cast[pointer](addr src)
   typeConstructor[VariantTypeString](addr result, addr argPtr)
 proc `=destroy`*(val {.bycopy.}: String) =
@@ -273,9 +273,9 @@ proc `=copy`*(dst: var String; src: String) =
   if dst == src: return
   `=destroy` dst
   wasMoved dst
-  dst = `=dup` src
+  dst = dup src
 
-proc `=dup`*(src: StringName): StringName =
+proc dup*(src: StringName): StringName =
   let argPtr = cast[pointer](addr src)
   typeConstructor[VariantTypeStringName](addr result, addr argPtr)
 proc `=destroy`*(val {.bycopy.}: StringName) =
@@ -285,9 +285,9 @@ proc `=copy`*(dst: var StringName; src: StringName) =
   if dst == src: return
   `=destroy` dst
   wasMoved dst
-  dst = `=dup` src
+  dst = dup src
 
-proc `=dup`*(src: NodePath): NodePath =
+proc dup*(src: NodePath): NodePath =
   let argPtr = cast[pointer](addr src)
   typeConstructor[VariantTypeNodePath](addr result, addr argPtr)
 proc `=destroy`*(val {.bycopy.}: NodePath) =
@@ -297,18 +297,18 @@ proc `=copy`*(dst: var NodePath; src: NodePath) =
   if dst == src: return
   `=destroy` dst
   wasMoved dst
-  dst = `=dup` src
+  dst = dup src
 
-proc `=dup`*(src: RID): RID =
+proc dup*(src: RID): RID =
   let argPtr = cast[pointer](addr src)
   typeConstructor[VariantTypeRID](addr result, addr argPtr)
 proc `=copy`*(dst: var RID; src: RID) =
   if dst == src: return
   `=destroy` dst
   wasMoved dst
-  dst = `=dup` src
+  dst = dup src
 
-proc `=dup`*(src: Callable): Callable =
+proc dup*(src: Callable): Callable =
   let argPtr = cast[pointer](addr src)
   typeConstructor[VariantTypeCallable](addr result, addr argPtr)
 proc `=destroy`*(val {.bycopy.}: Callable) =
@@ -318,9 +318,9 @@ proc `=copy`*(dst: var Callable; src: Callable) =
   if dst == src: return
   `=destroy` dst
   wasMoved dst
-  dst = `=dup` src
+  dst = dup src
 
-proc `=dup`*(src: Signal): Signal =
+proc dup*(src: Signal): Signal =
   let argPtr = cast[pointer](addr src)
   typeConstructor[VariantTypeSignal](addr result, addr argPtr)
 proc `=destroy`*(val {.bycopy.}: Signal) =
@@ -330,9 +330,9 @@ proc `=copy`*(dst: var Signal; src: Signal) =
   if dst == src: return
   `=destroy` dst
   wasMoved dst
-  dst = `=dup` src
+  dst = dup src
 
-proc `=dup`*(src: Dictionary): Dictionary =
+proc dup*(src: Dictionary): Dictionary =
   let argPtr = cast[pointer](addr src)
   typeConstructor[VariantTypeDictionary](addr result, addr argPtr)
 proc `=destroy`*(val {.bycopy.}: Dictionary) =
@@ -342,9 +342,9 @@ proc `=copy`*(dst: var Dictionary; src: Dictionary) =
   if dst == src: return
   `=destroy` dst
   wasMoved dst
-  dst = `=dup` src
+  dst = dup src
 
-proc `=dup`*(src: Array): Array =
+proc dup*(src: Array): Array =
   let argPtr = cast[pointer](addr src)
   typeConstructor[VariantTypeArray](addr result, addr argPtr)
 proc `=destroy`*(val {.bycopy.}: Array) =
@@ -354,9 +354,9 @@ proc `=copy`*(dst: var Array; src: Array) =
   if dst == src: return
   `=destroy` dst
   wasMoved dst
-  dst = `=dup` src
+  dst = dup src
 
-proc `=dup`*[T](src: PackedArray[T]): PackedArray[T] =
+proc dup*[T](src: PackedArray[T]): PackedArray[T] =
   let argPtr = cast[pointer](addr src)
   when T is byte:
     typeConstructor[VariantTypePackedByteArray](addr result, addr argPtr)
@@ -404,11 +404,11 @@ proc `=copy`*[T](dst: var PackedArray[T]; src: PackedArray[T]) =
   if dst == src: return
   `=destroy` dst
   wasMoved dst
-  dst = `=dup` src
+  dst = dup src
 
 proc `=destroy`*(x {.bycopy.}: Variant) =
   interface_variantDestroy(addr x)
-proc `=dup`*(x: Variant): Variant =
+proc dup*(x: Variant): Variant =
   interface_variantNewCopy(addr result, addr x)
 proc `=copy`*(dest: var Variant; source: Variant) =
   `=destroy` dest
@@ -424,7 +424,7 @@ proc `=destroy`*[T](self: GdRef[T]) =
   if objectptr.isNil: return
   if hook_unreference(objectptr):
     interfaceObjectDestroy objectPtr
-proc `=dup`*[T](src: GdRef[T]): GdRef[T] =
+proc dup*[T](src: GdRef[T]): GdRef[T] =
   if src.handle.isNil: return
   result.handle = src.handle
   let objectptr = src.handle.unsafeEngineInstance
@@ -433,7 +433,7 @@ proc `=dup`*[T](src: GdRef[T]): GdRef[T] =
 proc `=copy`*[T](dst: var GdRef[T]; src: GdRef[T]) =
   `=destroy`dst
   `=wasMoved`dst
-  dst = `=dup`src
+  dst = dup src
 
 proc hook_reference(o: ObjectPtr): Bool {.raises: [].} =
   if unlikely(o.isNil): return


### PR DESCRIPTION
Fix a bug in Nim 2.2.4 that caused compile failure with “mapType: tyGenericInvocation” error when using Godot primitives.
The `=dup` hook seems to be currently not inserted, so we unified it with the `=copy` hook.