### PR TITLE
make safe to access uninitialized containers at most case

### DIFF
--- a/coronation/src/coronation/operators/builtinclasses/methods.nim
+++ b/coronation/src/coronation/operators/builtinclasses/methods.nim
@@ -15,6 +15,11 @@ import std/strutils
 import std/sequtils
 import std/sets
 
+const NilUnsafe = [
+  TypeSym"Array",
+  TypeSym"Dictionary",
+]
+
 type
   BuiltinClassMethodEntry* = ref object of GodotProc
     containerKey: ContainerKey
@@ -72,6 +77,8 @@ proc weave_procdef*(entry: BuiltinClassMethodEntry): Cloth =
   weave multiline:
     weave ProcKey entry
     weave cloths.indent:
+      if entry.self.typeSym in NilUnsafe:
+        &"nilCheck {entry.self.name}"
       if entry.isVarargs:
         let vararg = entry.args[^1]
         if nonvarargs.len == 0:
@@ -97,6 +104,7 @@ proc weave_procdef*(entry: BuiltinClassMethodEntry): Cloth =
 
 proc weave_methods*(json: JsonBuiltinClass): Cloth =
   let typesym = json.name.convert(TypeSym)
+  let nilUnsafe = typesym in NilUnsafe
 
   proc extract_self(it: JsonBuiltinClassMethod): RenderableSelfArgument =
     RenderableSelfArgument(
@@ -123,6 +131,10 @@ proc weave_methods*(json: JsonBuiltinClass): Cloth =
 
       weave multiline:
         for entry in requires:
+          if nilUnsafe and not entry.self.info.isMutable:
+            entry.self.info.isMutable = true
+            weave_procdef entry
+            entry.self.info.isMutable = false
           weave_procdef entry
 
       weave multiline:

--- a/src/gdext/arraytools.nim
+++ b/src/gdext/arraytools.nim
@@ -25,6 +25,20 @@ import gdext/varianttools
 
 import std/[sequtils, importutils, hashes]
 
+template nilCheck*(self: Array) =
+  if unlikely(cast[pointer](self) == nil):
+    raise newException(NilAccessDefect, $typeof(self) & " requires init; call `new" & $typeof(self) & "()`")
+template nilCheck*(self: var Array) =
+  if unlikely(cast[pointer](self) == nil):
+    self = newArray()
+
+template nilCheck*[T](self: TypedArray[T]) =
+  if unlikely(cast[pointer](self) == nil):
+    raise newException(NilAccessDefect, $typeof(self) & " requires init; call `new" & $typeof(self) & "()`")
+template nilCheck*[T](self: var TypedArray[T]) =
+  if unlikely(cast[pointer](self) == nil):
+    self = newTypedArray[T]()
+
 proc setTyped(self: var Array; typ: VariantType; className: StringName; script: Variant) =
   interfaceArraySetTyped(addr self, typ, addr className, addr script)
 
@@ -115,9 +129,6 @@ template toOpenArray*(arr: Array): openArray[Variant] =
 # TypedArray
 # ==========
 
-proc newTypedArray*[T](arr: TypedArray[T]): TypedArray[T] =
-  TypedArray[T] newArray(arr.Array)
-
 proc newTypedArray*[T](arr: Array): TypedArray[T] =
   when T is Object:
     TypedArray[T] newArray(arr, Int VariantType_Object, T.className, variant())
@@ -125,6 +136,9 @@ proc newTypedArray*[T](arr: Array): TypedArray[T] =
     TypedArray[T] newArray(arr, Int VariantType_Object, T.RefCounted.className, variant())
   else:
     TypedArray[T] newArray(arr, Int T.variantType, newStringName(), variant())
+
+proc newTypedArray*[T](arr: TypedArray[T]): TypedArray[T] =
+  TypedArray[T] newArray(arr.Array)
 
 proc newTypedArray*[T](): TypedArray[T] =
   result = TypedArray[T] newArray()
@@ -168,62 +182,132 @@ iterator mpairs*[T](arr: var TypedArray[T]): (int, var T) =
 
 # func `+`*[T](left, right: TypedArray[T]): TypedArray[T] =
 #   TypedArray[T](left + right)
+proc get*[T](self: var TypedArray[T]; index: Int): T =
+  nilCheck self
+  self.Array.get(index).get(T)
 proc get*[T](self: TypedArray[T]; index: Int): T =
+  nilCheck self
   self.Array.get(index).get(T)
 proc set*[T](self: var TypedArray[T]; index: Int; value: T): void =
+  nilCheck self
   self.Array.set(index, variant value)
 proc pushBack*[T](self: var TypedArray[T]; value: T): void =
+  nilCheck self
   self.Array.pushBack(variant value)
 proc pushFront*[T](self: var TypedArray[T]; value: T): void =
+  nilCheck self
   self.Array.pushFront(variant value)
 proc append*[T](self: var TypedArray[T]; value: T): void =
+  nilCheck self
   self.Array.append(variant value)
 proc insert*[T](self: var TypedArray[T]; position: Int; value: T): Int =
+  nilCheck self
   self.Array.insert(position, variant value)
 proc fill*[T](self: var TypedArray[T]; value: T): void =
+  nilCheck self
   self.Array.fill(variant value)
 proc erase*[T](self: var TypedArray[T]; value: T): void =
+  nilCheck self
   self.Array.erase(variant value)
-proc front*[T](self: TypedArray[T]): T =
+proc front*[T](self: var TypedArray[T]): T =
+  nilCheck self
   self.Array.front().get(T)
-proc back*[T](self: TypedArray[T]): T =
+proc front*[T](self: TypedArray[T]): T =
+  nilCheck self
+  self.Array.front().get(T)
+proc back*[T](self: var TypedArray[T]): T =
+  nilCheck self
   self.Array.back().get(T)
-proc pickRandom*[T](self: TypedArray[T]): T =
+proc back*[T](self: TypedArray[T]): T =
+  nilCheck self
+  self.Array.back().get(T)
+proc pickRandom*[T](self: var TypedArray[T]): T =
+  nilCheck self
   self.Array.pickRandom().get(T)
+proc pickRandom*[T](self: TypedArray[T]): T =
+  nilCheck self
+  self.Array.pickRandom().get(T)
+proc find*[T](self: var TypedArray[T]; what: T; `from`: Int = 0): Int =
+  nilCheck self
+  self.Array.find(variant what, `from`)
 proc find*[T](self: TypedArray[T]; what: T; `from`: Int = 0): Int =
+  nilCheck self
   self.Array.find(variant what, `from`)
 # proc findCustom*[T](self: TypedArray[T]; `method`: Callable; `from`: Int = 0): Int =
+proc rfind*[T](self: var TypedArray[T]; what: T; `from`: Int = -1): Int =
+  nilCheck self
+  self.Array.rFind(variant what, `from`)
 proc rfind*[T](self: TypedArray[T]; what: T; `from`: Int = -1): Int =
+  nilCheck self
   self.Array.rFind(variant what, `from`)
 # proc rfindCustom*[T](self: TypedArray[T]; `method`: Callable; `from`: Int = -1): Int =
-proc count*[T](self: TypedArray[T]; value: T): Int =
+proc count*[T](self: var TypedArray[T]; value: T): Int =
+  nilCheck self
   self.Array.count(variant value)
+proc count*[T](self: TypedArray[T]; value: T): Int =
+  nilCheck self
+  self.Array.count(variant value)
+proc has*[T](self: var TypedArray[T]; value: T): bool =
+  nilCheck self
+  self.Array.has(variant value)
 proc has*[T](self: TypedArray[T]; value: T): bool =
+  nilCheck self
   self.Array.has(variant value)
 proc popBack*[T](self: var TypedArray[T]): T =
+  nilCheck self
   self.Array.popBack().get(T)
 proc popFront*[T](self: var TypedArray[T]): T =
+  nilCheck self
   self.Array.popFront().get(T)
 proc popAt*[T](self: var TypedArray[T]; position: Int): T =
+  nilCheck self
   self.Array.popAt(position).get(T)
 # proc sortCustom*[T](self: var TypedArray[T]; `func`: Callable): void =
-proc bsearch*[T](self: TypedArray[T]; value: T; before: bool = true): Int =
+proc bsearch*[T](self: var TypedArray[T]; value: T; before: bool = true): Int =
+  nilCheck self
   self.Array.bsearch(variant value, before)
-proc bsearchCustom*[T](self: TypedArray[T]; value: T; `func`: Callable; before: bool = true): Int =
+proc bsearch*[T](self: TypedArray[T]; value: T; before: bool = true): Int =
+  nilCheck self
+  self.Array.bsearch(variant value, before)
+proc bsearchCustom*[T](self: var TypedArray[T]; value: T; `func`: Callable; before: bool = true): Int =
+  nilCheck self
   self.Array.bsearchCustom(variant value, `func`, before)
-proc duplicate*[T](self: TypedArray[T]; deep: bool = false): TypedArray[T] =
+proc bsearchCustom*[T](self: TypedArray[T]; value: T; `func`: Callable; before: bool = true): Int =
+  nilCheck self
+  self.Array.bsearchCustom(variant value, `func`, before)
+proc duplicate*[T](self: var TypedArray[T]; deep: bool = false): TypedArray[T] =
+  nilCheck self
   TypedArray[T](self.Array.duplicate())
-proc slice*[T](self: TypedArray[T]; begin: Int; `end`: Int = 2147483647; step: Int = 1; deep: bool = false): TypedArray[T] =
+proc duplicate*[T](self: TypedArray[T]; deep: bool = false): TypedArray[T] =
+  nilCheck self
+  TypedArray[T](self.Array.duplicate())
+proc slice*[T](self: var TypedArray[T]; begin: Int; `end`: Int = 2147483647; step: Int = 1; deep: bool = false): TypedArray[T] =
+  nilCheck self
   TypedArray[T](self.Array.slice(begin, `end`, step, deep))
+proc slice*[T](self: TypedArray[T]; begin: Int; `end`: Int = 2147483647; step: Int = 1; deep: bool = false): TypedArray[T] =
+  nilCheck self
+  TypedArray[T](self.Array.slice(begin, `end`, step, deep))
+proc filter*[T](self: var TypedArray[T]; `method`: Callable): TypedArray[T] =
+  nilCheck self
+  TypedArray[T](self.Array.filter(`method`))
 proc filter*[T](self: TypedArray[T]; `method`: Callable): TypedArray[T] =
+  nilCheck self
   TypedArray[T](self.Array.filter(`method`))
 # proc map*[T](self: TypedArray[T]; `method`: Callable): Array =
 # proc reduce*[T](self: TypedArray[T]; `method`: Callable; accum: T = default(Variant)): Variant =
 # proc any*[T](self: TypedArray[T]; `method`: Callable): bool =
 # proc all*[T](self: TypedArray[T]; `method`: Callable): bool =
-proc max*[T](self: TypedArray[T]): T =
+proc max*[T](self: var TypedArray[T]): T =
+  nilCheck self
   self.Array.max().get(T)
+proc max*[T](self: TypedArray[T]): T =
+  nilCheck self
+  self.Array.max().get(T)
+proc min*[T](self: var TypedArray[T]): T =
+  nilCheck self
+  self.Array.min().get(T)
 proc min*[T](self: TypedArray[T]): T =
+  nilCheck self
   self.Array.min().get(T)
 
 # PackedArray
@@ -365,9 +449,15 @@ proc `[]=`*[T](arr: var PackedArray[T]; index: BackwardsIndex; value: T) =
 # contains
 proc contains*(arr: Array; value: Variant): bool =
   arr.has(value)
+proc contains*(arr: var Array; value: Variant): bool =
+  arr.has(value)
 proc contains*[T: SomeProperty](arr: Array; value: T): bool =
   arr.has(variant value)
+proc contains*[T: SomeProperty](arr: var Array; value: T): bool =
+  arr.has(variant value)
 proc contains*[T](arr: TypedArray[T]; value: T): bool =
+  arr.has(value)
+proc contains*[T](arr: var TypedArray[T]; value: T): bool =
   arr.has(value)
 proc contains*[T](arr: PackedArray[T]; item: T): bool =
   arr.toOpenArray.contains item
@@ -382,12 +472,16 @@ proc setLen*(arr: var PackedArray; newlen: int) =
 
 # len
 proc len*(arr: Array): int = int arr.size
-template len(arr: TypedArray): int = int arr.Array.len
+proc len*(arr: var Array): int = int arr.size
+proc len*(arr: TypedArray): int = int arr.Array.len
+proc len*(arr: var TypedArray): int = int arr.Array.len
 proc len*(arr: PackedArray): int = int arr.size
 
 # high
 proc high*(arr: Array): int = int arr.size.pred
+proc high*(arr: var Array): int = int arr.size.pred
 proc high*(arr: PackedArray): int = int arr.size.pred
+proc high*(arr: var PackedArray): int = int arr.size.pred
 
 # low
 proc low*(arr: Array): int = 0

--- a/src/gdext/bridge.nim
+++ b/src/gdext/bridge.nim
@@ -330,7 +330,10 @@ macro gdexport*(
   let classType = iden[0]
   let variable = iden[1]
   let getter = quote do:
-    proc(self: `classType`): `iden` = self.`variable`
+    proc(self: `classType`): `iden` =
+      when compiles(nilCheck self.`variable`):
+        nilCheck self.`variable`
+      self.`variable`
   let setter = quote do:
     proc(self: `classType`, value: `iden`) = self.`variable` = value
   quote do:

--- a/src/gdext/dicttools.nim
+++ b/src/gdext/dicttools.nim
@@ -6,6 +6,13 @@ import gdext/builtinindex
 
 import std/[hashes]
 
+template nilCheck*(self: Dictionary) =
+  if unlikely(cast[pointer](self) == nil):
+    raise newException(NilAccessDefect, $typeof(self) & " requires init; call `new" & $typeof(self) & "()`")
+template nilCheck*(self: var Dictionary) =
+  if unlikely(cast[pointer](self) == nil):
+    self = newDictionary()
+
 proc `[]`*(self: Dictionary; key: Variant): Variant =
   cast[ptr Variant](interface_Dictionary_operatorIndexConst(addr self, addr key))[]
 proc `[]`*(self: var Dictionary; key: Variant): var Variant =

--- a/src/gdext/gen/gdarray.nim
+++ b/src/gdext/gen/gdarray.nim
@@ -73,135 +73,292 @@ var `getTypedScript(Array)`: PtrBuiltinMethod
 var `makeReadOnly(Array)`: PtrBuiltinMethod
 var `isReadOnly(Array)`: PtrBuiltinMethod
 
-proc size*(self: Array): Int =
+proc size*(self: var Array): Int =
+  nilCheck self
   `size(Array)`(addr self, nil, addr result, 0)
+proc size*(self: Array): Int =
+  nilCheck self
+  `size(Array)`(addr self, nil, addr result, 0)
+proc isEmpty*(self: var Array): bool =
+  nilCheck self
+  `isEmpty(Array)`(addr self, nil, addr result, 0)
 proc isEmpty*(self: Array): bool =
+  nilCheck self
   `isEmpty(Array)`(addr self, nil, addr result, 0)
 proc clear*(self: var Array): void =
+  nilCheck self
   `clear(Array)`(addr self, nil, nil, 0)
+proc hash*(self: var Array): Hash =
+  nilCheck self
+  `hash(Array)`(addr self, nil, addr result, 0)
 proc hash*(self: Array): Hash =
+  nilCheck self
   `hash(Array)`(addr self, nil, addr result, 0)
 proc assign*(self: var Array; array: Array): void =
+  nilCheck self
   let argArr = [getPtr array]
   `assign(Array Array)`(addr self, addr argArr[0], nil, 1)
+proc get*(self: var Array; index: Int): Variant =
+  nilCheck self
+  let argArr = [getPtr index]
+  `get(Array Int)`(addr self, addr argArr[0], addr result, 1)
 proc get*(self: Array; index: Int): Variant =
+  nilCheck self
   let argArr = [getPtr index]
   `get(Array Int)`(addr self, addr argArr[0], addr result, 1)
 proc set*(self: var Array; index: Int; value: Variant): void =
+  nilCheck self
   let argArr = [getPtr index, getPtr value]
   `set(Array Int Variant)`(addr self, addr argArr[0], nil, 2)
 proc pushBack*(self: var Array; value: Variant): void =
+  nilCheck self
   let argArr = [getPtr value]
   `pushBack(Array Variant)`(addr self, addr argArr[0], nil, 1)
 proc pushFront*(self: var Array; value: Variant): void =
+  nilCheck self
   let argArr = [getPtr value]
   `pushFront(Array Variant)`(addr self, addr argArr[0], nil, 1)
 proc append*(self: var Array; value: Variant): void =
+  nilCheck self
   let argArr = [getPtr value]
   `append(Array Variant)`(addr self, addr argArr[0], nil, 1)
 proc appendArray*(self: var Array; array: Array): void =
+  nilCheck self
   let argArr = [getPtr array]
   `appendArray(Array Array)`(addr self, addr argArr[0], nil, 1)
 proc resize*(self: var Array; size: Int): Int =
+  nilCheck self
   let argArr = [getPtr size]
   `resize(Array Int)`(addr self, addr argArr[0], addr result, 1)
 proc insert*(self: var Array; position: Int; value: Variant): Int =
+  nilCheck self
   let argArr = [getPtr position, getPtr value]
   `insert(Array Int Variant)`(addr self, addr argArr[0], addr result, 2)
 proc removeAt*(self: var Array; position: Int): void =
+  nilCheck self
   let argArr = [getPtr position]
   `removeAt(Array Int)`(addr self, addr argArr[0], nil, 1)
 proc fill*(self: var Array; value: Variant): void =
+  nilCheck self
   let argArr = [getPtr value]
   `fill(Array Variant)`(addr self, addr argArr[0], nil, 1)
 proc erase*(self: var Array; value: Variant): void =
+  nilCheck self
   let argArr = [getPtr value]
   `erase(Array Variant)`(addr self, addr argArr[0], nil, 1)
-proc front*(self: Array): Variant =
+proc front*(self: var Array): Variant =
+  nilCheck self
   `front(Array)`(addr self, nil, addr result, 0)
-proc back*(self: Array): Variant =
+proc front*(self: Array): Variant =
+  nilCheck self
+  `front(Array)`(addr self, nil, addr result, 0)
+proc back*(self: var Array): Variant =
+  nilCheck self
   `back(Array)`(addr self, nil, addr result, 0)
-proc pickRandom*(self: Array): Variant =
+proc back*(self: Array): Variant =
+  nilCheck self
+  `back(Array)`(addr self, nil, addr result, 0)
+proc pickRandom*(self: var Array): Variant =
+  nilCheck self
   `pickRandom(Array)`(addr self, nil, addr result, 0)
-proc find*(self: Array; what: Variant; `from`: Int = 0): Int =
+proc pickRandom*(self: Array): Variant =
+  nilCheck self
+  `pickRandom(Array)`(addr self, nil, addr result, 0)
+proc find*(self: var Array; what: Variant; `from`: Int = 0): Int =
+  nilCheck self
   let argArr = [getPtr what, getPtr `from`]
   `find(Array Variant Int)`(addr self, addr argArr[0], addr result, 2)
-proc findCustom*(self: Array; `method`: Callable; `from`: Int = 0): Int =
+proc find*(self: Array; what: Variant; `from`: Int = 0): Int =
+  nilCheck self
+  let argArr = [getPtr what, getPtr `from`]
+  `find(Array Variant Int)`(addr self, addr argArr[0], addr result, 2)
+proc findCustom*(self: var Array; `method`: Callable; `from`: Int = 0): Int =
+  nilCheck self
   let argArr = [getPtr `method`, getPtr `from`]
   `findCustom(Array Callable Int)`(addr self, addr argArr[0], addr result, 2)
-proc rfind*(self: Array; what: Variant; `from`: Int = -1): Int =
+proc findCustom*(self: Array; `method`: Callable; `from`: Int = 0): Int =
+  nilCheck self
+  let argArr = [getPtr `method`, getPtr `from`]
+  `findCustom(Array Callable Int)`(addr self, addr argArr[0], addr result, 2)
+proc rfind*(self: var Array; what: Variant; `from`: Int = -1): Int =
+  nilCheck self
   let argArr = [getPtr what, getPtr `from`]
   `rfind(Array Variant Int)`(addr self, addr argArr[0], addr result, 2)
-proc rfindCustom*(self: Array; `method`: Callable; `from`: Int = -1): Int =
+proc rfind*(self: Array; what: Variant; `from`: Int = -1): Int =
+  nilCheck self
+  let argArr = [getPtr what, getPtr `from`]
+  `rfind(Array Variant Int)`(addr self, addr argArr[0], addr result, 2)
+proc rfindCustom*(self: var Array; `method`: Callable; `from`: Int = -1): Int =
+  nilCheck self
   let argArr = [getPtr `method`, getPtr `from`]
   `rfindCustom(Array Callable Int)`(addr self, addr argArr[0], addr result, 2)
-proc count*(self: Array; value: Variant): Int =
+proc rfindCustom*(self: Array; `method`: Callable; `from`: Int = -1): Int =
+  nilCheck self
+  let argArr = [getPtr `method`, getPtr `from`]
+  `rfindCustom(Array Callable Int)`(addr self, addr argArr[0], addr result, 2)
+proc count*(self: var Array; value: Variant): Int =
+  nilCheck self
   let argArr = [getPtr value]
   `count(Array Variant)`(addr self, addr argArr[0], addr result, 1)
+proc count*(self: Array; value: Variant): Int =
+  nilCheck self
+  let argArr = [getPtr value]
+  `count(Array Variant)`(addr self, addr argArr[0], addr result, 1)
+proc has*(self: var Array; value: Variant): bool =
+  nilCheck self
+  let argArr = [getPtr value]
+  `has(Array Variant)`(addr self, addr argArr[0], addr result, 1)
 proc has*(self: Array; value: Variant): bool =
+  nilCheck self
   let argArr = [getPtr value]
   `has(Array Variant)`(addr self, addr argArr[0], addr result, 1)
 proc popBack*(self: var Array): Variant =
+  nilCheck self
   `popBack(Array)`(addr self, nil, addr result, 0)
 proc popFront*(self: var Array): Variant =
+  nilCheck self
   `popFront(Array)`(addr self, nil, addr result, 0)
 proc popAt*(self: var Array; position: Int): Variant =
+  nilCheck self
   let argArr = [getPtr position]
   `popAt(Array Int)`(addr self, addr argArr[0], addr result, 1)
 proc sort*(self: var Array): void =
+  nilCheck self
   `sort(Array)`(addr self, nil, nil, 0)
 proc sortCustom*(self: var Array; `func`: Callable): void =
+  nilCheck self
   let argArr = [getPtr `func`]
   `sortCustom(Array Callable)`(addr self, addr argArr[0], nil, 1)
 proc shuffle*(self: var Array): void =
+  nilCheck self
   `shuffle(Array)`(addr self, nil, nil, 0)
-proc bsearch*(self: Array; value: Variant; before: bool = true): Int =
+proc bsearch*(self: var Array; value: Variant; before: bool = true): Int =
+  nilCheck self
   let argArr = [getPtr value, getPtr before]
   `bsearch(Array Variant bool)`(addr self, addr argArr[0], addr result, 2)
+proc bsearch*(self: Array; value: Variant; before: bool = true): Int =
+  nilCheck self
+  let argArr = [getPtr value, getPtr before]
+  `bsearch(Array Variant bool)`(addr self, addr argArr[0], addr result, 2)
+proc bsearchCustom*(self: var Array; value: Variant; `func`: Callable; before: bool = true): Int =
+  nilCheck self
+  let argArr = [getPtr value, getPtr `func`, getPtr before]
+  `bsearchCustom(Array Variant Callable bool)`(addr self, addr argArr[0], addr result, 3)
 proc bsearchCustom*(self: Array; value: Variant; `func`: Callable; before: bool = true): Int =
+  nilCheck self
   let argArr = [getPtr value, getPtr `func`, getPtr before]
   `bsearchCustom(Array Variant Callable bool)`(addr self, addr argArr[0], addr result, 3)
 proc reverse*(self: var Array): void =
+  nilCheck self
   `reverse(Array)`(addr self, nil, nil, 0)
-proc duplicate*(self: Array; deep: bool = false): Array =
+proc duplicate*(self: var Array; deep: bool = false): Array =
+  nilCheck self
   let argArr = [getPtr deep]
   `duplicate(Array bool)`(addr self, addr argArr[0], addr result, 1)
-proc slice*(self: Array; begin: Int; `end`: Int = 2147483647; step: Int = 1; deep: bool = false): Array =
+proc duplicate*(self: Array; deep: bool = false): Array =
+  nilCheck self
+  let argArr = [getPtr deep]
+  `duplicate(Array bool)`(addr self, addr argArr[0], addr result, 1)
+proc slice*(self: var Array; begin: Int; `end`: Int = 2147483647; step: Int = 1; deep: bool = false): Array =
+  nilCheck self
   let argArr = [getPtr begin, getPtr `end`, getPtr step, getPtr deep]
   `slice(Array Int Int Int bool)`(addr self, addr argArr[0], addr result, 4)
-proc filter*(self: Array; `method`: Callable): Array =
+proc slice*(self: Array; begin: Int; `end`: Int = 2147483647; step: Int = 1; deep: bool = false): Array =
+  nilCheck self
+  let argArr = [getPtr begin, getPtr `end`, getPtr step, getPtr deep]
+  `slice(Array Int Int Int bool)`(addr self, addr argArr[0], addr result, 4)
+proc filter*(self: var Array; `method`: Callable): Array =
+  nilCheck self
   let argArr = [getPtr `method`]
   `filter(Array Callable)`(addr self, addr argArr[0], addr result, 1)
-proc map*(self: Array; `method`: Callable): Array =
+proc filter*(self: Array; `method`: Callable): Array =
+  nilCheck self
+  let argArr = [getPtr `method`]
+  `filter(Array Callable)`(addr self, addr argArr[0], addr result, 1)
+proc map*(self: var Array; `method`: Callable): Array =
+  nilCheck self
   let argArr = [getPtr `method`]
   `map(Array Callable)`(addr self, addr argArr[0], addr result, 1)
-proc reduce*(self: Array; `method`: Callable; accum: Variant = default(Variant)): Variant =
+proc map*(self: Array; `method`: Callable): Array =
+  nilCheck self
+  let argArr = [getPtr `method`]
+  `map(Array Callable)`(addr self, addr argArr[0], addr result, 1)
+proc reduce*(self: var Array; `method`: Callable; accum: Variant = default(Variant)): Variant =
+  nilCheck self
   let argArr = [getPtr `method`, getPtr accum]
   `reduce(Array Callable Variant)`(addr self, addr argArr[0], addr result, 2)
-proc any*(self: Array; `method`: Callable): bool =
+proc reduce*(self: Array; `method`: Callable; accum: Variant = default(Variant)): Variant =
+  nilCheck self
+  let argArr = [getPtr `method`, getPtr accum]
+  `reduce(Array Callable Variant)`(addr self, addr argArr[0], addr result, 2)
+proc any*(self: var Array; `method`: Callable): bool =
+  nilCheck self
   let argArr = [getPtr `method`]
   `any(Array Callable)`(addr self, addr argArr[0], addr result, 1)
-proc all*(self: Array; `method`: Callable): bool =
+proc any*(self: Array; `method`: Callable): bool =
+  nilCheck self
+  let argArr = [getPtr `method`]
+  `any(Array Callable)`(addr self, addr argArr[0], addr result, 1)
+proc all*(self: var Array; `method`: Callable): bool =
+  nilCheck self
   let argArr = [getPtr `method`]
   `all(Array Callable)`(addr self, addr argArr[0], addr result, 1)
-proc max*(self: Array): Variant =
+proc all*(self: Array; `method`: Callable): bool =
+  nilCheck self
+  let argArr = [getPtr `method`]
+  `all(Array Callable)`(addr self, addr argArr[0], addr result, 1)
+proc max*(self: var Array): Variant =
+  nilCheck self
   `max(Array)`(addr self, nil, addr result, 0)
-proc min*(self: Array): Variant =
+proc max*(self: Array): Variant =
+  nilCheck self
+  `max(Array)`(addr self, nil, addr result, 0)
+proc min*(self: var Array): Variant =
+  nilCheck self
   `min(Array)`(addr self, nil, addr result, 0)
-proc isTyped*(self: Array): bool =
+proc min*(self: Array): Variant =
+  nilCheck self
+  `min(Array)`(addr self, nil, addr result, 0)
+proc isTyped*(self: var Array): bool =
+  nilCheck self
   `isTyped(Array)`(addr self, nil, addr result, 0)
-proc isSameTyped*(self: Array; array: Array): bool =
+proc isTyped*(self: Array): bool =
+  nilCheck self
+  `isTyped(Array)`(addr self, nil, addr result, 0)
+proc isSameTyped*(self: var Array; array: Array): bool =
+  nilCheck self
   let argArr = [getPtr array]
   `isSameTyped(Array Array)`(addr self, addr argArr[0], addr result, 1)
-proc getTypedBuiltin*(self: Array): Int =
+proc isSameTyped*(self: Array; array: Array): bool =
+  nilCheck self
+  let argArr = [getPtr array]
+  `isSameTyped(Array Array)`(addr self, addr argArr[0], addr result, 1)
+proc getTypedBuiltin*(self: var Array): Int =
+  nilCheck self
   `getTypedBuiltin(Array)`(addr self, nil, addr result, 0)
-proc getTypedClassName*(self: Array): StringName =
+proc getTypedBuiltin*(self: Array): Int =
+  nilCheck self
+  `getTypedBuiltin(Array)`(addr self, nil, addr result, 0)
+proc getTypedClassName*(self: var Array): StringName =
+  nilCheck self
   `getTypedClassName(Array)`(addr self, nil, addr result, 0)
+proc getTypedClassName*(self: Array): StringName =
+  nilCheck self
+  `getTypedClassName(Array)`(addr self, nil, addr result, 0)
+proc getTypedScript*(self: var Array): Variant =
+  nilCheck self
+  `getTypedScript(Array)`(addr self, nil, addr result, 0)
 proc getTypedScript*(self: Array): Variant =
+  nilCheck self
   `getTypedScript(Array)`(addr self, nil, addr result, 0)
 proc makeReadOnly*(self: var Array): void =
+  nilCheck self
   `makeReadOnly(Array)`(addr self, nil, nil, 0)
+proc isReadOnly*(self: var Array): bool =
+  nilCheck self
+  `isReadOnly(Array)`(addr self, nil, addr result, 0)
 proc isReadOnly*(self: Array): bool =
+  nilCheck self
   `isReadOnly(Array)`(addr self, nil, addr result, 0)
 
 proc load_Array_methods {.execon: staticevents.init_engine.on_load_builtinclassMethod.} =

--- a/src/gdext/gen/gddictionary.nim
+++ b/src/gdext/gen/gddictionary.nim
@@ -45,85 +45,203 @@ var `makeReadOnly(Dictionary)`: PtrBuiltinMethod
 var `isReadOnly(Dictionary)`: PtrBuiltinMethod
 var `recursiveEqual(Dictionary Dictionary Int)`: PtrBuiltinMethod
 
-proc size*(self: Dictionary): Int =
+proc size*(self: var Dictionary): Int =
+  nilCheck self
   `size(Dictionary)`(addr self, nil, addr result, 0)
+proc size*(self: Dictionary): Int =
+  nilCheck self
+  `size(Dictionary)`(addr self, nil, addr result, 0)
+proc isEmpty*(self: var Dictionary): bool =
+  nilCheck self
+  `isEmpty(Dictionary)`(addr self, nil, addr result, 0)
 proc isEmpty*(self: Dictionary): bool =
+  nilCheck self
   `isEmpty(Dictionary)`(addr self, nil, addr result, 0)
 proc clear*(self: var Dictionary): void =
+  nilCheck self
   `clear(Dictionary)`(addr self, nil, nil, 0)
 proc assign*(self: var Dictionary; dictionary: Dictionary): void =
+  nilCheck self
   let argArr = [getPtr dictionary]
   `assign(Dictionary Dictionary)`(addr self, addr argArr[0], nil, 1)
 proc sort*(self: var Dictionary): void =
+  nilCheck self
   `sort(Dictionary)`(addr self, nil, nil, 0)
 proc merge*(self: var Dictionary; dictionary: Dictionary; overwrite: bool = false): void =
+  nilCheck self
   let argArr = [getPtr dictionary, getPtr overwrite]
   `merge(Dictionary Dictionary bool)`(addr self, addr argArr[0], nil, 2)
-proc merged*(self: Dictionary; dictionary: Dictionary; overwrite: bool = false): Dictionary =
+proc merged*(self: var Dictionary; dictionary: Dictionary; overwrite: bool = false): Dictionary =
+  nilCheck self
   let argArr = [getPtr dictionary, getPtr overwrite]
   `merged(Dictionary Dictionary bool)`(addr self, addr argArr[0], addr result, 2)
-proc has*(self: Dictionary; key: Variant): bool =
+proc merged*(self: Dictionary; dictionary: Dictionary; overwrite: bool = false): Dictionary =
+  nilCheck self
+  let argArr = [getPtr dictionary, getPtr overwrite]
+  `merged(Dictionary Dictionary bool)`(addr self, addr argArr[0], addr result, 2)
+proc has*(self: var Dictionary; key: Variant): bool =
+  nilCheck self
   let argArr = [getPtr key]
   `has(Dictionary Variant)`(addr self, addr argArr[0], addr result, 1)
-proc hasAll*(self: Dictionary; keys: Array): bool =
+proc has*(self: Dictionary; key: Variant): bool =
+  nilCheck self
+  let argArr = [getPtr key]
+  `has(Dictionary Variant)`(addr self, addr argArr[0], addr result, 1)
+proc hasAll*(self: var Dictionary; keys: Array): bool =
+  nilCheck self
   let argArr = [getPtr keys]
   `hasAll(Dictionary Array)`(addr self, addr argArr[0], addr result, 1)
+proc hasAll*(self: Dictionary; keys: Array): bool =
+  nilCheck self
+  let argArr = [getPtr keys]
+  `hasAll(Dictionary Array)`(addr self, addr argArr[0], addr result, 1)
+proc findKey*(self: var Dictionary; value: Variant): Variant =
+  nilCheck self
+  let argArr = [getPtr value]
+  `findKey(Dictionary Variant)`(addr self, addr argArr[0], addr result, 1)
 proc findKey*(self: Dictionary; value: Variant): Variant =
+  nilCheck self
   let argArr = [getPtr value]
   `findKey(Dictionary Variant)`(addr self, addr argArr[0], addr result, 1)
 proc erase*(self: var Dictionary; key: Variant): bool =
+  nilCheck self
   let argArr = [getPtr key]
   `erase(Dictionary Variant)`(addr self, addr argArr[0], addr result, 1)
-proc hash*(self: Dictionary): Hash =
+proc hash*(self: var Dictionary): Hash =
+  nilCheck self
   `hash(Dictionary)`(addr self, nil, addr result, 0)
-proc keys*(self: Dictionary): Array =
+proc hash*(self: Dictionary): Hash =
+  nilCheck self
+  `hash(Dictionary)`(addr self, nil, addr result, 0)
+proc keys*(self: var Dictionary): Array =
+  nilCheck self
   `keys(Dictionary)`(addr self, nil, addr result, 0)
-proc values*(self: Dictionary): Array =
+proc keys*(self: Dictionary): Array =
+  nilCheck self
+  `keys(Dictionary)`(addr self, nil, addr result, 0)
+proc values*(self: var Dictionary): Array =
+  nilCheck self
   `values(Dictionary)`(addr self, nil, addr result, 0)
-proc duplicate*(self: Dictionary; deep: bool = false): Dictionary =
+proc values*(self: Dictionary): Array =
+  nilCheck self
+  `values(Dictionary)`(addr self, nil, addr result, 0)
+proc duplicate*(self: var Dictionary; deep: bool = false): Dictionary =
+  nilCheck self
   let argArr = [getPtr deep]
   `duplicate(Dictionary bool)`(addr self, addr argArr[0], addr result, 1)
+proc duplicate*(self: Dictionary; deep: bool = false): Dictionary =
+  nilCheck self
+  let argArr = [getPtr deep]
+  `duplicate(Dictionary bool)`(addr self, addr argArr[0], addr result, 1)
+proc get*(self: var Dictionary; key: Variant; default: Variant = default(Variant)): Variant =
+  nilCheck self
+  let argArr = [getPtr key, getPtr default]
+  `get(Dictionary Variant Variant)`(addr self, addr argArr[0], addr result, 2)
 proc get*(self: Dictionary; key: Variant; default: Variant = default(Variant)): Variant =
+  nilCheck self
   let argArr = [getPtr key, getPtr default]
   `get(Dictionary Variant Variant)`(addr self, addr argArr[0], addr result, 2)
 proc getOrAdd*(self: var Dictionary; key: Variant; default: Variant = default(Variant)): Variant =
+  nilCheck self
   let argArr = [getPtr key, getPtr default]
   `getOrAdd(Dictionary Variant Variant)`(addr self, addr argArr[0], addr result, 2)
 proc set*(self: var Dictionary; key: Variant; value: Variant): bool =
+  nilCheck self
   let argArr = [getPtr key, getPtr value]
   `set(Dictionary Variant Variant)`(addr self, addr argArr[0], addr result, 2)
-proc isTyped*(self: Dictionary): bool =
+proc isTyped*(self: var Dictionary): bool =
+  nilCheck self
   `isTyped(Dictionary)`(addr self, nil, addr result, 0)
-proc isTypedKey*(self: Dictionary): bool =
+proc isTyped*(self: Dictionary): bool =
+  nilCheck self
+  `isTyped(Dictionary)`(addr self, nil, addr result, 0)
+proc isTypedKey*(self: var Dictionary): bool =
+  nilCheck self
   `isTypedKey(Dictionary)`(addr self, nil, addr result, 0)
-proc isTypedValue*(self: Dictionary): bool =
+proc isTypedKey*(self: Dictionary): bool =
+  nilCheck self
+  `isTypedKey(Dictionary)`(addr self, nil, addr result, 0)
+proc isTypedValue*(self: var Dictionary): bool =
+  nilCheck self
   `isTypedValue(Dictionary)`(addr self, nil, addr result, 0)
-proc isSameTyped*(self: Dictionary; dictionary: Dictionary): bool =
+proc isTypedValue*(self: Dictionary): bool =
+  nilCheck self
+  `isTypedValue(Dictionary)`(addr self, nil, addr result, 0)
+proc isSameTyped*(self: var Dictionary; dictionary: Dictionary): bool =
+  nilCheck self
   let argArr = [getPtr dictionary]
   `isSameTyped(Dictionary Dictionary)`(addr self, addr argArr[0], addr result, 1)
-proc isSameTypedKey*(self: Dictionary; dictionary: Dictionary): bool =
+proc isSameTyped*(self: Dictionary; dictionary: Dictionary): bool =
+  nilCheck self
+  let argArr = [getPtr dictionary]
+  `isSameTyped(Dictionary Dictionary)`(addr self, addr argArr[0], addr result, 1)
+proc isSameTypedKey*(self: var Dictionary; dictionary: Dictionary): bool =
+  nilCheck self
   let argArr = [getPtr dictionary]
   `isSameTypedKey(Dictionary Dictionary)`(addr self, addr argArr[0], addr result, 1)
-proc isSameTypedValue*(self: Dictionary; dictionary: Dictionary): bool =
+proc isSameTypedKey*(self: Dictionary; dictionary: Dictionary): bool =
+  nilCheck self
+  let argArr = [getPtr dictionary]
+  `isSameTypedKey(Dictionary Dictionary)`(addr self, addr argArr[0], addr result, 1)
+proc isSameTypedValue*(self: var Dictionary; dictionary: Dictionary): bool =
+  nilCheck self
   let argArr = [getPtr dictionary]
   `isSameTypedValue(Dictionary Dictionary)`(addr self, addr argArr[0], addr result, 1)
-proc getTypedKeyBuiltin*(self: Dictionary): Int =
+proc isSameTypedValue*(self: Dictionary; dictionary: Dictionary): bool =
+  nilCheck self
+  let argArr = [getPtr dictionary]
+  `isSameTypedValue(Dictionary Dictionary)`(addr self, addr argArr[0], addr result, 1)
+proc getTypedKeyBuiltin*(self: var Dictionary): Int =
+  nilCheck self
   `getTypedKeyBuiltin(Dictionary)`(addr self, nil, addr result, 0)
-proc getTypedValueBuiltin*(self: Dictionary): Int =
+proc getTypedKeyBuiltin*(self: Dictionary): Int =
+  nilCheck self
+  `getTypedKeyBuiltin(Dictionary)`(addr self, nil, addr result, 0)
+proc getTypedValueBuiltin*(self: var Dictionary): Int =
+  nilCheck self
   `getTypedValueBuiltin(Dictionary)`(addr self, nil, addr result, 0)
-proc getTypedKeyClassName*(self: Dictionary): StringName =
+proc getTypedValueBuiltin*(self: Dictionary): Int =
+  nilCheck self
+  `getTypedValueBuiltin(Dictionary)`(addr self, nil, addr result, 0)
+proc getTypedKeyClassName*(self: var Dictionary): StringName =
+  nilCheck self
   `getTypedKeyClassName(Dictionary)`(addr self, nil, addr result, 0)
-proc getTypedValueClassName*(self: Dictionary): StringName =
+proc getTypedKeyClassName*(self: Dictionary): StringName =
+  nilCheck self
+  `getTypedKeyClassName(Dictionary)`(addr self, nil, addr result, 0)
+proc getTypedValueClassName*(self: var Dictionary): StringName =
+  nilCheck self
   `getTypedValueClassName(Dictionary)`(addr self, nil, addr result, 0)
-proc getTypedKeyScript*(self: Dictionary): Variant =
+proc getTypedValueClassName*(self: Dictionary): StringName =
+  nilCheck self
+  `getTypedValueClassName(Dictionary)`(addr self, nil, addr result, 0)
+proc getTypedKeyScript*(self: var Dictionary): Variant =
+  nilCheck self
   `getTypedKeyScript(Dictionary)`(addr self, nil, addr result, 0)
+proc getTypedKeyScript*(self: Dictionary): Variant =
+  nilCheck self
+  `getTypedKeyScript(Dictionary)`(addr self, nil, addr result, 0)
+proc getTypedValueScript*(self: var Dictionary): Variant =
+  nilCheck self
+  `getTypedValueScript(Dictionary)`(addr self, nil, addr result, 0)
 proc getTypedValueScript*(self: Dictionary): Variant =
+  nilCheck self
   `getTypedValueScript(Dictionary)`(addr self, nil, addr result, 0)
 proc makeReadOnly*(self: var Dictionary): void =
+  nilCheck self
   `makeReadOnly(Dictionary)`(addr self, nil, nil, 0)
-proc isReadOnly*(self: Dictionary): bool =
+proc isReadOnly*(self: var Dictionary): bool =
+  nilCheck self
   `isReadOnly(Dictionary)`(addr self, nil, addr result, 0)
+proc isReadOnly*(self: Dictionary): bool =
+  nilCheck self
+  `isReadOnly(Dictionary)`(addr self, nil, addr result, 0)
+proc recursiveEqual*(self: var Dictionary; dictionary: Dictionary; recursionCount: Int): bool =
+  nilCheck self
+  let argArr = [getPtr dictionary, getPtr recursionCount]
+  `recursiveEqual(Dictionary Dictionary Int)`(addr self, addr argArr[0], addr result, 2)
 proc recursiveEqual*(self: Dictionary; dictionary: Dictionary; recursionCount: Int): bool =
+  nilCheck self
   let argArr = [getPtr dictionary, getPtr recursionCount]
   `recursiveEqual(Dictionary Dictionary Int)`(addr self, addr argArr[0], addr result, 2)
 

--- a/src/gdext/private/internalbridge.nim
+++ b/src/gdext/private/internalbridge.nim
@@ -205,7 +205,10 @@ macro processExports(T: typed): untyped =
         gettersym = genSym(nskProc, "get_" & name)
         settersym = genSym(nskProc, "set_" & name)
         getterdef = quote do:
-          proc `gettersym`(self: `classIdent`): `classIdent`.`fieldIdent` = self.`fieldIdent`
+          proc `gettersym`(self: `classIdent`): `classIdent`.`fieldIdent` =
+            when compiles(nilCheck self.`fieldIdent`):
+              nilCheck self.`fieldIdent`
+            self.`fieldIdent`
         setterdef = quote do:
           proc `settersym`(self: `classIdent`; value: `classIdent`.`fieldIdent`) = self.`fieldIdent` = value
         gettername  = newlit "get_" & name

--- a/testproject/editor/nim/src/classes/gdproptestnode_pragmas.nim
+++ b/testproject/editor/nim/src/classes/gdproptestnode_pragmas.nim
@@ -60,7 +60,7 @@ PropTestNodePragmas.bind PropTestPragmasEnum
 
 method onInit(self: PropTestNodePragmas) =
   self.StringArray_with_export_multiline = newTypedArray[String](1)
-  self.string_array = newTypedArray[String]()
+  # self.string_array = newTypedArray[String]()
   self.texture2D_array = newTypedArray[Texture2D]()
 
 method enterTree(self: PropTestNodePragmas) {.gdsync.} =

--- a/testproject/runtime/nim/src/cases/primitives.nim
+++ b/testproject/runtime/nim/src/cases/primitives.nim
@@ -184,6 +184,12 @@ runtime: suite "size":
     check sizeof(Variant) == VariantSize
 
 runtime: suite "Array":
+  test "nil access":
+    var arr: Array
+    let imm_arr = arr
+    check arr.len == 0
+    expect NilAccessDefect:
+      discard imm_arr.len
   test "construct":
     var arr = newArray(10)
     check not arr.isTyped
@@ -219,6 +225,12 @@ runtime: suite "Array":
     check pb == newArray [byte 1, 24, 25, 26, 8]
 
 runtime: suite "TypedArray":
+  test "nil access":
+    var arr: TypedArray[String]
+    let imm_arr = arr
+    check arr.len == 0
+    expect NilAccessDefect:
+      discard imm_arr.len
   test "construct":
     var arr = newTypedArray[String](10)
     check arr.isTyped
@@ -371,6 +383,14 @@ runtime: suite "newPackedArray":
     var pb = newPackedArray [byte 1, 2, 3, 4, 5, 6, 7, 8]
     pb[1 .. ^2] = newPackedArray [byte 24, 25, 26]
     check pb == newPackedArray [byte 1, 24, 25, 26, 8]
+
+runtime: suite "Dictionary":
+  test "nil access":
+    var dict: Dictionary
+    let imm_dict = dict
+    check dict.size == 0
+    expect NilAccessDefect:
+      discard imm_dict.size
 
 runtime: suite "String":
   test "to nim-string":


### PR DESCRIPTION
The primary purpose of this change is to simplify object instantiation. Previously, when using Array or Dictionary as object fields, it was necessary to explicitly initialize them within the constructor. This update allows omitting such initialization code.

The target is Arrays or Dictionaries passed as the first argument to Godot API functions. We added initialization checks as follows:

At the beginning of each function, it checks whether the container (Array/Dictionary) is initialized.

If it is uninitialized:

  - If the argument is immutable (not var), a NilAccessDefect is thrown.

  - If the argument is mutable (var), it is automatically initialized inside the function (lazy initialization).

This allows omitting calls to newArray() or newDictionary(); however, since a NilAccessDefect exception may be thrown instead of initialization as described above, explicit initialization is still recommended.
