### PR TITLE
Add flexible symbol name formatting with new nameformats module and {.rename.} pragma

### DIFF
--- a/src/gdext.nim
+++ b/src/gdext.nim
@@ -139,7 +139,7 @@ template GDExtension_EntryPoint*: untyped =
 
       defaultClassFormatter = asIs
       defaultFunctionFormatter = asIs
-      defaultVirtualMethodFormatter = withLeadingUnderScore
+      defaultVirtualMethodFormatter = asIs
       defaultConstFormatter = asIs
       defaultPropertyFormatter = asIs
 

--- a/src/gdext.nim
+++ b/src/gdext.nim
@@ -23,7 +23,7 @@
 ## * `utilityfuncs <gdext/utilityfuncs.html>`_: Printing functions + misc
 ## * `conversions <gdext/conversions.html>`_: Utility converters to make easier to convert types
 ## * `dollars <gdext/dollars.html>`_: `$` for all engine-builtins
-
+## * `nameformats <gdext/nameformats.html>`_: Provides formatter functions for transforming Nim identifiers when exporting them to Godot.
 
 {.warning[UnusedImport]: off.}
 

--- a/src/gdext.nim
+++ b/src/gdext.nim
@@ -69,8 +69,12 @@ export gdengine.isEditorHint
 import gdext/extclasses/[gdextensionmain]
 export gdextensionmain.ExtensionMain, gdextensionmain.extmain
 
+import gdext/nameformats
+
 when Assistance.genEditorHelp:
   import gdext/private/doctools
+
+const EntryPoint* = event("EntryPoint")
 
 template GDExtension_EntryPoint*: untyped =
   ## Responds to initialization requests by Godot and performs extension initialization, such as loading functions and registering classes.
@@ -86,6 +90,7 @@ template GDExtension_EntryPoint*: untyped =
   proc exec_eliminate_servers {.expandEvent: eliminate_servers.}
   proc exec_eliminate_scene {.expandEvent: eliminate_scene.}
   proc exec_eliminate_editor {.expandEvent: eliminate_editor.}
+  proc execEntryPoint{.expandEvent: EntryPoint.}
 
   {.emit: "N_LIB_EXPORT N_CDECL(void, NimMain)(void);".}
   proc initializer(userdata: pointer; p_level: InitializationLevel) {.gdcall.} = errproof:
@@ -132,11 +137,19 @@ template GDExtension_EntryPoint*: untyped =
       r_initialization.deinitialize = deinitializer
       r_initialization.minimum_initialization_level = Initialization_Scene
 
+      defaultClassFormatter = asIs
+      defaultFunctionFormatter = asIs
+      defaultVirtualMethodFormatter = withLeadingUnderScore
+      defaultConstFormatter = asIs
+      defaultPropertyFormatter = asIs
+
       utilityfuncs.load()
 
       load_builtinclassConstructor()
       load_builtinclassOperator()
       load_builtinclassMethod()
+
+      execEntryPoint()
 
       return true
 

--- a/src/gdext/bridge.nim
+++ b/src/gdext/bridge.nim
@@ -11,11 +11,42 @@ import gdext/builtinindex
 import gdext/stringtools
 import gdext/appearances
 
-template name*(newname: static string) {.pragma.} ## Attaching it to a function along with gdsync allows to alias to the registered function.
-## ```nim
-## proc myCallback(self: MyClass; value: Int) {.gdsync, name:　"_my_callback".} =
-##   print "hi! the value is: ", value, "!"
-## ```
+template name*(newname: static string) {.pragma.}
+  ## Specifies a **fixed name** for a function when exporting it to Godot.
+  ## When this pragma is used, the specified string will be used as the name on the Godot side instead of the original Nim name.
+  ## If used together with `{.rename.}`, `{.name.}` takes precedence and a warning will be issued.
+  ## 
+  ## **See also:**
+  ## * `rename template<#rename.t,staticproc(string)>`_
+  ## 
+  ## **Example:**
+  ## ```nim
+  ## proc myCallback(self: MyClass; value: Int) {.gdsync, name:　"_my_callback".} =
+  ##   print "hi! the value is: ", value, "!"
+  ## ```
+
+
+template rename*(f: proc(str: string): string) {.pragma.}
+  ## Used when you want to **dynamically transform** the name of a function or property when exporting it to Godot.
+  ## By providing a formatter function, you can convert camelCase to snake_case, prefix an underscore for internal use, or apply other transformations.
+  ## If no formatter is specified, **the formatter set in the compile-time variable** `nameformats.defaultFunctionFormatter` will be used.
+  ## By default, `defaultFunctionFormatter` is set to `nameformats.asIs`, but you can change it to switch the default formatter for the entire project.
+  ## 
+  ## **See also:**
+  ## * `name template<#name.t,staticstring>`_
+  ## * `nameformats module<nameformats.html>`_
+  ## 
+  ## **Example:**
+  ## ```nim
+  ## proc myCallback(self: MyClass; value: Int) {.gdsync, rename:　nameformats.toGodotInternalFuncCase.} =
+  ## # => "_my_callback"
+  ##   print "hi! the value is: ", value, "!"
+  ## ```
+  ## ```nim
+  ## proc myCallback(self: MyClass; value: Int) {.gdsync, rename:　proc(s: string): string = "_" & s.} =
+  ## # => "_myCallback"
+  ##   print "hi! the value is: ", value, "!"
+  ## ```
 
 template signal* {.pragma.} ## With gdsync, register a function as a signal. Thereafter, calling the function will emit the associated signal.
 ## ```nim

--- a/src/gdext/bridge.nim
+++ b/src/gdext/bridge.nim
@@ -205,9 +205,9 @@ macro registerEnumInternal(Class, Enum; isBitField: static bool) =
     let fieldName = newlit $fieldsym
     call.add case isBitField
     of true:
-      quote do: (newStringName `fieldName`, Int 1 shl int `fieldsym`)
+      quote do: (newStringName defaultConstFormatter(`fieldName`), Int 1 shl int `fieldsym`)
     of false:
-      quote do: (newStringName `fieldName`, Int `fieldsym`)
+      quote do: (newStringName defaultConstFormatter(`fieldName`), Int `fieldsym`)
 
   call.add newlit isBitField
   result = quote do:

--- a/src/gdext/bridge.nim
+++ b/src/gdext/bridge.nim
@@ -10,6 +10,7 @@ import gdext/private/userclass/virtuals
 import gdext/builtinindex
 import gdext/stringtools
 import gdext/appearances
+import gdext/nameformats
 
 template name*(newname: static string) {.pragma.}
   ## Specifies a **fixed name** for a function when exporting it to Godot.
@@ -251,7 +252,14 @@ template `bind`*[E: enum](Flags: typedesc[set[E]]) =
   ## Same as `ExtensionMain.bind Flags`. ExtensionMain is a special sigleton class that names by config.nims
   registerEnumInternal(Extensionmain, E, true)
 
-macro gdname(P: proc): string = P.getPragmaVal("name") or newLit $P
+macro gdname(P: proc): string =
+  result = P.getPragmaVal("name")
+  if result.isNil:
+    result = P.getPragmaVal("rename")
+    if not result.isNil:
+      result = result.newCall(newLit $P)
+  if result.isNil:
+    result = newLit nameformats.defaultFunctionFormatter($P)
 
 template gdexport*() {.pragma.} ## Exposes a member variable to the engine as a property.
 ## ```nim

--- a/src/gdext/bridge.nim
+++ b/src/gdext/bridge.nim
@@ -12,7 +12,7 @@ import gdext/stringtools
 import gdext/appearances
 import gdext/nameformats
 
-template name*(newname: static string) {.pragma.}
+template name*(newname: string) {.pragma.}
   ## Specifies a **fixed name** for a function when exporting it to Godot.
   ## When this pragma is used, the specified string will be used as the name on the Godot side instead of the original Nim name.
   ## If used together with `{.rename.}`, `{.name.}` takes precedence and a warning will be issued.

--- a/src/gdext/bridge.nim
+++ b/src/gdext/bridge.nim
@@ -252,15 +252,6 @@ template `bind`*[E: enum](Flags: typedesc[set[E]]) =
   ## Same as `ExtensionMain.bind Flags`. ExtensionMain is a special sigleton class that names by config.nims
   registerEnumInternal(Extensionmain, E, true)
 
-macro gdname(P: proc): string =
-  result = P.getPragmaVal("name")
-  if result.isNil:
-    result = P.getPragmaVal("rename")
-    if not result.isNil:
-      result = result.newCall(newLit $P)
-  if result.isNil:
-    result = newLit nameformats.defaultFunctionFormatter($P)
-
 template gdexport*() {.pragma.} ## Exposes a member variable to the engine as a property.
 ## ```nim
 ## type MyResource* {.gdsync.} = ptr object of Resource

