### PR TITLE
fix Object callback conflicts

### DIFF
--- a/src/gdext/private/internalbridge.nim
+++ b/src/gdext/private/internalbridge.nim
@@ -12,7 +12,6 @@ import gdext/builtinindex
 import gdext/objectcallbacks
 import gdext/appearances
 import gdext/stringtools
-import gdext/classes/gdEngine
 
 when Assistance.genEditorHelp:
   import gdext/private/doctools
@@ -163,6 +162,8 @@ proc propertyinfo*(
     ): HeapPropertyInfo =
   propertyInfo(VariantType_Nil, name, StringName(),
     appearance.hint, appearance.hintstring, appearance.usage)
+
+import gdext/classes/gdEngine
 
 proc gdexport_internal*(
     info: HeapPropertyInfo;


### PR DESCRIPTION
This PR makes the following example work:

```nim
method notification(self: A; what: int) {.gdsync.} =
  print "notification: ", what
```