### PR TITLE
Vector3i (+-*/) int -> Vector3i

### DIFF
--- a/src/gdext/math.nim
+++ b/src/gdext/math.nim
@@ -740,6 +740,19 @@ when real_elem is float32:
   func `*`(left: float64; right: float32): float32 = float32 system.`*`(left,right)
   func `/`(left: float64; right: float32): float32 = float32 system.`/`(left,right)
 
+when int_elem is int32:
+  func `+`(left: int32; right: int64): int32 = int32 system.`+`(left,right)
+  func `-`(left: int32; right: int64): int32 = int32 system.`-`(left,right)
+  func `*`(left: int32; right: int64): int32 = int32 system.`*`(left,right)
+  func `div`(left: int32; right: int64): int32 = int32 system.`div`(left,right)
+  func `mod`(left: int32; right: int64): int32 = int32 system.`mod`(left,right)
+
+  func `+`(left: int64; right: int32): int32 = int32 system.`+`(left,right)
+  func `-`(left: int64; right: int32): int32 = int32 system.`-`(left,right)
+  func `*`(left: int64; right: int32): int32 = int32 system.`*`(left,right)
+  func `div`(left: int64; right: int32): int32 = int32 system.`div`(left,right)
+  func `mod`(left: int64; right: int32): int32 = int32 system.`mod`(left,right)
+
 # basic
 func `+`*[N: static int; T,S: SomeNumber](left: Vector[N,T]; right: Vector[N,S]): auto = `+`.fmap(left, right)
 func `-`*[N: static int; T,S: SomeNumber](left: Vector[N,T]; right: Vector[N,S]): auto = `-`.fmap(left, right)


### PR DESCRIPTION
## Issue

Currently, Vector3i (+-\*/) int will be array[3, int], not Vector3i. That's because int32 (+-\*/) int is int.

```nim
var v: Vector3i = vector3i(1, 2, 3)

assert (v * 3) is array[3, int]
assert (v * 3) isnot Vector3i
```

## Expects

```nim
assert (v * 3) is Vector3i
```