--- a/src/gdext/bridge.nim
+++ b/src/gdext/bridge.nim
@@ -189,7 +189,7 @@ macro registerEnumInternal(Class, Enum; isBitField: static bool) =
   let def = Enum.getImpl
   let enumType = Enum.getTypeInst
   let enumTypeStr = $enumType.toStrLit
-  let enumName = newLit $Enum
+  let enumName = def.gdname
 
   if registeredEnums.contains enumTypeStr: return newStmtList()
 

--- a/src/gdext/nameformats.nim
+++ b/src/gdext/nameformats.nim
@@ -1,0 +1,307 @@
+## Provides formatter functions for transforming Nim identifiers when exporting them to Godot.
+## This module defines common naming style conversions (snake_case, PascalCase, etc.)
+## and Godot-specific conventions for function and internal function identifiers.
+
+import std/strutils
+import std/sequtils
+
+type Formatter* = proc(str: string): string
+  ## A function type that maps an identifier string to a formatted string.
+
+proc getOrDefault(str: string; i: int; default: char = '\0'): char =
+  ## Returns the character at index `i` in `str`,
+  ## or `default` if the index is out of bounds.
+  if i in str.low..str.high:
+    str[i]
+  else:
+    default
+
+proc uncapitalizeAscii(str: string): string =
+  ## Returns a copy of `str` with the first ASCII letter lowercased.
+  result = str
+  if result.len != 0:
+    result[0] = result[0].toLowerAscii
+
+iterator words*(str: string): string =
+  ## Splits an identifier `str` into word-like segments.
+  ##
+  ## The splitting rules are designed for converting between
+  ## naming conventions (snake_case, camelCase, PascalCase, etc.):
+  ##
+  ## - Underscores (`_`) act as delimiters.
+  ## - Transitions between lowercase → UPPERCASE, or UPPERCASE → lowercase
+  ##   create boundaries. (e.g. "XMLHttp" → `["XML", "Http"]`)
+  ## - Digits are separated from letters. (e.g. "Version2Parser" → `["Version", "2", "Parser"]`)
+  ## - Consecutive uppercase letters are grouped unless followed by a lowercase,
+  ##   in which case the last uppercase starts a new word.
+  ##
+  ## Examples:
+  ## - "sendHTTPResponse200" → `["send", "HTTP", "Response", "200"]`
+  ## - "XMLHttpRequest" → `["XML", "Http", "Request"]`
+  ## - "my_custom_resource" → `["my", "custom", "resource"]`
+  ## - "aaa111Aa" → `["aaa", "111", "Aa"]`
+  ## - "aaa111AAa" → `["aaa", "111A", "Aa"]`
+  ## - "aaa111aA" → `["aaa", "111a", "A"]`
+  ##
+  ## Useful as a foundation for implementing case-conversion formatters.
+  var word: string
+  for i, c in str:
+    case c
+    of 'a'..'z':
+      if str.getOrDefault(i-1) in {'0'..'9'} and str.getOrDefault(i+1) in {'a'..'z'}:
+        if word.len != 0:
+          yield word
+          reset word
+      word.add c
+    of '_':
+      if word.len != 0:
+        yield word
+        reset word
+    of 'A'..'Z':
+      if str.getOrDefault(i-1) in {'a'..'z'} or str.getOrDefault(i+1) in {'a'..'z'}:
+        if word.len != 0:
+          yield word
+          reset word
+      if str.getOrDefault(i-1) in {'0'..'9'} and str.getOrDefault(i+1) in {'a'..'z'}:
+        if word.len != 0:
+          yield word
+          reset word
+      word.add c
+    of '0'..'9':
+      if str.getOrDefault(i-1) in {'a'..'z', 'A'..'Z'}:
+        if word.len != 0:
+          yield word
+          reset word
+      word.add c
+    else:
+      word.add c
+  if word.len != 0:
+    yield word
+
+proc toSnakeCase*(str: string): string =
+  ## Converts `str` into lower snake_case.
+  ## 
+  ## **Example:** "sendHTTPResponse200" -> "send_http_response_200"
+  str.words.toSeq.join("_").toLowerAscii
+
+proc toUpperSnakeCase*(str: string): string =
+  ## Converts `str` into UPPER_SNAKE_CASE.
+  ## 
+  ## **Example:** "sendHTTPResponse200" -> "SEND_HTTP_RESPONSE_200"
+  str.words.toSeq.join("_").toUpperAscii
+
+proc toPascalCase*(str: string): string =
+  ## Converts `str` into PascalCase.
+  ## 
+  ## **Example:** "sendHTTPResponse200" -> "SendHttpResponse200"
+  str.words.toSeq.mapIt(it.toLowerAscii.capitalizeAscii).join()
+
+proc toCamelCase*(str: string): string =
+  ## Converts `str` into camelCase.
+  ## 
+  ## **Example:** "sendHTTPResponse200" -> "sendHttpResponse200"
+  str.toPascalCase.uncapitalizeAscii
+
+proc toGodotFuncCase*(str: string): string =
+  ## Converts `str` into Godot’s recommended function naming convention (snake_case).
+  ## 
+  ## **Example:** "sendHTTPResponse200" -> "send_http_response_200"
+  str.toSnakeCase
+
+proc toGodotInternalFuncCase*(str: string): string =
+  ## Converts `str` into Godot’s internal-function/virtual-method naming convention:
+  ## snake_case with a leading underscore.
+  ## 
+  ## **Example:** "sendHTTPRequest" -> "_send_http_request"
+  "_" & str.toGodotFuncCase
+
+proc toGodotClassCase*(str: string): string =
+  ## Converts `str` into Godot’s recommended type/class naming convention (PascalCase).
+  ##
+  ## **Example:** "my_custom_resource" -> "MyCustomResource"
+  str.toPascalCase
+
+proc toGodotConstCase*(str: string): string =
+  ## Converts `str` into Godot’s recommended constant naming convention (UPPER_SNAKE_CASE).
+  ##
+  ## **Example:** "maxSpeed" -> "MAX_SPEED"
+  str.toUpperSnakeCase
+
+proc toGodotPropertyCase*(str: string): string =
+  ## Converts `str` into Godot’s recommended property naming convention (snake_case).
+  ## 
+  ## **Example:** "httpResponseCode" -> "http_response_code"
+  str.toSnakeCase
+
+proc asIs*(str: string): string =
+  ## Returns `str` unchanged.
+  ## Useful for opting out of formatting when exporting identifiers.
+  str
+
+proc prefix*(prefix: string): Formatter =
+  ## Returns a formatter that prepends `prefix` to the input string.
+  ## 
+  ## **Example:**
+  ## ```nim
+  ## let f = prefix("godot_")
+  ## assert f("signal") == "godot_signal"
+  ## ```
+  proc(str: string): string = prefix & str
+
+proc suffix*(suffix: string): Formatter =
+  ## Returns a formatter that appends `suffix` to the input string.
+  ## 
+  ## **Example:**
+  ## ```nim
+  ## let f = suffix("_gd")
+  ## assert f("player") == "player_gd"
+  ## ```
+  proc(str: string): string = str & suffix
+
+proc then*(a, b: Formatter): Formatter =
+  ## Composes two formatters sequentially.
+  ## The result of `a` is passed to `b`.
+  ##
+  ## **Example:**
+  ## ```nim
+  ## let f = toSnakeCase.then suffix("_gd")
+  ## assert f("PlayerID") == "player_id_gd"
+  ## ```
+  proc(str: string): string = b(a(str))
+
+template `>>`*(a, b: Formatter): Formatter =
+  ## Operator alias for `then`, allowing formatter chaining with `>>`.
+  ##
+  ## **Example:**
+  ## ```nim
+  ## let f = toPascalCase >> prefix("Gd")
+  ## assert f("player_id") == "GdPlayerId"
+  ## ```
+  a.then b
+
+# strutils glue
+# =============
+
+export capitalizeAscii
+export normalize
+export nimIdentNormalize
+
+proc removePrefix*(prefix: string): Formatter =
+  ## Returns a formatter that removes `prefix` from the beginning of the string,
+  ## if it exists. If `str` does not start with `prefix`, the string is returned unchanged.
+  ##
+  ## **Example:**
+  ## ```nim
+  ## let f = removePrefix("gd_")
+  ## assert f("gd_player") == "player"
+  ## assert f("player") == "player"
+  ## ```
+  proc(str: string): string =
+    result = str
+    strutils.removePrefix(result, prefix)
+
+proc removeSuffix*(suffix: string): Formatter =
+  ## Returns a formatter that removes `suffix` from the end of the string,
+  ## if it exists. If `str` does not end with `suffix`, the string is returned unchanged.
+  ##
+  ## **Example:**
+  ## ```nim
+  ## let f = removeSuffix("_gd")
+  ## assert f("player_gd") == "player"
+  ## assert f("player") == "player"
+  ## ```
+  proc(str: string): string =
+    result = str
+    strutils.removeSuffix(result, suffix)
+
+proc replace*(sub, by: string): Formatter =
+  ## Returns a formatter that replaces all occurrences of substring `sub`
+  ## with `by` inside the input string.
+  ##
+  ## **Example:**
+  ## ```nim
+  ## let f = replace("foo", "bar")
+  ## assert f("foo_test_foo") == "bar_test_bar"
+  ## ```
+  proc(str: string): string = strutils.replace(str, sub, by)
+
+proc multiReplace*(replacements: varargs[tuple[sub, by: string]]): Formatter =
+  ## Returns a formatter that applies multiple substring replacements at once.
+  ## Each `(sub, by)` pair is replaced in order.
+  ##
+  ## **Example:**
+  ## ```nim
+  ## let f = multiReplace(("foo", "bar"), ("baz", "qux"))
+  ## assert f("foo_baz_foo") == "bar_qux_bar"
+  ## ```
+  let r = @replacements
+  proc(str: string): string = strutils.multiReplace(str, r)
+
+# switches
+# ========
+
+var
+  defaultClassFormatter* {.compileTime.}: Formatter = asIs
+    ## The default formatter intended for exported classes
+    ## when neither `{.name.}` nor `{.rename.}` is specified.
+    ##
+    ## By default this is `asIs`, but it can be overridden at compile time.
+    ##
+    ## **Example:**
+    ## ```nim
+    ## import gdext/nameformats
+    ## static:
+    ##   nameformats.defaultClassFormatter = nameformats.toGodotClassCase
+    ## ```
+
+  defaultFunctionFormatter* {.compileTime.}: Formatter = asIs
+    ## The default formatter applied to exported functions
+    ## when neither `{.name.}` nor `{.rename.}` is specified.
+    ##
+    ## By default this is `asIs`, but it can be overridden at compile time.
+    ##
+    ## **Example:**
+    ## ```nim
+    ## import gdext/nameformats
+    ## static:
+    ##   nameformats.defaultFunctionFormatter = nameformats.toGodotFuncCase
+    ## ```
+
+  defaultVirtualMethodFormatter* {.compileTime.}: Formatter = asIs
+    ## The default formatter intended for exported virtual methods
+    ## when neither `{.name.}` nor `{.rename.}` is specified.
+    ##
+    ## By default this is `asIs`, but it can be overridden at compile time.
+    ##
+    ## **Example:**
+    ## ```nim
+    ## import gdext/nameformats
+    ## static:
+    ##   nameformats.defaultVirtualMethodFormatter = nameformats.toGodotVirtualMethodCase
+    ## ```
+
+  defaultConstFormatter* {.compileTime.}: Formatter = asIs
+    ## The default formatter intended for exported constants
+    ## when neither `{.name.}` nor `{.rename.}` is specified.
+    ##
+    ## By default this is `asIs`, but it can be overridden at compile time.
+    ##
+    ## **Example:**
+    ## ```nim
+    ## import gdext/nameformats
+    ## static:
+    ##   nameformats.defaultConstFormatter = nameformats.toUpperSnakeCase
+    ## ```
+
+  defaultPropertyFormatter* {.compileTime.}: Formatter = asIs
+    ## The default formatter intended for exported properties and signals
+    ## when neither `{.name.}` nor `{.rename.}` is specified.
+    ##
+    ## By default this is `asIs`, but it can be overridden at compile time.
+    ##
+    ## **Example:**
+    ## ```nim
+    ## import gdext/nameformats
+    ## static:
+    ##   nameformats.defaultPropertyFormatter = nameformats.toGodotFuncCase
+    ## ```

