### PR TITLE
Add `{.rpc.}` pragma

### DIFF
--- a/src/gdext/bridge.nim
+++ b/src/gdext/bridge.nim
@@ -97,6 +97,9 @@ template singleton* {.pragma.}
   ## type MySingleton {.gdsync, singleton.} = ptr object of Object
   ## ```
 
+template rpc*(mode= rpcModeAnyPeer; callLocal= false; transferMode= transferModeReliable; transferChannel= 0) {.pragma.}
+  ## See `Godot Docs - Remote procedure calls <https://docs.godotengine.org/en/stable/tutorials/networking/high_level_multiplayer.html#remote-procedure-calls>`_
+
 var Initialization_Default* {.compileTime.} = Initialization_Scene
 
 proc toLevel(node: NimNode): InitializationLevel =

--- a/src/gdext/private/gdinterface.nim
+++ b/src/gdext/private/gdinterface.nim
@@ -41,6 +41,7 @@ type
     virtualMethods*: Table[StringName, ClassCallVirtual]
     className*: StringName
     callbacks*: InstanceBindingCallbacks
+    rpcConfigs*: Table[StringName, Variant]
 
 const ErrorName: array[CallErrorType, string] = [
   "ok",

--- a/src/gdext/private/internalbridge.nim
+++ b/src/gdext/private/internalbridge.nim
@@ -14,6 +14,8 @@ import gdext/appearances
 import gdext/stringtools
 import gdext/nameformats
 
+from gdext/classes/gdNode import NotificationReady, rpc_config
+
 when Assistance.genEditorHelp:
   import gdext/private/doctools
 
@@ -46,7 +48,13 @@ proc property_can_revert_func[T](p_instance: ClassInstancePtr; p_name: ConstStri
 proc property_get_revert_func[T](p_instance: ClassInstancePtr; p_name: ConstStringNamePtr; r_ret: VariantPtr): Bool {.gdcall.} =
   procCall propertyGetRevert(cast[T](p_instance), p_name, r_ret)
 
+proc registerRpcConfigsRecursive[T: Object](instance: T)
 proc notification_func[T](p_instance: ClassInstancePtr; p_what: int32, p_reversed: bool) {.gdcall.} =
+  case p_what
+  of NotificationReady:
+    cast[T](p_instance).registerRpcConfigsRecursive()
+  else:
+    discard
   procCall notification(cast[T](p_instance), p_what)
 
 proc to_string_func[T](p_instance: ClassInstancePtr; r_is_valid: ptr Bool; p_out: StringPtr) {.gdcall.} =
@@ -125,8 +133,11 @@ proc creationInfo(T: typedesc[SomeUserClass]; is_virtual, is_abstract, is_expose
       else: property_get_revert_func[T],
     validate_property_func: nil,
     notification_func:
-      when compiles(notificationT[T](notification)): nil
-      else: notification_func[T],
+      if Meta(T).rpcConfigs.len != 0:
+        notification_func[T]
+      else:
+        when compiles(notificationT[T](notification)): nil
+        else: notification_func[T],
     to_string_func:
       when compiles(toStringT[T](toString)): nil
       else: to_string_func[T],
@@ -278,3 +289,9 @@ macro register_implicitly*(level: static InitializationLevel) =
     if registration in implicitRegistrationSingletons:
       result.add quote do:
         Engine.singleton.registerSingleton(className `registration`, instantiate `registration`)
+
+proc registerRpcConfigsRecursive[T: Object](instance: T) =
+  when T is SomeUserClass and T is Node:
+    for key, value in Meta(T).rpcConfigs.pairs:
+      instance.rpc_config(key, value)
+    ((T.Super) instance).registerRpcConfigsRecursive()

--- a/src/gdext/private/userclass/procs.nim
+++ b/src/gdext/private/userclass/procs.nim
@@ -6,6 +6,8 @@ import gdext/private/gdinterface
 import gdext/private/staticevents
 import gdext/private/methodinfo
 
+import gdext/dicttools
+
 import tools
 import virtuals
 
@@ -24,11 +26,20 @@ macro registerProc*(procdef): untyped =
   let middle = procdef.parseMiddle
   let methodinfoDef = middle.classMethodInfo()
   let gdname = middle.gdname
+  let name = middle.name
 
   result = quote do:
     proc `gdname` {.execon: Contract[typedesc[`Self`]].procedure.} =
       let info = `methodinfoDef`
       ClassDB.registerExtensionClassMethod(className(typedesc `Self`), addr info)
+      when `name`.hasCustomPragma(bridge.rpc):
+        var dict = newDictionary()
+        const (rpc_mode, call_local, transfer_mode, transfer_channel) = `name`.getCustomPragmaVal(bridge.rpc)
+        dict[variant "rpc_mode"] = variant rpc_mode
+        dict[variant "call_local"] = variant call_local
+        dict[variant "transfer_mode"] = variant transfer_mode
+        dict[variant "transfer_channel"] = variant transfer_channel
+        Meta(`Self`).rpcConfigs[cast[ptr StringName](info.name)[]] = variant dict
 
   when Assistance.genEditorHelp:
     let desc = procdef.getEditorHelp
@@ -37,7 +48,7 @@ macro registerProc*(procdef): untyped =
 
 proc makeNimMainProc(procdef: NimNode): NimNode =
   newProc(
-    name = ident $procdef.name,
+    name = genSym(nskProc, $procdef.name),
     params = concat(
       @[procdef.params[0],
         newIdentDefs(ident"_", bindsym"typeof".newcall(ident"extmain"))],

--- a/testproject/runtime/main.gd
+++ b/testproject/runtime/main.gd
@@ -10,6 +10,7 @@ var signal_arg_1_executed = false
 func _ready():
 
 	test_func($FunctionTester)
+	call_deferred("test_rpc_func", $FunctionTester)
 	test_func(FunctionTester.new())
 	test_virtual_func()
 	test_grobal_func()
@@ -17,7 +18,7 @@ func _ready():
 	test_enum(EnumTester.new())
 	test_rename()
 
-	exit_with_status()
+	call_deferred("exit_with_status")
 
 func test_rename():
 	assert_true(RenameTestSnakeCaseNoPragma.new() != null)
@@ -52,6 +53,11 @@ func test_func(node: FunctionTester):
 	assert_equal(node.varargs_concrete(1, 2, 3, 4, 5), "1, 2, 3, 4, 5")
 
 	assert_equal(node.most_complex("a", "b", "c", "d", "e", "f", "g"), "a b c d e f g")
+
+func test_rpc_func(node: FunctionTester):
+	node.test_nim_rpc()
+	node.rpc("rpc_func", "GDScriptRPC")
+	assert_equal(node.rpc_result, "GDScriptRPC")
 
 func test_virtual_func():
 	# $VirtualNode01.virtualMethod()

--- a/testproject/runtime/nim/src/classes/gdfunctiontester.nim
+++ b/testproject/runtime/nim/src/classes/gdfunctiontester.nim
@@ -1,9 +1,11 @@
-import std/[sequtils, strutils]
+import std/[sequtils, strutils, unittest]
 import gdext
+import gdext/classes/[gdNode]
 
 type FunctionTester* {.gdsync.} = ptr object of Node
   arg0_noret_result: string
   arg1_noret_result: string
+  rpcResult* {.gdexport.}: String
 
 # {.gdsync.} for forward declaration should be ignored.
 proc arg0_noret(self: FunctionTester) {.gdsync.}
@@ -54,3 +56,11 @@ proc most_complex(self: FunctionTester;
       args: varargs[string]
     ): string {.gdsync.} =
   @[str1, str2, str3, str4].concat(@args).join(" ")
+
+proc rpcFunc(self: FunctionTester; value: String) {.gdsync, rpc(callLocal = true).} =
+  self.rpcResult = value
+
+proc testNimRPC(self: FunctionTester) {.gdsync.} =
+  test "RPC":
+    check self.rpc("rpc_func", "NimRPC") == ok
+    check $self.rpcResult == "NimRPC"


### PR DESCRIPTION
Example:

```nim
import gdext
import gdext/classes/[gdNode]
proc rpc_func(self: MyNode; value: String) {.gdsync, rpc(callLocal = true).} =
  print value, ": hi, there!"

proc call_rpc(self: MyNode) {.gdsync.} =
  assert self.rpc("rpc_func", "NimRPC") == ok
  # => stdout: "NimRPC: hi, there!"

method ready(self: MyNode) {.gdsync.} =
  discard self.callDeferred("call_rpc")
```