### PR TITLE
Improve dictionary

### DIFF
--- a/src/gdext/dicttools.nim
+++ b/src/gdext/dicttools.nim
@@ -3,6 +3,7 @@ import gdext/private/staticevents
 import gdext/private/typeshift
 import gdext/private/macros
 import gdext/builtinindex
+import gdext/varianttools
 
 import std/[hashes, tables]
 
@@ -37,6 +38,26 @@ proc newDictionary*[A, B](pairs: openArray[(A, B)]): Dictionary =
   result = newDictionary()
   for (key, value) in pairs:
     result[variant key] = variant value
+
+iterator keys*(self: Dictionary): Variant =
+  for key in self.variant.keys:
+    yield key
+
+iterator values*(self: Dictionary): Variant =
+  for key in self.variant.keys:
+    yield self[key]
+
+iterator pairs*(self: Dictionary): tuple[key, item: Variant] =
+  for key in self.variant.keys:
+    yield (key, self[key])
+
+iterator mvalues*(self: var Dictionary): var Variant =
+  for key in self.variant.keys:
+    yield self[key]
+
+iterator mpairs*(self: var Dictionary): tuple[key: Variant; item: var Variant] =
+  for key in self.variant.keys:
+    yield (key, self[key])
 
 proc contains*[T: SomeProperty](dict: Dictionary; value: T): bool = dict.has(variant value)
 

--- a/src/gdext/dicttools.nim
+++ b/src/gdext/dicttools.nim
@@ -4,7 +4,7 @@ import gdext/private/typeshift
 import gdext/private/macros
 import gdext/builtinindex
 
-import std/[hashes]
+import std/[hashes, tables]
 
 template nilCheck*(self: Dictionary) =
   if unlikely(cast[pointer](self) == nil):
@@ -22,6 +22,21 @@ proc `[]=`*(self: var Dictionary; key: Variant; value: sink Variant) =
 
 include gdext/gen/gddictionaryconstr
 include gdext/gen/gddictionary
+
+proc newDictionary*(table: Table): Dictionary =
+  result = newDictionary()
+  for key, value in table:
+    result[variant key] = variant value
+
+proc newDictionary*(table: TableRef): Dictionary =
+  result = newDictionary()
+  for key, value in table:
+    result[variant key] = variant value
+
+proc newDictionary*[A, B](pairs: openArray[(A, B)]): Dictionary =
+  result = newDictionary()
+  for (key, value) in pairs:
+    result[variant key] = variant value
 
 proc contains*[T: SomeProperty](dict: Dictionary; value: T): bool = dict.has(variant value)
 

--- a/src/gdext/dicttools.nim
+++ b/src/gdext/dicttools.nim
@@ -61,4 +61,13 @@ iterator mpairs*(self: var Dictionary): tuple[key: Variant; item: var Variant] =
 
 proc contains*[T: SomeProperty](dict: Dictionary; value: T): bool = dict.has(variant value)
 
+proc `[]`*(self: Dictionary; key: SomeProperty): Variant =
+  self[variant key]
+proc `[]`*(self: var Dictionary; key: SomeProperty): var Variant =
+  self[variant key]
+proc `[]=`*(self: var Dictionary; key: SomeProperty; value: sink Variant) =
+  self[variant key] = value
+proc `[]=`*[A, B: SomeProperty](self: var Dictionary; key: A; value: sink B) =
+  self[variant key] = variant value
+
 template dictionary*(args: varargs[untyped]): untyped {.deprecated: "use newDictionary instead".} = unpackVarargs(newDictionary, args)

--- a/testproject/runtime/nim/src/cases/primitives.nim
+++ b/testproject/runtime/nim/src/cases/primitives.nim
@@ -1,6 +1,6 @@
 import gdext
 import testutils
-import std/[unicode, strutils]
+import std/[unicode, strutils, tables]
 import gdext/classes/gdnode
 include gdext/gen/variantsizes
 
@@ -400,12 +400,94 @@ runtime: suite "newPackedArray":
       discard arr[10]
 
 runtime: suite "Dictionary":
+  let keys = [
+    "int",
+    "float",
+    "string",
+    "Object",
+    ]
+  let values = [
+    variant(1),
+    variant(2.0),
+    variant("three"),
+    variant(instantiate Object),
+    ]
+  let data = {
+    keys[0]: values[0],
+    keys[1]: values[1],
+    keys[2]: values[2],
+    keys[3]: values[3],
+    }
   test "nil access":
     var dict: Dictionary
     let imm_dict = dict
     check dict.size == 0
     expect NilAccessDefect:
       discard imm_dict.size
+
+  test "construct from Table":
+    var tab = data.toTable
+    var dict = newDictionary(tab)
+    check not dict.isTyped
+    check dict.size == 4
+    for (key, val) in data:
+      check dict[variant key] == val
+
+  test "construct from TableRef":
+    var tab = data.newTable
+    var dict = newDictionary(tab)
+    check not dict.isTyped
+    check dict.size == 4
+    for (key, val) in data:
+      check dict[variant key] == val
+
+  test "construct from openArray":
+    var dict = newDictionary(data)
+    check not dict.isTyped
+    check dict.size == 4
+    for (key, val) in data:
+      check dict[variant key] == val
+
+  test "keys":
+    var dict = newDictionary(data)
+    for key in dict.keys:
+      check key as string in keys
+
+  test "values":
+    var dict = newDictionary(data)
+    for value in dict.values:
+      check value in values
+
+  test "pairs":
+    var dict = newDictionary(data)
+    for key, value in dict:
+      check values[keys.find(key)] == value
+
+  test "mvalues":
+    var dict = newDictionary(data)
+    for value in dict.mvalues:
+      value = variant Inf
+    for value in dict.values:
+      check value as float == Inf
+
+  test "mpairs":
+    var dict = newDictionary(data)
+    for key, value in dict.mpairs:
+      value = key
+    for key, value in dict:
+      check value == key
+
+  test "[]":
+    var dict = newDictionary(data)
+    check dict["int"] of int and dict["int"] as int == 1
+    check dict["float"] of float and dict["float"] as float == 2.0
+    check dict["string"] of string and dict["string"] as string == "three"
+    check dict["Object"] of Object and dict["Object"] as Object == values[3]
+
+  test "[]=":
+    var dict = newDictionary(data)
+    dict["int"] = 10
+    check dict["int"] as int == 10
 
 runtime: suite "String":
   test "to nim-string":


### PR DESCRIPTION
Closes #282 

Add several wrapper functions for Dictionary.

```nim
var node = instantiate Node
node.name = "four"
var dict = newDictionary {
  "int": variant 1,
  "float": variant 2.0,
  "string": variant "three", 
  "node": variant Node,
  }

for key, value in dict:
  case key as string
  of "int": echo value as int
  of "float": echo value as float
  of "string": echo value as string
  of "node": echo value as node

echo "dict[\"int\"] = ", dict["int"]
```