--- a/src/gdext/nameformats.nim
+++ b/src/gdext/nameformats.nim
@@ -102,6 +102,9 @@ proc toCamelCase*(str: string): string =
   ## **Example:** "sendHTTPResponse200" -> "sendHttpResponse200"
   str.toPascalCase.uncapitalizeAscii
 
+proc withLeadingUnderscore*(str: string): string =
+  "_" & str
+
 proc toGodotFuncCase*(str: string): string =
   ## Converts `str` into Godot’s recommended function naming convention (snake_case).
   ## 
@@ -113,7 +116,7 @@ proc toGodotInternalFuncCase*(str: string): string =
   ## snake_case with a leading underscore.
   ## 
   ## **Example:** "sendHTTPRequest" -> "_send_http_request"
-  "_" & str.toGodotFuncCase
+  str.toSnakeCase.withLeadingUnderscore
 
 proc toGodotClassCase*(str: string): string =
   ## Converts `str` into Godot’s recommended type/class naming convention (PascalCase).
@@ -267,17 +270,17 @@ var
     ##   nameformats.defaultFunctionFormatter = nameformats.toGodotFuncCase
     ## ```
 
-  defaultVirtualMethodFormatter* {.compileTime.}: Formatter = asIs
+  defaultVirtualMethodFormatter* {.compileTime.}: Formatter = withLeadingUnderscore
     ## The default formatter intended for exported virtual methods
     ## when neither `{.name.}` nor `{.rename.}` is specified.
     ##
-    ## By default this is `asIs`, but it can be overridden at compile time.
+    ## By default this is `withLeadingUnderscore`, but it can be overridden at compile time.
     ##
     ## **Example:**
     ## ```nim
     ## import gdext/nameformats
     ## static:
-    ##   nameformats.defaultVirtualMethodFormatter = nameformats.toGodotVirtualMethodCase
+    ##   nameformats.defaultVirtualMethodFormatter = nameformats.toGodotInternalFuncCase
     ## ```
 
   defaultConstFormatter* {.compileTime.}: Formatter = asIs

--- a/src/gdext/nameformats.nim
+++ b/src/gdext/nameformats.nim
@@ -103,7 +103,10 @@ proc toCamelCase*(str: string): string =
   str.toPascalCase.uncapitalizeAscii
 
 proc withLeadingUnderscore*(str: string): string =
-  "_" & str
+  if str[0] == '_':
+    str
+  else:
+    "_" & str
 
 proc toGodotFuncCase*(str: string): string =
   ## Converts `str` into Godot’s recommended function naming convention (snake_case).

--- a/src/gdext/nameformats.nim
+++ b/src/gdext/nameformats.nim
@@ -102,7 +102,7 @@ proc toCamelCase*(str: string): string =
   ## **Example:** "sendHTTPResponse200" -> "sendHttpResponse200"
   str.toPascalCase.uncapitalizeAscii
 
-proc withLeadingUnderscore*(str: string): string =
+proc ensureLeadingUnderscore*(str: string): string =
   if str[0] == '_':
     str
   else:
@@ -119,7 +119,7 @@ proc toGodotInternalFuncCase*(str: string): string =
   ## snake_case with a leading underscore.
   ## 
   ## **Example:** "sendHTTPRequest" -> "_send_http_request"
-  str.toSnakeCase.withLeadingUnderscore
+  str.toSnakeCase.ensureLeadingUnderscore
 
 proc toGodotClassCase*(str: string): string =
   ## Converts `str` into Godot’s recommended type/class naming convention (PascalCase).

--- a/src/gdext/nameformats.nim
+++ b/src/gdext/nameformats.nim
@@ -277,7 +277,7 @@ var
     ## The default formatter intended for exported virtual methods
     ## when neither `{.name.}` nor `{.rename.}` is specified.
     ##
-    ## By default this is `withLeadingUnderscore`, but it can be overridden at compile time.
+    ## By default this is `asIs`, but it can be overridden at compile time.
     ##
     ## **Example:**
     ## ```nim

--- a/src/gdext/nameformats.nim
+++ b/src/gdext/nameformats.nim
@@ -244,7 +244,7 @@ proc multiReplace*(replacements: varargs[tuple[sub, by: string]]): Formatter =
 # ========
 
 var
-  defaultClassFormatter* {.compileTime.}: Formatter = asIs
+  defaultClassFormatter*: Formatter
     ## The default formatter intended for exported classes
     ## when neither `{.name.}` nor `{.rename.}` is specified.
     ##
@@ -253,11 +253,11 @@ var
     ## **Example:**
     ## ```nim
     ## import gdext/nameformats
-    ## static:
+    ## proc set_formatters {.execon: EntryPoint.} =
     ##   nameformats.defaultClassFormatter = nameformats.toGodotClassCase
     ## ```
 
-  defaultFunctionFormatter* {.compileTime.}: Formatter = asIs
+  defaultFunctionFormatter*: Formatter
     ## The default formatter applied to exported functions
     ## when neither `{.name.}` nor `{.rename.}` is specified.
     ##
@@ -266,11 +266,11 @@ var
     ## **Example:**
     ## ```nim
     ## import gdext/nameformats
-    ## static:
+    ## proc set_formatters {.execon: EntryPoint.} =
     ##   nameformats.defaultFunctionFormatter = nameformats.toGodotFuncCase
     ## ```
 
-  defaultVirtualMethodFormatter* {.compileTime.}: Formatter = withLeadingUnderscore
+  defaultVirtualMethodFormatter*: Formatter
     ## The default formatter intended for exported virtual methods
     ## when neither `{.name.}` nor `{.rename.}` is specified.
     ##
@@ -279,11 +279,11 @@ var
     ## **Example:**
     ## ```nim
     ## import gdext/nameformats
-    ## static:
+    ## proc set_formatters {.execon: EntryPoint.} =
     ##   nameformats.defaultVirtualMethodFormatter = nameformats.toGodotInternalFuncCase
     ## ```
 
-  defaultConstFormatter* {.compileTime.}: Formatter = asIs
+  defaultConstFormatter*: Formatter
     ## The default formatter intended for exported constants
     ## when neither `{.name.}` nor `{.rename.}` is specified.
     ##
@@ -292,11 +292,11 @@ var
     ## **Example:**
     ## ```nim
     ## import gdext/nameformats
-    ## static:
+    ## proc set_formatters {.execon: EntryPoint.} =
     ##   nameformats.defaultConstFormatter = nameformats.toUpperSnakeCase
     ## ```
 
-  defaultPropertyFormatter* {.compileTime.}: Formatter = asIs
+  defaultPropertyFormatter*: Formatter
     ## The default formatter intended for exported properties and signals
     ## when neither `{.name.}` nor `{.rename.}` is specified.
     ##
@@ -305,6 +305,6 @@ var
     ## **Example:**
     ## ```nim
     ## import gdext/nameformats
-    ## static:
+    ## proc set_formatters {.execon: EntryPoint.} =
     ##   nameformats.defaultPropertyFormatter = nameformats.toGodotFuncCase
     ## ```

--- a/src/gdext/private/gdinterface.nim
+++ b/src/gdext/private/gdinterface.nim
@@ -124,9 +124,9 @@ macro gdname*(T: typedesc[SomeClass]): string =
   if result.isNil:
     result = T.typeDef.getPragmaVal("rename")
     if not result.isNil:
-      result = result.newCall(T.typeSym.toStrLit)
+      result = result.newCall newLit($T.typeSym)
   if result.isNil:
-    result = newLit nameformats.defaultClassFormatter($T.typeSym)
+    result = bindSym"defaultClassFormatter".newCall newLit($T.typeSym)
 
 proc gdname*(someProc: NimNode): NimNode =
   someProc.expectKind RoutineNodes
@@ -134,13 +134,13 @@ proc gdname*(someProc: NimNode): NimNode =
   if result.isNil:
     result = someProc.getPragmaVal("rename")
     if not result.isNil:
-      result = result.newCall(someProc.name.toStrLit)
+      result = result.newCall newLit($someProc.name)
   if result.isNil:
     case someProc.kind
     of nnkMethodDef:
-      result = newLit nameformats.defaultVirtualMethodFormatter($someProc.name)
+      result = bindsym"defaultVirtualMethodFormatter".newCall newLit($someProc.name)
     else:
-      result = newLit nameformats.defaultFunctionFormatter($someProc.name)
+      result = bindSym"defaultFunctionFormatter".newCall newLit($someProc.name)
 
 macro gdname*(P: proc): string =
   P.getImpl.gdname()

--- a/src/gdext/private/gdinterface.nim
+++ b/src/gdext/private/gdinterface.nim
@@ -134,7 +134,7 @@ proc gdname*(someProc: NimNode): NimNode =
   if result.isNil:
     result = someProc.getPragmaVal("rename")
     if not result.isNil:
-      result = result.newCall(result.name.toStrLit)
+      result = result.newCall(someProc.name.toStrLit)
   if result.isNil:
     result = newLit nameformats.defaultFunctionFormatter($someProc.name)
 

--- a/src/gdext/private/gdinterface.nim
+++ b/src/gdext/private/gdinterface.nim
@@ -142,6 +142,8 @@ proc gdname*(node: NimNode): NimNode =
       result = bindSym"defaultFunctionFormatter".newCall newLit($node.identifier)
     of nnkIdentDefs:
       result = bindSym"defaultPropertyFormatter".newCall newLit($node.identifier)
+    of nnkTypeDef:
+      result = bindSym"defaultClassFormatter".newCall newLit($node.typeSym)
     else:
       discard
 

--- a/src/gdext/private/gdinterface.nim
+++ b/src/gdext/private/gdinterface.nim
@@ -128,19 +128,22 @@ macro gdname*(T: typedesc[SomeClass]): string =
   if result.isNil:
     result = bindSym"defaultClassFormatter".newCall newLit($T.typeSym)
 
-proc gdname*(someProc: NimNode): NimNode =
-  someProc.expectKind RoutineNodes
-  result = someProc.getPragmaVal("name")
+proc gdname*(node: NimNode): NimNode =
+  result = node.getPragmaVal("name")
   if result.isNil:
-    result = someProc.getPragmaVal("rename")
+    result = node.getPragmaVal("rename")
     if not result.isNil:
-      result = result.newCall newLit($someProc.name)
+      result = result.newCall newLit($node.identifier)
   if result.isNil:
-    case someProc.kind
+    case node.kind
     of nnkMethodDef:
-      result = bindsym"defaultVirtualMethodFormatter".newCall newLit($someProc.name)
+      result = bindsym"defaultVirtualMethodFormatter".newCall newLit($node.identifier)
+    of (RoutineNodes - {nnkMethodDef}):
+      result = bindSym"defaultFunctionFormatter".newCall newLit($node.identifier)
+    of nnkIdentDefs:
+      result = bindSym"defaultPropertyFormatter".newCall newLit($node.identifier)
     else:
-      result = bindSym"defaultFunctionFormatter".newCall newLit($someProc.name)
+      discard
 
 macro gdname*(P: proc): string =
   P.getImpl.gdname()

--- a/src/gdext/private/gdinterface.nim
+++ b/src/gdext/private/gdinterface.nim
@@ -128,6 +128,19 @@ macro gdname*(T: typedesc[SomeClass]): string =
   if result.isNil:
     result = newLit nameformats.defaultClassFormatter($T.typeSym)
 
+proc gdname*(someProc: NimNode): NimNode =
+  someProc.expectKind RoutineNodes
+  result = someProc.getPragmaVal("name")
+  if result.isNil:
+    result = someProc.getPragmaVal("rename")
+    if not result.isNil:
+      result = result.newCall(result.name.toStrLit)
+  if result.isNil:
+    result = newLit nameformats.defaultFunctionFormatter($someProc.name)
+
+macro gdname*(P: proc): string =
+  P.getImpl.gdname()
+
 proc Meta*(T: typedesc[SomeClass]): var GodotClassMeta =
   var instance {.global.} : GodotClassMeta
   once:

--- a/src/gdext/private/gdinterface.nim
+++ b/src/gdext/private/gdinterface.nim
@@ -136,7 +136,11 @@ proc gdname*(someProc: NimNode): NimNode =
     if not result.isNil:
       result = result.newCall(someProc.name.toStrLit)
   if result.isNil:
-    result = newLit nameformats.defaultFunctionFormatter($someProc.name)
+    case someProc.kind
+    of nnkMethodDef:
+      result = newLit nameformats.defaultVirtualMethodFormatter($someProc.name)
+    else:
+      result = newLit nameformats.defaultFunctionFormatter($someProc.name)
 
 macro gdname*(P: proc): string =
   P.getImpl.gdname()

--- a/src/gdext/private/gdinterface.nim
+++ b/src/gdext/private/gdinterface.nim
@@ -6,6 +6,7 @@ import gdext/private/debugging
 import gdext/builtinindex {.all.}
 import gdext/stringtools
 import gdext/objectcallbacks
+import gdext/nameformats
 
 privateAccess Object
 
@@ -118,19 +119,32 @@ proc reference_callback(p_token: pointer; p_binding: pointer; p_reference: Bool)
   result = true
   debugReference(cast[Object](p_binding), p_reference)
 
+macro gdname*(T: typedesc[SomeClass]): string =
+  result = T.typeDef.getPragmaVal("name")
+  if result.isNil:
+    result = T.typeDef.getPragmaVal("rename")
+    if not result.isNil:
+      result = result.newCall(T.typeSym.toStrLit)
+  if result.isNil:
+    result = newLit nameformats.defaultClassFormatter($T.typeSym)
+
 proc Meta*(T: typedesc[SomeClass]): var GodotClassMeta =
   var instance {.global.} : GodotClassMeta
   once:
-    instance = GodotClassMeta(
-      className: newStringName $T,
-    )
     when T is SomeEngineClass:
-      instance.callbacks = InstanceBindingCallbacks(
-        create_callback: create_callback[T],
-        free_callback: free_callback[T],
-        reference_callback:
-          when T is RefCounted: reference_callback
-          else: nil
+      instance = GodotClassMeta(
+        className: newStringName $T,
+        callbacks: InstanceBindingCallbacks(
+          create_callback: create_callback[T],
+          free_callback: free_callback[T],
+          reference_callback:
+            when T is RefCounted: reference_callback
+            else: nil
+        )
+      )
+    else:
+      instance = GodotClassMeta(
+        className: newStringName gdname T,
       )
   instance
 

--- a/src/gdext/private/internalbridge.nim
+++ b/src/gdext/private/internalbridge.nim
@@ -212,8 +212,8 @@ macro processExports(T: typed): untyped =
             self.`fieldIdent`
         setterdef = quote do:
           proc `settersym`(self: `classIdent`; value: `classIdent`.`fieldIdent`) = self.`fieldIdent` = value
-        gettername  = newlit nameformats.defaultFunctionFormatter("get_" & name)
-        settername  = newlit nameformats.defaultFunctionFormatter("set_" & name)
+        gettername  = bindSym"defaultFunctionFormatter".newCall newLit("get_" & name)
+        settername  = bindSym"defaultFunctionFormatter".newCall newLit("set_" & name)
 
       result.add quote do:
         `getterdef`

--- a/src/gdext/private/internalbridge.nim
+++ b/src/gdext/private/internalbridge.nim
@@ -12,6 +12,7 @@ import gdext/builtinindex
 import gdext/objectcallbacks
 import gdext/appearances
 import gdext/stringtools
+import gdext/nameformats
 
 when Assistance.genEditorHelp:
   import gdext/private/doctools
@@ -211,8 +212,8 @@ macro processExports(T: typed): untyped =
             self.`fieldIdent`
         setterdef = quote do:
           proc `settersym`(self: `classIdent`; value: `classIdent`.`fieldIdent`) = self.`fieldIdent` = value
-        gettername  = newlit "get_" & name
-        settername  = newlit "set_" & name
+        gettername  = newlit nameformats.defaultFunctionFormatter("get_" & name)
+        settername  = newlit nameformats.defaultFunctionFormatter("set_" & name)
 
       result.add quote do:
         `getterdef`

--- a/src/gdext/private/internalbridge.nim
+++ b/src/gdext/private/internalbridge.nim
@@ -200,20 +200,21 @@ macro processExports(T: typed): untyped =
     if field.hasPragma("gdexport"):
       let
         fieldIdent = field.identifier
-        name = $fieldIdent
+        name = field.gdname
         desc = field.getPragmaVal("description") or newLit ""
         editorhint = field.getPragmaVal("gdexport") or (quote do: Appearance())
-        gettersym = genSym(nskProc, "get_" & name)
-        settersym = genSym(nskProc, "set_" & name)
+        gettersym = genSym(nskProc, "get_" & $fieldIdent)
+        settersym = genSym(nskProc, "set_" & $fieldIdent)
+        gettername  = bindSym"defaultFunctionFormatter".newCall "&".newCall(newLit"get_", name)
+        settername  = bindSym"defaultFunctionFormatter".newCall "&".newCall(newLit"set_", name)
         getterdef = quote do:
-          proc `gettersym`(self: `classIdent`): `classIdent`.`fieldIdent` =
+          proc `gettersym`(self: `classIdent`): `classIdent`.`fieldIdent` {.rename: proc(s: string): string = `gettername`.} =
             when compiles(nilCheck self.`fieldIdent`):
               nilCheck self.`fieldIdent`
             self.`fieldIdent`
         setterdef = quote do:
-          proc `settersym`(self: `classIdent`; value: `classIdent`.`fieldIdent`) = self.`fieldIdent` = value
-        gettername  = bindSym"defaultFunctionFormatter".newCall newLit("get_" & name)
-        settername  = bindSym"defaultFunctionFormatter".newCall newLit("set_" & name)
+          proc `settersym`(self: `classIdent`; value: `classIdent`.`fieldIdent`) {.rename: proc(s: string): string = `settername`.} =
+            self.`fieldIdent` = value
 
       result.add quote do:
         `getterdef`

--- a/src/gdext/private/macros.nim
+++ b/src/gdext/private/macros.nim
@@ -112,12 +112,12 @@ func recList*(node: NimNode): NimNode =
 
 func identifier*(node: NimNode): NimNode =
   case node.kind
-  of nnkIdent:
+  of nnkIdent, nnkSym, nnkAccQuoted:
     node
-  of nnkSym:
-    newIdentNode($node)
-  of nnkIdentDefs, nnkPragma, nnkPragmaExpr, nnkCall, nnkExprColonExpr, nnkTemplateDef:
+  of nnkIdentDefs, nnkPragma, nnkPragmaExpr, nnkCall, nnkExprColonExpr:
     node[0].identifier
+  of RoutineNodes:
+    node.name
   of nnkPostfix:
     node[1].identifier
   else:

--- a/src/gdext/private/macros.nim
+++ b/src/gdext/private/macros.nim
@@ -114,7 +114,7 @@ func identifier*(node: NimNode): NimNode =
   case node.kind
   of nnkIdent, nnkSym, nnkAccQuoted:
     node
-  of nnkIdentDefs, nnkPragma, nnkPragmaExpr, nnkCall, nnkExprColonExpr:
+  of nnkIdentDefs, nnkPragma, nnkPragmaExpr, nnkCall, nnkExprColonExpr, nnkTypeDef:
     node[0].identifier
   of RoutineNodes:
     node.name

--- a/src/gdext/private/macros.nim
+++ b/src/gdext/private/macros.nim
@@ -83,7 +83,14 @@ func typeSym*(node: NimNode): NimNode =
   of nnkOfInherit:
     node[0]
   of nnkSym:
-    node
+    case node.symKind
+    of nskType:
+      node
+    of nskParam:
+      node.getTypeImpl[1].typeSym
+    else:
+      error lisprepr node, node
+      nil
   of nnkPostfix:
     if node[0].eqIdent "*":
       node[1]

--- a/src/gdext/private/methodinfo.nim
+++ b/src/gdext/private/methodinfo.nim
@@ -5,8 +5,6 @@ import gdext/private/gdinterface
 import gdext/private/typeshift
 import gdext/private/propertyinfo
 import gdext/builtinindex
-import gdext/nameformats
-
 
 type
   Arg* = tuple
@@ -25,13 +23,7 @@ proc parseMiddle*(procdef: NimNode): MiddleExp =
   result.name = procdef[0]
   if result.name.kind == nnkPostfix: result.name = result.name[1]
 
-  result.gdname = procdef.getPragmaVal("name")
-  if result.gdname.isNil:
-    result.gdname = procdef.getPragmaVal("rename")
-    if not result.gdname.isNil:
-      result.gdname = result.gdname.newCall(result.name.toStrLit)
-  if result.gdname.isNil:
-    result.gdname = newLit nameformats.defaultFunctionFormatter($result.name)
+  result.gdname = procdef.gdname
 
   result.self_T = procdef.params[1][1]
   if procdef.hasReturn:

--- a/src/gdext/private/methodinfo.nim
+++ b/src/gdext/private/methodinfo.nim
@@ -5,6 +5,7 @@ import gdext/private/gdinterface
 import gdext/private/typeshift
 import gdext/private/propertyinfo
 import gdext/builtinindex
+import gdext/nameformats
 
 
 type
@@ -12,6 +13,7 @@ type
     namesym, typesym, default: NimNode
   MiddleExp* = object
     name*: NimNode
+    gdname*: NimNode
     isStatic*: bool
     isVarargs*: bool
     self_T*: NimNode
@@ -22,6 +24,14 @@ type
 proc parseMiddle*(procdef: NimNode): MiddleExp =
   result.name = procdef[0]
   if result.name.kind == nnkPostfix: result.name = result.name[1]
+
+  result.gdname = procdef.getPragmaVal("name")
+  if result.gdname.isNil:
+    result.gdname = procdef.getPragmaVal("rename")
+    if not result.gdname.isNil:
+      result.gdname = result.gdname.newCall(result.name.toStrLit)
+  if result.gdname.isNil:
+    result.gdname = newLit nameformats.defaultFunctionFormatter($result.name)
 
   result.self_T = procdef.params[1][1]
   if procdef.hasReturn:
@@ -210,10 +220,10 @@ proc classMethodInfo(
     default_arguments: default_arguments.head,
   )
 
-proc classMethodInfo(middle: MiddleExp; gdname: NimNode): NimNode =
+proc classMethodInfo*(middle: MiddleExp): NimNode =
   result = quote("@") do:
     classMethodInfo(
-      newStringName @gdname,
+      newStringName @(middle.gdname),
       @(middle.callFunc),
       @(middle.ptrCallFunc),
       @(middle.method_flags),
@@ -225,9 +235,6 @@ proc classMethodInfo(middle: MiddleExp; gdname: NimNode): NimNode =
     result.add(
       middle.returnValueInfo,
       middle.returnValueMeta,)
-
-proc classMethodInfo*(procdef: NimNode; gdname: NimNode): NimNode =
-  parseMiddle(procdef).classMethodInfo(gdname)
 
 proc classVirtualMethodInfo(
       name: Stringname;
@@ -264,7 +271,7 @@ proc classVirtualMethodInfo(
 proc virtualMethodInfo*(middle: MiddleExp): NimNode =
   quote"@" do:
     classVirtualMethodInfo(
-      newStringName @(middle.name.toStrLit),
+      newStringName @(middle.gdname),
       @(middle.returnValue),
       @(middle.returnValueMeta),
       @(middle.argumentsInfo),

--- a/src/gdext/private/userclass/procs.nim
+++ b/src/gdext/private/userclass/procs.nim
@@ -21,9 +21,9 @@ macro registerProc*(procdef): untyped =
     else: procdef.getImpl
   let Self = procdef.params[1][1]
 
-  let gdname = procdef.getPragmaVal("name") or newLit $procdef.name
-
-  let methodinfoDef = procdef.classMethodInfo(gdname)
+  let middle = procdef.parseMiddle
+  let methodinfoDef = middle.classMethodInfo()
+  let gdname = middle.gdname
 
   result = quote do:
     proc `gdname` {.execon: Contract[typedesc[`Self`]].procedure.} =

--- a/src/gdext/private/userclass/signals.nim
+++ b/src/gdext/private/userclass/signals.nim
@@ -44,7 +44,7 @@ macro parseParams (params): seq[PropertyInfo] =
 
 macro contractSignal (params, procdef; gdname: string): untyped =
   let arg0_T = params[1][1]
-  let procsym = ident $gdname
+  let procsym = ident gdname.repr
 
   result = quote do:
     proc `procsym` {.execon: Contract[`arg0_T`].signal.} =
@@ -63,7 +63,7 @@ macro syncSignalGlobal(procdef): untyped =
   if procdef.hasNoReturn:
     error errmsgSignalResultTypeMismatch, procdef
 
-  let gdname = procdef.getPragmaVal("name") or procdef.name.toStrLit
+  let gdname = procdef.gdname
 
   let params = newFormalParams(
       procdef.params[0],
@@ -86,7 +86,7 @@ macro syncSignalLocal(procdef): untyped =
 
   let params = procdef.params
 
-  let gdname = procdef.getPragmaVal("name") or procdef.name.toStrLit
+  let gdname = procdef.gdname
 
   let arg0T = params[1][1]
 

--- a/src/gdext/private/userclass/virtuals.nim
+++ b/src/gdext/private/userclass/virtuals.nim
@@ -30,7 +30,7 @@ proc emitterdef(middle: MiddleExp; procdef: NimNode): NimNode =
         discard call
         return
 
-  result.body = genAst(namesym, namelit = middle.name.toStrLit, sentence, body):
+  result.body = genAst(namesym, namelit = middle.gdname, sentence, body):
     try:
       let namesym {.global.} = newStringName namelit
       if self.hasScriptMethod(namesym):
@@ -58,7 +58,7 @@ proc sync_virtualDef*(procdef: NimNode): NimNode =
 
   procdef.body = procdef.callWithEmitter()
 
-  result = quote"@" do:
+  quote"@" do:
     @(middle.emitterdef(procdef))
     @procdef
     proc register_virtualMethod {.execon: Contract[@(middle.self_T)].virtual_base.} =

--- a/testproject/runtime/inherited_node01.gd
+++ b/testproject/runtime/inherited_node01.gd
@@ -1,4 +1,4 @@
 extends VirtualNode01
 
-func virtualMethod(str: String) -> String:
+func _virtual_method(str: String) -> String:
   return "virtualMethod of InheritedNode01 is called " + str

--- a/testproject/runtime/inherited_node02.gd
+++ b/testproject/runtime/inherited_node02.gd
@@ -1,4 +1,4 @@
 extends VirtualNode02
 
-func virtualMethod(str: String) -> String:
+func _virtual_method(str: String) -> String:
   return "virtualMethod of InheritedNode02 is called " + str

--- a/testproject/runtime/main.gd
+++ b/testproject/runtime/main.gd
@@ -2,8 +2,8 @@ extends "res://test_base.gd"
 
 @onready var node = $GDExtNode
 
-var signal_arg0_executed = false
-var signal_arg1_executed = false
+var signal_arg_0_executed = false
+var signal_arg_1_executed = false
 
 
 # Called when the node enters the scene tree for the first time.
@@ -15,15 +15,30 @@ func _ready():
 	test_grobal_func()
 	test_enum($EnumTester)
 	test_enum(EnumTester.new())
+	test_rename()
 
 	exit_with_status()
 
-func test_func(node: FunctionTester):
-	node.arg0_noret()
-	assert_equal(node.arg0_noret_result, "arg0_noret()")
+func test_rename():
+	assert_true(RenameTestSnakeCaseNoPragma.new() != null)
+	assert_true(rename_test_pascal_case_to_snake_case.new() != null)
+	assert_true(GDRenameTestClosurePrefix.new() != null)
+	assert_true(RenameTestNameAndRename.new() != null)
 
-	node.arg1_noret(node.arg1_ret(node.arg0_ret()))
-	assert_equal(node.arg1_noret_result, "arg1_noret(arg1_ret(arg0_ret()))")
+	var tester := RenameTester.new()
+
+	assert_true(tester.rename_test_func_pascal_case_no_pragma())
+	assert_true(tester.RenameTestFuncSnakeCaseToPascalCase())
+	assert_true(tester.gd_rename_test_func_closure_prefix())
+	assert_true(tester.rename_test_func_name_and_rename())
+
+
+func test_func(node: FunctionTester):
+	node.arg_0_noret()
+	assert_equal(node.get_arg_0_noret_result(), "arg0_noret()")
+
+	node.arg_1_noret(node.arg_1_ret(node.arg_0_ret()))
+	assert_equal(node.get_arg_1_noret_result(), "arg1_noret(arg1_ret(arg0_ret()))")
 
 	assert_equal(node.default_value_simple(), "default_value_simple(default)")
 	assert_equal(node.default_value_simple("custom"), "default_value_simple(custom)")
@@ -40,46 +55,46 @@ func test_func(node: FunctionTester):
 
 func test_virtual_func():
 	# $VirtualNode01.virtualMethod()
-	assert_equal($InheritedNode01.virtualMethod("from GDScript"),
+	assert_equal($InheritedNode01._virtual_method("from GDScript"),
 	"virtualMethod of InheritedNode01 is called from GDScript")
 	# $VirtualNode02.virtualMethod()
-	assert_equal($InheritedNode02.virtualMethod("from GDScript"),
+	assert_equal($InheritedNode02._virtual_method("from GDScript"),
 	"virtualMethod of InheritedNode02 is called from GDScript")
 
 func test_grobal_func():
-	RuntimeTest.signal_arg0.connect(_on_nim_signal_arg0)
-	RuntimeTest.signal_arg1.connect(_on_nim_signal_arg1)
-	RuntimeTest.arg0_noret()
-	RuntimeTest.arg1_noret(RuntimeTest.arg1_ret(RuntimeTest.arg0_ret()))
-	RuntimeTest.signal_arg0.emit()
-	RuntimeTest.signal_arg1.emit("signal")
-	RuntimeTest.emit_signal_arg0()
-	RuntimeTest.emit_signal_arg1("signal")
+	RuntimeTest.signal_arg_0.connect(_on_nim_signal_arg_0)
+	RuntimeTest.signal_arg_1.connect(_on_nim_signal_arg_1)
+	RuntimeTest.arg_0_noret()
+	RuntimeTest.arg_1_noret(RuntimeTest.arg_1_ret(RuntimeTest.arg_0_ret()))
+	RuntimeTest.signal_arg_0.emit()
+	RuntimeTest.signal_arg_1.emit("signal")
+	RuntimeTest.emit_signal_arg_0()
+	RuntimeTest.emit_signal_arg_1("signal")
 
 	RuntimeTest.exec_checks_use_api_from_toplevel()
-	assert_true(signal_arg0_executed and signal_arg1_executed)
+	assert_true(signal_arg_0_executed and signal_arg_1_executed)
 
 func test_enum(node: EnumTester):
-	assert_equal(node.echoTestEnumA(EnumTester.EnumA1), EnumTester.EnumA1)
-	assert_equal(node.echoTestEnumB(EnumTester.EnumB1), EnumTester.EnumB1)
-	assert_equal(node.test_enum_a, EnumTester.EnumA2)
-	assert_equal(node.test_enum_b, EnumTester.EnumB2)
-	node.test_enum_a = EnumTester.EnumA3
-	node.test_enum_b = EnumTester.EnumB3
-	assert_equal(node.test_enum_a, EnumTester.EnumA3)
-	assert_equal(node.test_enum_b, EnumTester.EnumB3)
-	assert_equal(node.echoVector2Axis(Vector2.AXIS_X), Vector2.AXIS_X)
+	assert_equal(node.echo_test_enum_a(EnumTester.ENUM_A_1), EnumTester.ENUM_A_1)
+	assert_equal(node.echo_test_enum_b(EnumTester.ENUM_B_1), EnumTester.ENUM_B_1)
+	assert_equal(node.test_enum_a, EnumTester.ENUM_A_2)
+	assert_equal(node.test_enum_b, EnumTester.ENUM_B_2)
+	node.test_enum_a = EnumTester.ENUM_A_3
+	node.test_enum_b = EnumTester.ENUM_B_3
+	assert_equal(node.test_enum_a, EnumTester.ENUM_A_3)
+	assert_equal(node.test_enum_b, EnumTester.ENUM_B_3)
+	assert_equal(node.echo_vector_2_axis(Vector2.AXIS_X), Vector2.AXIS_X)
 
-	assert_equal(node.echoTestFlags(EnumTester.Flag1), EnumTester.Flag1)
-	assert_equal(node.echoTestFlags(EnumTester.Flag2 | EnumTester.Flag4), EnumTester.Flag2 | EnumTester.Flag4)
-	assert_equal(node.test_flags, EnumTester.Flag2)
-	node.test_flags = EnumTester.Flag3
-	assert_equal(node.test_flags, EnumTester.Flag3)
-	node.test_flags = EnumTester.Flag1 | EnumTester.Flag4
-	assert_equal(node.test_flags, EnumTester.Flag1 | EnumTester.Flag4)
+	assert_equal(node.echo_test_flags(EnumTester.FLAG_1), EnumTester.FLAG_1)
+	assert_equal(node.echo_test_flags(EnumTester.FLAG_2 | EnumTester.FLAG_4), EnumTester.FLAG_2 | EnumTester.FLAG_4)
+	assert_equal(node.test_flags, EnumTester.FLAG_2)
+	node.test_flags = EnumTester.FLAG_3
+	assert_equal(node.test_flags, EnumTester.FLAG_3)
+	node.test_flags = EnumTester.FLAG_1 | EnumTester.FLAG_4
+	assert_equal(node.test_flags, EnumTester.FLAG_1 | EnumTester.FLAG_4)
 
-func _on_nim_signal_arg0():
-	signal_arg0_executed = true
-func _on_nim_signal_arg1(what):
+func _on_nim_signal_arg_0():
+	signal_arg_0_executed = true
+func _on_nim_signal_arg_1(what):
 	assert_equal(what, "signal")
-	signal_arg1_executed = true
+	signal_arg_1_executed = true

--- a/testproject/runtime/main.tscn
+++ b/testproject/runtime/main.tscn
@@ -11,7 +11,7 @@ font_size = 64
 [node name="Main" type="Node"]
 script = ExtResource("1_x2b6x")
 
-[node name="GDExtNode" type="GDExtNode" parent="." groups=["tester"]]
+[node name="GDExtNode" type="GdExtNode" parent="." groups=["tester"]]
 
 [node name="Sprite2D" type="Sprite2D" parent="GDExtNode"]
 texture = ExtResource("2_x3ep8")

--- a/testproject/runtime/nim/bootstrap.nim
+++ b/testproject/runtime/nim/bootstrap.nim
@@ -1,4 +1,5 @@
 import gdext
+import gdext/nameformats
 
 {.warning[UnusedImport]:off.}
 # import your extension classes here
@@ -18,8 +19,16 @@ import classes/gdextlabel
 import classes/gdsingleton
 import classes/gdfunctiontester
 import classes/gdenumtester
+import classes/gdrenametester
 
 # ==================================
+
+proc set_formatters {.execon: EntryPoint.} =
+  nameformats.defaultClassFormatter = nameformats.toGodotClassCase
+  nameformats.defaultPropertyFormatter = nameformats.toGodotPropertyCase
+  nameformats.defaultFunctionFormatter = nameformats.toGodotFuncCase
+  nameformats.defaultVirtualMethodFormatter = nameformats.toGodotInternalFuncCase
+  nameformats.defaultConstFormatter = nameformats.toUpperSnakeCase
 
 proc register_classes {.execon: initialize_scene.} =
   # register your extension classes here

--- a/testproject/runtime/nim/src/cases/use_api_from_toplevel.nim
+++ b/testproject/runtime/nim/src/cases/use_api_from_toplevel.nim
@@ -51,8 +51,8 @@ runtime: test "instantiate at global":
   destroy extentclass
 
 runtime: test "connect to global signal":
-  var signal_arg0_obj = extmain.signal"signal_arg0"
-  var signal_arg1_obj = extmain.signal"signal_arg1"
+  var signal_arg0_obj = extmain.signal"signal_arg_0"
+  var signal_arg1_obj = extmain.signal"signal_arg_1"
 
   check signal_arg0_obj.connect(extmain.callable"listen_0") == 0
   # check signal_arg0_obj.connect(extmain.callable"listen_1") == 0

--- a/testproject/runtime/nim/src/classes/gdextnode.nim
+++ b/testproject/runtime/nim/src/classes/gdextnode.nim
@@ -126,9 +126,9 @@ proc lesten_call_group(self: GDExtNode, str: string) {.gdsync.} =
 proc test_FirstClassFunction(self: GDExtNode) =
   suite "First-class function":
     test "connect to signal":
-      check self.connect("signal_arg0", self.callable"listen_0") == ok
-      check self.connect("signal_arg1", self.callable"listen_0") == ok
-      check self.connect("signal_arg1", self.callable"listen_1") == ok
+      check self.connect("signal_arg_0", self.callable"listen_0") == ok
+      check self.connect("signal_arg_1", self.callable"listen_0") == ok
+      check self.connect("signal_arg_1", self.callable"listen_1") == ok
 
     test "execute call_group":
       self.getTree.callGroup("tester", "lesten_call_group", variant "Hello, world!")
@@ -142,10 +142,10 @@ proc test_FirstClassFunction(self: GDExtNode) =
       check listen_result[1] == "SIGNAL"
       reset listen_result
     test "send Signal with emit":
-      self.signal"signal_arg0"()
+      self.signal"signal_arg_0"()
       check listen_result[0]
       reset listen_result
-      self.signal"signal_arg1"("SIGNAL")
+      self.signal"signal_arg_1"("SIGNAL")
       check listen_result[0]
       check listen_result[1] == "SIGNAL"
       reset listen_result

--- a/testproject/runtime/nim/src/classes/gdrenametester.nim
+++ b/testproject/runtime/nim/src/classes/gdrenametester.nim
@@ -1,0 +1,43 @@
+import gdext
+import gdext/nameformats
+
+type rename_test_snake_case_no_pragma* {.gdsync.} = ptr object of Node
+
+type RenameTestPascalCaseToSnakeCase* {.gdsync, rename: toSnakeCase.} = ptr object of Node
+
+type RenameTestClosurePrefix* {.gdsync, rename: prefix("GD").} = ptr object of Node
+
+type `RenameTest name & rename`* {.gdsync, name: "RenameTestNameAndRename", rename: toSnakeCase.} = ptr object of Node
+
+type RenameTester* {.gdsync.} = ptr object of Node
+  RenameTestPropertyPascalCaseNoPragma* {.gdexport.}: bool = true
+  rename_test_property_snake_case_to_pascal_case* {.gdexport, rename: toPascalCase.}: bool = true
+  rename_test_property_closure_prefix* {.gdexport, rename: prefix("gd_").}: bool = true
+  `rename_test_property name & rename`* {.gdexport, name: "rename_test_property_name_and_rename", rename: toPascalCase.}: bool = true
+
+proc RenameTestFuncPascalCaseNoPragma*(self: RenameTester): bool {.gdsync.} = true
+proc rename_test_func_snake_case_to_pascal_case*(self: RenameTester): bool {.gdsync, rename: toPascalCase.} = true
+proc rename_test_func_closure_prefix*(self: RenameTester): bool {.gdsync, rename: prefix("gd_").} = true
+proc `rename_test_func name & rename`*(self: RenameTester): bool {.gdsync, name: "rename_test_func_name_and_rename", rename: toPascalCase.} = true
+
+proc RenameTestSignalPascalCaseNoPragma*(self: RenameTester): Error {.gdsync, signal.}
+proc rename_test_signal_snake_case_to_pascal_case*(self: RenameTester): Error {.gdsync, signal, rename: toPascalCase.}
+
+method RenameTestMethodPascalCaseNoPragma*(self: RenameTester): bool {.gdsync, base.} = true
+method rename_test_method_snake_case_to_pascal_case*(self: RenameTester): bool {.gdsync, base, rename: toPascalCase.} = true
+
+type rename_test_enum_snake_case_no_pragma* = enum
+  a
+RenameTester.bind rename_test_enum_snake_case_no_pragma
+
+type RenameTestEnumPascalCaseToSnakeCase* {.rename: toSnakeCase.} = enum
+  b
+RenameTester.bind RenameTestEnumPascalCaseToSnakeCase
+
+type RenameTestEnumClosurePrefix* {.rename: prefix("GD").} = enum
+  c
+RenameTester.bind RenameTestEnumClosurePrefix
+
+type `RenameTestEnum name & rename`* {.name: "RenameTestEnumNameAndRename", rename: toSnakeCase.} = enum
+  d
+RenameTester.bind `RenameTestEnum name & rename`

--- a/tests/testnameformats.nim
+++ b/tests/testnameformats.nim
@@ -1,0 +1,65 @@
+import gdext/nameformats
+import std/[sequtils, unittest]
+
+test "words":
+  check "aaa".words.toSeq == @["aaa"]
+  check "aaa111".words.toSeq == @["aaa", "111"]
+  check "AAA".words.toSeq == @["AAA"]
+  check "AAAa".words.toSeq == @["AA", "Aa"]
+  check "AAAaAA".words.toSeq == @["AA", "Aa", "AA"]
+  check "AAA111".words.toSeq == @["AAA", "111"]
+  check "aaa111A".words.toSeq == @["aaa", "111A"]
+  check "aaa111AA".words.toSeq == @["aaa", "111AA"]
+  check "aaa111Aa".words.toSeq == @["aaa", "111", "Aa"]
+  check "aaa_aaa".words.toSeq == @["aaa", "aaa"]
+  check "sendHTTPResponse200".words.toSeq == @["send", "HTTP", "Response", "200"]
+  check "XMLHttpRequest".words.toSeq == @["XML", "Http", "Request"]
+  check "MyXMLParser".words.toSeq == @["My", "XML", "Parser"]
+  check "snake_case_already".words.toSeq == @["snake", "case", "already"]
+  check "Camel123Case".words.toSeq == @["Camel", "123", "Case"]
+  check "Version2Parser".words.toSeq == @["Version", "2", "Parser"]
+  check "aAAAa1A1a1Aa1aA".words.toSeq == @["a", "AA", "Aa", "1A", "1a", "1", "Aa", "1a", "A"]
+  check "aaa111AAAaaaAAA111aaa".words.toSeq == @["aaa", "111AA", "Aaaa", "AAA", "111", "aaa"]
+  check "a1AaA1a".words.toSeq == @["a", "1", "Aa", "A", "1a"]
+  check "___".words.toSeq == newSeq[string]()
+test "toSnakeCase":
+  check "sendHTTPResponse200".toSnakeCase == "send_http_response_200"
+test "toUpperSnakeCase":
+  check "sendHTTPResponse200".toUpperSnakeCase == "SEND_HTTP_RESPONSE_200"
+test "toPascalCase":
+  check "sendHTTPResponse200".toPascalCase == "SendHttpResponse200"
+test "toCamelCase":
+  check "sendHTTPResponse200".toCamelCase == "sendHttpResponse200"
+
+test "prefix":
+  let f = prefix("godot_")
+  check f("signal") == "godot_signal"
+
+test "suffix":
+  let f = suffix("_gd")
+  check f("player") == "player_gd"
+
+test "removePrefix":
+  let f = removePrefix("gd_")
+  check f("gd_player") == "player"
+  check f("player") == "player"
+
+test "removeSuffix":
+  let f = removeSuffix("_gd")
+  check f("player_gd") == "player"
+  check f("player") == "player"
+
+test "replace":
+  let f = replace("foo", "bar")
+  check f("foo_test_foo") == "bar_test_bar"
+
+test "multiReplace":
+  let f = multiReplace(("foo", "bar"), ("baz", "qux"))
+  check f("foo_baz_foo") == "bar_qux_bar"
+
+test "then":
+  let f = toSnakeCase.then suffix("_gd")
+  check f("PlayerID") == "player_id_gd"
+
+  let g = removePrefix("m") >> replace("Identity", "ID") >> suffix("_gd") >> toSnakeCase
+  check g("mPlayerIdentity") == "player_id_gd"


### PR DESCRIPTION
# Overview

This PR introduces a new module **`nameformats`** that provides flexible ways to transform Nim symbols (classes, functions, etc.) into Godot-compatible names upon export.  
Along with this, a new pragma **`{.rename.}`** has been added, which allows specifying a custom formatter function at symbol definition.  

With this PR, the following becomes possible:

- Attach `{.name: string.}` or `{.rename: proc(string): string.}` to classes, properties, functions, virtual methods, signals, and enums.
  - These pragmas only affect the exported Godot symbols and do **not** affect their usage inside Nim.
- Switch default formatters globally to transform symbols consistently without per-symbol overrides.
- Even when the default formatter is changed, explicitly provided `{.name.}` or `{.rename.}` always take precedence.

---

# Main Changes

- **New module `nameformats`**
  - Provides common formatters such as `toSnakeCase`, `toPascalCase`, `toCamelCase`, `toUpperSnakeCase`, etc.
  - Adds formatters matching **Godot’s naming conventions** (functions, classes, constants, properties, etc.).
  - Provides **combinators** for flexible transformations:
    - `prefix`, `suffix`, `removePrefix`, `replace`, `multiReplace`, `then (>>)` and more.
- **New default formatter variables**
  - `defaultClassFormatter`
  - `defaultFunctionFormatter`
  - `defaultVirtualMethodFormatter`
  - `defaultConstFormatter`
  - `defaultPropertyFormatter`
- **`words` iterator** to simplify writing custom case converters.
- **`{.rename.}` pragma**

---

# Background

Godot’s coding guidelines recommend:

- **snake_case** for functions and properties  
- **PascalCase** for class names  
- **UPPER_SNAKE_CASE** for constants  

Meanwhile, Nim encourages the use of camelCase and PascalCase.  
Until now, aligning with Godot’s naming style required either renaming Nim symbols to match Godot conventions directly, or manually applying `{.name.}` pragma for each symbol.  

With this PR, the conversion between Nim identifiers and Godot API naming can be handled **consistently and flexibly** using declarative rules.

---

# Example

```nim
import gdext
import gdext/nameformats

proc set_formatters {.execon: EntryPoint.} =
  defaultClassFormatter = removePrefix("GD")
  defaultPropertyFormatter = removePrefix("gd") >> toSnakeCase
  defaultFunctionFormatter = toSnakeCase
  defaultVirtualMethodFormatter = toSnakeCase >> ensureLeadingUnderScore

proc replaceShortHands(str: string): string =
  str.replace("Identity", "ID")

type GDMyNode* {.gdsync.} = ptr object of Node # => MyNode
  gdMyProperty* {.gdexport.}: bool # => my_property
  gdUserIdentity* {.gdexport, rename: replaceShortHands >> defaultPropertyFormatter.}: bool # => user_id

proc myFunction*(self: GDMyNode): bool {.gdsync.} = true 
# => my_function

proc myHiddenFunction*(self: GDMyNode): bool {.gdsync, rename: toGodotInternalFuncCase.} = true 
# => _my_hidden_function

method myMethod*(self: GDMyNode): bool {.gdsync, base.} = true 
# => _my_method

proc mySignal*(self: GDMyNode): Error {.gdsync, signal.} 
# => my_signal
```