### PR TITLE
Fix identifier conflicts preventing correct Godot API calls

### DIFF
--- a/coronation/src/coronation/build.nim
+++ b/coronation/src/coronation/build.nim
@@ -170,8 +170,9 @@ proc project(config: BuildConfig; api: JsonAPI): ProjectRoot =
               for constant in class.json.constants.get(@[]):
                 constant.weave(sym)
             weave margin:
-              for entry in class.json.methods.get(@[]):
-                weave entry.convert(sym)
+              var methods = class.json.methods.get(@[]).mapIt(it.convert(sym)).squash
+              for entry in methods:
+                weave entry
             weave_properties class
 
     layout gen:

--- a/coronation/src/coronation/operators/classes/methods.nim
+++ b/coronation/src/coronation/operators/classes/methods.nim
@@ -15,24 +15,19 @@ import std/strutils
 import std/strformat
 
 type
-  ClassMethodKind* = enum
-    cmkNormal, cmkVirtual, cmkVararg
-  ClassMethodPtrCallEntry* = ref object of GodotProc
-  ClassMethodVarargsVariantEntry* = ref object of GodotProc
-  ClassMethodVarargsTypedEntry* = ref object of GodotProc
-  ClassMethodVirtualEntry* = ref object of GodotProc
+  ClassMethodEntry* = ref object of GodotProc
+    json: JsonClassMethod
+  ClassMethodPtrCallEntry* = ref object of ClassMethodEntry
+  ClassMethodCallEntry* = ref object of ClassMethodEntry
+    variant: ProcKey
+    typed: ProcKey
+  ClassMethodVirtualEntry* = ref object of ClassMethodEntry
     call_self: RenderableSelfArgument
     call_args: seq[RenderableArgument]
     call_result: RenderableResult
-  RenderableClassMethod* = ref object
-    case kind*: ClassMethodKind
-    of cmkVararg:
-      variant*: ClassMethodVarargsVariantEntry
-      typed*: ClassMethodVarargsTypedEntry
-    of cmkVirtual:
-      virtual*: ClassMethodVirtualEntry
-    of cmkNormal:
-      ptrcall*: ClassMethodPtrCallEntry
+    virtual_name: string
+
+method weave*(classMethod: ClassMethodEntry): Cloth {.base.} = (discard)
 
 proc joinArg(args: seq[string]): string = args.join(", ")
 
@@ -66,23 +61,31 @@ proc classMethodPtrCallEntry(json: JsonClassMethod; self_type: RenderableSelfArg
 
     native_name: json.name,
     hash: json.hash,
+
+    json: json,
   )
 
-proc classMethodVarargsVariantEntry(json: JsonClassMethod; self_type: RenderableSelfArgument): ClassMethodVarargsVariantEntry =
-  ClassMethodVarargsVariantEntry(
+proc variantKey(call: ClassMethodCallEntry): ProcKey =
+  ProcKey(
     kind: pkProc,
-    name: json.name.scan.convert(ProcSym),
-    self: self_type,
-    args: json.extract_args(fuzzy= true),
-    result: json.extract_result(),
-
-    native_name: json.name,
-    hash: json.hash,
+    name: call.name,
+    self: call.self,
+    args: call.json.extract_args(fuzzy= true),
+    result: call.result,
   )
 
-proc classMethodVarargsTypedEntry(json: JsonClassMethod; self_type: RenderableSelfArgument): ClassMethodVarargsTypedEntry =
-  ClassMethodVarargsTypedEntry(
+proc typedKey(call: ClassMethodCallEntry): ProcKey =
+  ProcKey(
     kind: pkTemplate,
+    name: call.name,
+    self: call.self,
+    args: call.args,
+    result: call.result,
+  )
+
+proc classMethodCallEntry(json: JsonClassMethod; self_type: RenderableSelfArgument): ClassMethodCallEntry =
+  result = ClassMethodCallEntry(
+    kind: pkProc,
     name: json.name.scan.convert(ProcSym),
     self: self_type,
     args: json.extract_args(),
@@ -90,7 +93,11 @@ proc classMethodVarargsTypedEntry(json: JsonClassMethod; self_type: RenderableSe
 
     native_name: json.name,
     hash: json.hash,
+
+    json: json,
   )
+  result.variant = result.variantKey
+  result.typed = result.typedKey
 
 proc classMethodVirtualEntry*(json: JsonClassMethod; self_type: RenderableSelfArgument): ClassMethodVirtualEntry =
   ClassMethodVirtualEntry(
@@ -102,13 +109,17 @@ proc classMethodVirtualEntry*(json: JsonClassMethod; self_type: RenderableSelfAr
     pragmas: Pragmas(list: @["base"]),
 
     native_name: json.name,
+
+    json: json,
+
+    virtual_name: json.name,
   )
 
 
 proc methodbind(gdproc: GodotProc): Cloth = weave multiline:
   &"expandMethodBind(className {gdproc.self.typesym}, \"{gdproc.native_name}\", {get gdproc.hash})"
 
-proc weave(entry: ClassMethodPtrCallEntry): Cloth =
+proc weaveAsPtrCallEntry(entry: GodotProc): Cloth =
   var args: seq[string]
   if not entry.self.isStatic: args.add $entry.self.name
   args.add "[" & entry.args.mapIt(&"getPtr {it.name}").join(", ") & "]"
@@ -121,53 +132,63 @@ proc weave(entry: ClassMethodPtrCallEntry): Cloth =
       if entry.result.typesym != TypeSym.Void:
         &"var ret: encoded {weave entry.result}"
       &"methodbind.ptrcall({args.joinArg})"
-
       if entry.result.typesym != TypeSym.Void:
         &"(addr ret).decode_result({weave entry.result})"
 
-proc weave(entry: ClassMethodVarargsVariantEntry): Cloth =
+method weave*(entry: ClassMethodPtrCallEntry): Cloth =
+  entry.weaveAsPtrCallEntry()
+
+proc weave_varargsVariant(entry: ClassMethodCallEntry): Cloth =
   let
-    vararg = entry.args[^1]
-    argCount = $entry.args.high & "+" & $vararg.name & ".len"
-    paramarray = "[" & entry.args[0..^2].mapIt("getTypedPtr " & $it.name).join(", ") & "]"
-    args = case entry.self.isStatic
+    vararg = entry.variant.args[^1]
+    argCount = $entry.variant.args.high & "+" & $vararg.name & ".len"
+    paramarray = "[" & entry.variant.args[0..^2].mapIt("getTypedPtr " & $it.name).join(", ") & "]"
+    args = case entry.variant.self.isStatic
     of true: &"`?param`"
-    of false: &"{entry.self.name}, `?param`, {vararg.name}"
+    of false: &"{entry.variant.self.name}, `?param`, {vararg.name}"
 
   weave multiline:
-    weave ProcKey entry
+    weave entry.variant
     weave cloths.indent:
       entry.methodbind
       &"var `?param` = newSeqOfCap[VariantPtr]({argCount})"
       &"`?param`.add {paramarray}"
-      if entry.result.typesym == TypeSym.Void:
+      if entry.variant.result.typesym == TypeSym.Void:
         &"discard methodbind.call({args})"
       else:
-        &"methodbind.call({args}).get({weave entry.result})"
+        &"methodbind.call({args}).get({weave entry.variant.result})"
 
-proc weave(entry: ClassMethodVarargsTypedEntry): Cloth =
+proc weave_varargsTyped(entry: ClassMethodCallEntry): Cloth =
   let
-    vararg = entry.args[^1]
-    fixed_args = entry.args[0..^2].mapIt("variant " & $it.name).join(", ")
+    vararg = entry.typed.args[^1]
+    fixed_args = entry.typed.args[0..^2].mapIt("variant " & $it.name).join(", ")
     args =
       if fixed_args.len == 0: $vararg.name
       else: fixed_args & ", " & $vararg.name
   weave multiline:
-    weave ProcKey entry
+    weave entry.typed
     weave cloths.indent:
-      &"{entry.name}({entry.self.name}, {args})"
+      &"{entry.variant.name}({entry.typed.self.name}, {args})"
 
-proc weave(entry: ClassMethodVirtualEntry): Cloth =
-  weave text:
-    weave ProcKey entry
-    "(discard)"
+method weave*(entry: ClassMethodCallEntry): Cloth =
+  weave multiline:
+    entry.weave_varargsVariant
+    entry.weave_varargsTyped
 
-proc weave_native(entry: ClassMethodVirtualEntry): Cloth =
+proc weave_method(entry: ClassMethodVirtualEntry): Cloth =
+  if entry.hash.isSome:
+    entry.weaveAsPtrCallEntry
+  else:
+    weave text:
+      weave ProcKey entry
+      "(discard)"
+
+proc weave_register(entry: ClassMethodVirtualEntry): Cloth =
   weave multiline:
     &"proc registerVirtual_{entry.name.dropQuote}*[T: {entry.self.typeSym}](Self: typedesc[T]) ="
     weave cloths.indent:
       const StringName = TypeSym"StringName"
-      &"Self.vmethods[{constructorName StringName}\"{entry.native_name}\"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {{.gdcall.}} ="
+      &"Self.vmethods[{constructorName StringName}\"{entry.virtual_name}\"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {{.gdcall.}} ="
       weave cloths.indent >> Join(delim: ""):
         &"errproof: cast[{entry.self.typesym}](p_instance).{entry.name}("
         weave Join(delim: ", "):
@@ -178,34 +199,42 @@ proc weave_native(entry: ClassMethodVirtualEntry): Cloth =
         else:
           ").encode(r_ret)"
 
-proc convert*(json: JsonClassMethod; caller: TypeSym): RenderableClassMethod =
+method weave*(entry: ClassMethodVirtualEntry): Cloth =
+  weave multiline:
+    entry.weave_method
+    entry.weave_register
+
+proc convert*(json: JsonClassMethod; caller: TypeSym): ClassMethodEntry =
   let self_type = RenderableSelfArgument(
     isStatic: json.isStatic,
     typesym: caller,
   )
   if json.is_vararg:
-    RenderableClassMethod(kind: cmkVararg,
-      variant: classMethodVarargsVariantEntry(json, self_type),
-      typed: classMethodVarargsTypedEntry(json, self_type),
-    )
+    classMethodCallEntry(json, self_type)
   elif json.isVirtual:
-    RenderableClassMethod(kind: cmkVirtual,
-      virtual: classMethodVirtualEntry(json, self_type),
-    )
+    classMethodVirtualEntry(json, self_type)
   else:
-    RenderableClassMethod(kind: cmkNormal,
-      ptrcall: classMethodPtrCallEntry(json, self_type),
-    )
+    classMethodPtrCallEntry(json, self_type)
 
-proc weave*(renderable: RenderableClassMethod): Cloth =
-  case renderable.kind
-  of cmkVararg:
-    weave multiline:
-      weave renderable.variant
-      weave renderable.`typed`
-  of cmkVirtual:
-    weave multiline:
-      weave renderable.virtual
-      weave_native renderable.virtual
-  of cmkNormal:
-    weave renderable.ptrcall
+proc squash*(methods: seq[ClassMethodEntry]): seq[ClassMethodEntry] =
+  var virtuals: seq[ClassMethodVirtualEntry]
+  var nonVirtuals: seq[ClassMethodEntry]
+  var drop: seq[ClassMethodEntry]
+  for m in methods:
+    if m of ClassMethodVirtualEntry:
+      virtuals.add ClassMethodVirtualEntry(m)
+    else:
+      nonVirtuals.add m
+
+  for v in virtuals:
+    for nv in nonVirtuals:
+      if v.native_name == "_" & nv.native_name:
+        v.native_name = nv.native_name
+        v.hash = nv.hash
+        v.args = nv.args
+        drop.add nv
+        break
+
+  for m in methods:
+    if m notin drop:
+      result.add m

--- a/src/gdext/classes/gdaudiostream.nim
+++ b/src/gdext/classes/gdaudiostream.nim
@@ -6,7 +6,11 @@ import gdresource; export gdresource
 
 expandOnClassImported(AudioStream, Resource)
 
-method instantiatePlayback*(self: AudioStream): gdref AudioStreamPlayback {.base.} = (discard)
+method instantiatePlayback*(self: AudioStream): gdref AudioStreamPlayback {.base.} =
+  expandMethodBind(className AudioStream, "instantiate_playback", 210135309)
+  var ret: encoded gdref AudioStreamPlayback
+  methodbind.ptrcall(self, [], addr ret)
+  (addr ret).decode_result(gdref AudioStreamPlayback)
 proc registerVirtual_instantiatePlayback*[T: AudioStream](Self: typedesc[T]) =
   Self.vmethods[newStringName"_instantiate_playback"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[AudioStream](p_instance).instantiatePlayback().encode(r_ret)
@@ -16,12 +20,20 @@ proc registerVirtual_getStreamName*[T: AudioStream](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_stream_name"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[AudioStream](p_instance).getStreamName().encode(r_ret)
 
-method getLength*(self: AudioStream): float64 {.base.} = (discard)
+method getLength*(self: AudioStream): float64 {.base.} =
+  expandMethodBind(className AudioStream, "get_length", 1740695150)
+  var ret: encoded float64
+  methodbind.ptrcall(self, [], addr ret)
+  (addr ret).decode_result(float64)
 proc registerVirtual_getLength*[T: AudioStream](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_length"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[AudioStream](p_instance).getLength().encode(r_ret)
 
-method isMonophonic*(self: AudioStream): bool {.base.} = (discard)
+method isMonophonic*(self: AudioStream): bool {.base.} =
+  expandMethodBind(className AudioStream, "is_monophonic", 36873697)
+  var ret: encoded bool
+  methodbind.ptrcall(self, [], addr ret)
+  (addr ret).decode_result(bool)
 proc registerVirtual_isMonophonic*[T: AudioStream](Self: typedesc[T]) =
   Self.vmethods[newStringName"_is_monophonic"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[AudioStream](p_instance).isMonophonic().encode(r_ret)
@@ -55,24 +67,6 @@ method getBarBeats*(self: AudioStream): int32 {.base.} = (discard)
 proc registerVirtual_getBarBeats*[T: AudioStream](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_bar_beats"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[AudioStream](p_instance).getBarBeats().encode(r_ret)
-
-proc getLength*(self: AudioStream): float64 =
-  expandMethodBind(className AudioStream, "get_length", 1740695150)
-  var ret: encoded float64
-  methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(float64)
-
-proc isMonophonic*(self: AudioStream): bool =
-  expandMethodBind(className AudioStream, "is_monophonic", 36873697)
-  var ret: encoded bool
-  methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(bool)
-
-proc instantiatePlayback*(self: AudioStream): gdref AudioStreamPlayback =
-  expandMethodBind(className AudioStream, "instantiate_playback", 210135309)
-  var ret: encoded gdref AudioStreamPlayback
-  methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(gdref AudioStreamPlayback)
 
 proc canBeSampled*(self: AudioStream): bool =
   expandMethodBind(className AudioStream, "can_be_sampled", 36873697)

--- a/src/gdext/classes/gdaudiostreamplayback.nim
+++ b/src/gdext/classes/gdaudiostreamplayback.nim
@@ -6,32 +6,50 @@ import gdrefcounted; export gdrefcounted
 
 expandOnClassImported(AudioStreamPlayback, RefCounted)
 
-method start*(self: AudioStreamPlayback; fromPos: float64): void {.base.} = (discard)
+method start*(self: AudioStreamPlayback; fromPos: float64 = 0.0): void {.base.} =
+  expandMethodBind(className AudioStreamPlayback, "start", 1958160172)
+  methodbind.ptrcall(self, [getPtr fromPos])
 proc registerVirtual_start*[T: AudioStreamPlayback](Self: typedesc[T]) =
   Self.vmethods[newStringName"_start"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[AudioStreamPlayback](p_instance).start(p_args[0].decode(float64))
 
-method stop*(self: AudioStreamPlayback): void {.base.} = (discard)
+method stop*(self: AudioStreamPlayback): void {.base.} =
+  expandMethodBind(className AudioStreamPlayback, "stop", 3218959716)
+  methodbind.ptrcall(self, [])
 proc registerVirtual_stop*[T: AudioStreamPlayback](Self: typedesc[T]) =
   Self.vmethods[newStringName"_stop"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[AudioStreamPlayback](p_instance).stop()
 
-method isPlaying*(self: AudioStreamPlayback): bool {.base.} = (discard)
+method isPlaying*(self: AudioStreamPlayback): bool {.base.} =
+  expandMethodBind(className AudioStreamPlayback, "is_playing", 36873697)
+  var ret: encoded bool
+  methodbind.ptrcall(self, [], addr ret)
+  (addr ret).decode_result(bool)
 proc registerVirtual_isPlaying*[T: AudioStreamPlayback](Self: typedesc[T]) =
   Self.vmethods[newStringName"_is_playing"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[AudioStreamPlayback](p_instance).isPlaying().encode(r_ret)
 
-method getLoopCount*(self: AudioStreamPlayback): int32 {.base.} = (discard)
+method getLoopCount*(self: AudioStreamPlayback): int32 {.base.} =
+  expandMethodBind(className AudioStreamPlayback, "get_loop_count", 3905245786)
+  var ret: encoded int32
+  methodbind.ptrcall(self, [], addr ret)
+  (addr ret).decode_result(int32)
 proc registerVirtual_getLoopCount*[T: AudioStreamPlayback](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_loop_count"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[AudioStreamPlayback](p_instance).getLoopCount().encode(r_ret)
 
-method getPlaybackPosition*(self: AudioStreamPlayback): float64 {.base.} = (discard)
+method getPlaybackPosition*(self: AudioStreamPlayback): float64 {.base.} =
+  expandMethodBind(className AudioStreamPlayback, "get_playback_position", 1740695150)
+  var ret: encoded float64
+  methodbind.ptrcall(self, [], addr ret)
+  (addr ret).decode_result(float64)
 proc registerVirtual_getPlaybackPosition*[T: AudioStreamPlayback](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_playback_position"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[AudioStreamPlayback](p_instance).getPlaybackPosition().encode(r_ret)
 
-method seek*(self: AudioStreamPlayback; position: float64): void {.base.} = (discard)
+method seek*(self: AudioStreamPlayback; time: float64 = 0.0): void {.base.} =
+  expandMethodBind(className AudioStreamPlayback, "seek", 1958160172)
+  methodbind.ptrcall(self, [getPtr time])
 proc registerVirtual_seek*[T: AudioStreamPlayback](Self: typedesc[T]) =
   Self.vmethods[newStringName"_seek"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[AudioStreamPlayback](p_instance).seek(p_args[0].decode(float64))
@@ -71,33 +89,3 @@ proc mixAudio*(self: AudioStreamPlayback; rateScale: Float; frames: int32): Pack
   var ret: encoded PackedVector2Array
   methodbind.ptrcall(self, [getPtr rateScale, getPtr frames], addr ret)
   (addr ret).decode_result(PackedVector2Array)
-
-proc start*(self: AudioStreamPlayback; fromPos: float64 = 0.0): void =
-  expandMethodBind(className AudioStreamPlayback, "start", 1958160172)
-  methodbind.ptrcall(self, [getPtr fromPos])
-
-proc seek*(self: AudioStreamPlayback; time: float64 = 0.0): void =
-  expandMethodBind(className AudioStreamPlayback, "seek", 1958160172)
-  methodbind.ptrcall(self, [getPtr time])
-
-proc stop*(self: AudioStreamPlayback): void =
-  expandMethodBind(className AudioStreamPlayback, "stop", 3218959716)
-  methodbind.ptrcall(self, [])
-
-proc getLoopCount*(self: AudioStreamPlayback): int32 =
-  expandMethodBind(className AudioStreamPlayback, "get_loop_count", 3905245786)
-  var ret: encoded int32
-  methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(int32)
-
-proc getPlaybackPosition*(self: AudioStreamPlayback): float64 =
-  expandMethodBind(className AudioStreamPlayback, "get_playback_position", 1740695150)
-  var ret: encoded float64
-  methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(float64)
-
-proc isPlaying*(self: AudioStreamPlayback): bool =
-  expandMethodBind(className AudioStreamPlayback, "is_playing", 36873697)
-  var ret: encoded bool
-  methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(bool)

--- a/src/gdext/classes/gdcodeedit.nim
+++ b/src/gdext/classes/gdcodeedit.nim
@@ -6,12 +6,16 @@ import gdtextedit; export gdtextedit
 
 expandOnClassImported(CodeEdit, TextEdit)
 
-method confirmCodeCompletion*(self: CodeEdit; replace: bool): void {.base.} = (discard)
+method confirmCodeCompletion*(self: CodeEdit; replace: bool = false): void {.base.} =
+  expandMethodBind(className CodeEdit, "confirm_code_completion", 107499316)
+  methodbind.ptrcall(self, [getPtr replace])
 proc registerVirtual_confirmCodeCompletion*[T: CodeEdit](Self: typedesc[T]) =
   Self.vmethods[newStringName"_confirm_code_completion"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[CodeEdit](p_instance).confirmCodeCompletion(p_args[0].decode(bool))
 
-method requestCodeCompletion*(self: CodeEdit; force: bool): void {.base.} = (discard)
+method requestCodeCompletion*(self: CodeEdit; force: bool = false): void {.base.} =
+  expandMethodBind(className CodeEdit, "request_code_completion", 107499316)
+  methodbind.ptrcall(self, [getPtr force])
 proc registerVirtual_requestCodeCompletion*[T: CodeEdit](Self: typedesc[T]) =
   Self.vmethods[newStringName"_request_code_completion"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[CodeEdit](p_instance).requestCodeCompletion(p_args[0].decode(bool))
@@ -439,10 +443,6 @@ proc getTextForCodeCompletion*(self: CodeEdit): String =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(String)
 
-proc requestCodeCompletion*(self: CodeEdit; force: bool = false): void =
-  expandMethodBind(className CodeEdit, "request_code_completion", 107499316)
-  methodbind.ptrcall(self, [getPtr force])
-
 proc addCodeCompletionOption*(self: CodeEdit; `type`: CodeEdit_CodeCompletionKind; displayText: String; insertText: String; textColor: Color = color(1, 1, 1, 1); icon: gdref Resource = default gdref Resource; value: Variant = default(Variant); location: int32 = 1024): void =
   expandMethodBind(className CodeEdit, "add_code_completion_option", 3944379502)
   methodbind.ptrcall(self, [getPtr `type`, getPtr displayText, getPtr insertText, getPtr textColor, getPtr icon, getPtr value, getPtr location])
@@ -472,10 +472,6 @@ proc getCodeCompletionSelectedIndex*(self: CodeEdit): int32 =
 proc setCodeCompletionSelectedIndex*(self: CodeEdit; index: int32): void =
   expandMethodBind(className CodeEdit, "set_code_completion_selected_index", 1286410249)
   methodbind.ptrcall(self, [getPtr index])
-
-proc confirmCodeCompletion*(self: CodeEdit; replace: bool = false): void =
-  expandMethodBind(className CodeEdit, "confirm_code_completion", 107499316)
-  methodbind.ptrcall(self, [getPtr replace])
 
 proc cancelCodeCompletion*(self: CodeEdit): void =
   expandMethodBind(className CodeEdit, "cancel_code_completion", 3218959716)

--- a/src/gdext/classes/gdcontrol.nim
+++ b/src/gdext/classes/gdcontrol.nim
@@ -28,12 +28,20 @@ proc registerVirtual_structuredTextParser*[T: Control](Self: typedesc[T]) =
   Self.vmethods[newStringName"_structured_text_parser"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Control](p_instance).structuredTextParser(p_args[0].decode(Array), p_args[1].decode(String)).encode(r_ret)
 
-method getMinimumSize*(self: Control): Vector2 {.base.} = (discard)
+method getMinimumSize*(self: Control): Vector2 {.base.} =
+  expandMethodBind(className Control, "get_minimum_size", 3341600327)
+  var ret: encoded Vector2
+  methodbind.ptrcall(self, [], addr ret)
+  (addr ret).decode_result(Vector2)
 proc registerVirtual_getMinimumSize*[T: Control](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_minimum_size"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Control](p_instance).getMinimumSize().encode(r_ret)
 
-method getTooltip*(self: Control; atPosition: Vector2): String {.base.} = (discard)
+method getTooltip*(self: Control; atPosition: Vector2 = vector2(0, 0)): String {.base.} =
+  expandMethodBind(className Control, "get_tooltip", 2895288280)
+  var ret: encoded String
+  methodbind.ptrcall(self, [getPtr atPosition], addr ret)
+  (addr ret).decode_result(String)
 proc registerVirtual_getTooltip*[T: Control](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_tooltip"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Control](p_instance).getTooltip(p_args[0].decode(Vector2)).encode(r_ret)
@@ -76,12 +84,6 @@ proc registerVirtual_guiInput*[T: Control](Self: typedesc[T]) =
 proc acceptEvent*(self: Control): void =
   expandMethodBind(className Control, "accept_event", 3218959716)
   methodbind.ptrcall(self, [])
-
-proc getMinimumSize*(self: Control): Vector2 =
-  expandMethodBind(className Control, "get_minimum_size", 3341600327)
-  var ret: encoded Vector2
-  methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Vector2)
 
 proc getCombinedMinimumSize*(self: Control): Vector2 =
   expandMethodBind(className Control, "get_combined_minimum_size", 3341600327)
@@ -587,12 +589,6 @@ proc getTooltipText*(self: Control): String =
   expandMethodBind(className Control, "get_tooltip_text", 201670096)
   var ret: encoded String
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(String)
-
-proc getTooltip*(self: Control; atPosition: Vector2 = vector2(0, 0)): String =
-  expandMethodBind(className Control, "get_tooltip", 2895288280)
-  var ret: encoded String
-  methodbind.ptrcall(self, [getPtr atPosition], addr ret)
   (addr ret).decode_result(String)
 
 proc setDefaultCursorShape*(self: Control; shape: Control_CursorShape): void =

--- a/src/gdext/classes/gdeditorproperty.nim
+++ b/src/gdext/classes/gdeditorproperty.nim
@@ -6,12 +6,16 @@ import gdcontainer; export gdcontainer
 
 expandOnClassImported(EditorProperty, Container)
 
-method updateProperty*(self: EditorProperty): void {.base.} = (discard)
+method updateProperty*(self: EditorProperty): void {.base.} =
+  expandMethodBind(className EditorProperty, "update_property", 3218959716)
+  methodbind.ptrcall(self, [])
 proc registerVirtual_updateProperty*[T: EditorProperty](Self: typedesc[T]) =
   Self.vmethods[newStringName"_update_property"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorProperty](p_instance).updateProperty()
 
-method setReadOnly*(self: EditorProperty; readOnly: bool): void {.base.} = (discard)
+method setReadOnly*(self: EditorProperty; readOnly: bool): void {.base.} =
+  expandMethodBind(className EditorProperty, "set_read_only", 2586408642)
+  methodbind.ptrcall(self, [getPtr readOnly])
 proc registerVirtual_setReadOnly*[T: EditorProperty](Self: typedesc[T]) =
   Self.vmethods[newStringName"_set_read_only"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorProperty](p_instance).setReadOnly(p_args[0].decode(bool))
@@ -25,10 +29,6 @@ proc getLabel*(self: EditorProperty): String =
   var ret: encoded String
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(String)
-
-proc setReadOnly*(self: EditorProperty; readOnly: bool): void =
-  expandMethodBind(className EditorProperty, "set_read_only", 2586408642)
-  methodbind.ptrcall(self, [getPtr readOnly])
 
 proc isReadOnly*(self: EditorProperty): bool =
   expandMethodBind(className EditorProperty, "is_read_only", 36873697)
@@ -117,10 +117,6 @@ proc getEditedObject*(self: EditorProperty): Object =
   var ret: encoded Object
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Object)
-
-proc updateProperty*(self: EditorProperty): void =
-  expandMethodBind(className EditorProperty, "update_property", 3218959716)
-  methodbind.ptrcall(self, [])
 
 proc addFocusable*(self: EditorProperty; control: Control): void =
   expandMethodBind(className EditorProperty, "add_focusable", 1496901182)

--- a/src/gdext/classes/gdgraphedit.nim
+++ b/src/gdext/classes/gdgraphedit.nim
@@ -16,7 +16,11 @@ proc registerVirtual_isInOutputHotzone*[T: GraphEdit](Self: typedesc[T]) =
   Self.vmethods[newStringName"_is_in_output_hotzone"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[GraphEdit](p_instance).isInOutputHotzone(p_args[0].decode(Object), p_args[1].decode(int32), p_args[2].decode(Vector2)).encode(r_ret)
 
-method getConnectionLine*(self: GraphEdit; fromPosition: Vector2; toPosition: Vector2): PackedVector2Array {.base.} = (discard)
+method getConnectionLine*(self: GraphEdit; fromNode: Vector2; toNode: Vector2): PackedVector2Array {.base.} =
+  expandMethodBind(className GraphEdit, "get_connection_line", 3932192302)
+  var ret: encoded PackedVector2Array
+  methodbind.ptrcall(self, [getPtr fromNode, getPtr toNode], addr ret)
+  (addr ret).decode_result(PackedVector2Array)
 proc registerVirtual_getConnectionLine*[T: GraphEdit](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_connection_line"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[GraphEdit](p_instance).getConnectionLine(p_args[0].decode(Vector2), p_args[1].decode(Vector2)).encode(r_ret)
@@ -127,12 +131,6 @@ proc isValidConnectionType*(self: GraphEdit; fromType: int32; toType: int32): bo
   var ret: encoded bool
   methodbind.ptrcall(self, [getPtr fromType, getPtr toType], addr ret)
   (addr ret).decode_result(bool)
-
-proc getConnectionLine*(self: GraphEdit; fromNode: Vector2; toNode: Vector2): PackedVector2Array =
-  expandMethodBind(className GraphEdit, "get_connection_line", 3932192302)
-  var ret: encoded PackedVector2Array
-  methodbind.ptrcall(self, [getPtr fromNode, getPtr toNode], addr ret)
-  (addr ret).decode_result(PackedVector2Array)
 
 proc attachGraphElementToFrame*(self: GraphEdit; element: StringName; frame: StringName): void =
   expandMethodBind(className GraphEdit, "attach_graph_element_to_frame", 3740211285)

--- a/src/gdext/classes/gdmesh.nim
+++ b/src/gdext/classes/gdmesh.nim
@@ -6,7 +6,11 @@ import gdresource; export gdresource
 
 expandOnClassImported(Mesh, Resource)
 
-method getSurfaceCount*(self: Mesh): int32 {.base.} = (discard)
+method getSurfaceCount*(self: Mesh): int32 {.base.} =
+  expandMethodBind(className Mesh, "get_surface_count", 3905245786)
+  var ret: encoded int32
+  methodbind.ptrcall(self, [], addr ret)
+  (addr ret).decode_result(int32)
 proc registerVirtual_getSurfaceCount*[T: Mesh](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_surface_count"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Mesh](p_instance).getSurfaceCount().encode(r_ret)
@@ -21,12 +25,20 @@ proc registerVirtual_surfaceGetArrayIndexLen*[T: Mesh](Self: typedesc[T]) =
   Self.vmethods[newStringName"_surface_get_array_index_len"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Mesh](p_instance).surfaceGetArrayIndexLen(p_args[0].decode(int32)).encode(r_ret)
 
-method surfaceGetArrays*(self: Mesh; index: int32): Array {.base.} = (discard)
+method surfaceGetArrays*(self: Mesh; surfIdx: int32): Array {.base.} =
+  expandMethodBind(className Mesh, "surface_get_arrays", 663333327)
+  var ret: encoded Array
+  methodbind.ptrcall(self, [getPtr surfIdx], addr ret)
+  (addr ret).decode_result(Array)
 proc registerVirtual_surfaceGetArrays*[T: Mesh](Self: typedesc[T]) =
   Self.vmethods[newStringName"_surface_get_arrays"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Mesh](p_instance).surfaceGetArrays(p_args[0].decode(int32)).encode(r_ret)
 
-method surfaceGetBlendShapeArrays*(self: Mesh; index: int32): TypedArray[Array] {.base.} = (discard)
+method surfaceGetBlendShapeArrays*(self: Mesh; surfIdx: int32): TypedArray[Array] {.base.} =
+  expandMethodBind(className Mesh, "surface_get_blend_shape_arrays", 663333327)
+  var ret: encoded TypedArray[Array]
+  methodbind.ptrcall(self, [getPtr surfIdx], addr ret)
+  (addr ret).decode_result(TypedArray[Array])
 proc registerVirtual_surfaceGetBlendShapeArrays*[T: Mesh](Self: typedesc[T]) =
   Self.vmethods[newStringName"_surface_get_blend_shape_arrays"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Mesh](p_instance).surfaceGetBlendShapeArrays(p_args[0].decode(int32)).encode(r_ret)
@@ -46,12 +58,18 @@ proc registerVirtual_surfaceGetPrimitiveType*[T: Mesh](Self: typedesc[T]) =
   Self.vmethods[newStringName"_surface_get_primitive_type"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Mesh](p_instance).surfaceGetPrimitiveType(p_args[0].decode(int32)).encode(r_ret)
 
-method surfaceSetMaterial*(self: Mesh; index: int32; material: gdref Material): void {.base.} = (discard)
+method surfaceSetMaterial*(self: Mesh; surfIdx: int32; material: gdref Material): void {.base.} =
+  expandMethodBind(className Mesh, "surface_set_material", 3671737478)
+  methodbind.ptrcall(self, [getPtr surfIdx, getPtr material])
 proc registerVirtual_surfaceSetMaterial*[T: Mesh](Self: typedesc[T]) =
   Self.vmethods[newStringName"_surface_set_material"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Mesh](p_instance).surfaceSetMaterial(p_args[0].decode(int32), p_args[1].decode(gdref Material))
 
-method surfaceGetMaterial*(self: Mesh; index: int32): gdref Material {.base.} = (discard)
+method surfaceGetMaterial*(self: Mesh; surfIdx: int32): gdref Material {.base.} =
+  expandMethodBind(className Mesh, "surface_get_material", 2897466400)
+  var ret: encoded gdref Material
+  methodbind.ptrcall(self, [getPtr surfIdx], addr ret)
+  (addr ret).decode_result(gdref Material)
 proc registerVirtual_surfaceGetMaterial*[T: Mesh](Self: typedesc[T]) =
   Self.vmethods[newStringName"_surface_get_material"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Mesh](p_instance).surfaceGetMaterial(p_args[0].decode(int32)).encode(r_ret)
@@ -71,7 +89,11 @@ proc registerVirtual_setBlendShapeName*[T: Mesh](Self: typedesc[T]) =
   Self.vmethods[newStringName"_set_blend_shape_name"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Mesh](p_instance).setBlendShapeName(p_args[0].decode(int32), p_args[1].decode(StringName))
 
-method getAabb*(self: Mesh): AABB {.base.} = (discard)
+method getAabb*(self: Mesh): AABB {.base.} =
+  expandMethodBind(className Mesh, "get_aabb", 1068685055)
+  var ret: encoded AABB
+  methodbind.ptrcall(self, [], addr ret)
+  (addr ret).decode_result(AABB)
 proc registerVirtual_getAabb*[T: Mesh](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_aabb"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Mesh](p_instance).getAabb().encode(r_ret)
@@ -86,45 +108,11 @@ proc getLightmapSizeHint*(self: Mesh): Vector2i =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Vector2i)
 
-proc getAabb*(self: Mesh): AABB =
-  expandMethodBind(className Mesh, "get_aabb", 1068685055)
-  var ret: encoded AABB
-  methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(AABB)
-
 proc getFaces*(self: Mesh): PackedVector3Array =
   expandMethodBind(className Mesh, "get_faces", 497664490)
   var ret: encoded PackedVector3Array
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(PackedVector3Array)
-
-proc getSurfaceCount*(self: Mesh): int32 =
-  expandMethodBind(className Mesh, "get_surface_count", 3905245786)
-  var ret: encoded int32
-  methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(int32)
-
-proc surfaceGetArrays*(self: Mesh; surfIdx: int32): Array =
-  expandMethodBind(className Mesh, "surface_get_arrays", 663333327)
-  var ret: encoded Array
-  methodbind.ptrcall(self, [getPtr surfIdx], addr ret)
-  (addr ret).decode_result(Array)
-
-proc surfaceGetBlendShapeArrays*(self: Mesh; surfIdx: int32): TypedArray[Array] =
-  expandMethodBind(className Mesh, "surface_get_blend_shape_arrays", 663333327)
-  var ret: encoded TypedArray[Array]
-  methodbind.ptrcall(self, [getPtr surfIdx], addr ret)
-  (addr ret).decode_result(TypedArray[Array])
-
-proc surfaceSetMaterial*(self: Mesh; surfIdx: int32; material: gdref Material): void =
-  expandMethodBind(className Mesh, "surface_set_material", 3671737478)
-  methodbind.ptrcall(self, [getPtr surfIdx, getPtr material])
-
-proc surfaceGetMaterial*(self: Mesh; surfIdx: int32): gdref Material =
-  expandMethodBind(className Mesh, "surface_get_material", 2897466400)
-  var ret: encoded gdref Material
-  methodbind.ptrcall(self, [getPtr surfIdx], addr ret)
-  (addr ret).decode_result(gdref Material)
 
 proc createPlaceholder*(self: Mesh): gdref Resource =
   expandMethodBind(className Mesh, "create_placeholder", 121922552)

--- a/src/gdext/classes/gdphysicsserver3drenderingserverhandler.nim
+++ b/src/gdext/classes/gdphysicsserver3drenderingserverhandler.nim
@@ -6,29 +6,23 @@ import gdobject; export gdobject
 
 expandOnClassImported(PhysicsServer3DRenderingServerHandler, Object)
 
-method setVertex*(self: PhysicsServer3DRenderingServerHandler; vertexId: int32; vertex: Vector3): void {.base.} = (discard)
+method setVertex*(self: PhysicsServer3DRenderingServerHandler; vertexId: int32; vertex: Vector3): void {.base.} =
+  expandMethodBind(className PhysicsServer3DRenderingServerHandler, "set_vertex", 1530502735)
+  methodbind.ptrcall(self, [getPtr vertexId, getPtr vertex])
 proc registerVirtual_setVertex*[T: PhysicsServer3DRenderingServerHandler](Self: typedesc[T]) =
   Self.vmethods[newStringName"_set_vertex"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[PhysicsServer3DRenderingServerHandler](p_instance).setVertex(p_args[0].decode(int32), p_args[1].decode(Vector3))
 
-method setNormal*(self: PhysicsServer3DRenderingServerHandler; vertexId: int32; normal: Vector3): void {.base.} = (discard)
+method setNormal*(self: PhysicsServer3DRenderingServerHandler; vertexId: int32; normal: Vector3): void {.base.} =
+  expandMethodBind(className PhysicsServer3DRenderingServerHandler, "set_normal", 1530502735)
+  methodbind.ptrcall(self, [getPtr vertexId, getPtr normal])
 proc registerVirtual_setNormal*[T: PhysicsServer3DRenderingServerHandler](Self: typedesc[T]) =
   Self.vmethods[newStringName"_set_normal"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[PhysicsServer3DRenderingServerHandler](p_instance).setNormal(p_args[0].decode(int32), p_args[1].decode(Vector3))
 
-method setAabb*(self: PhysicsServer3DRenderingServerHandler; aabb: AABB): void {.base.} = (discard)
+method setAabb*(self: PhysicsServer3DRenderingServerHandler; aabb: AABB): void {.base.} =
+  expandMethodBind(className PhysicsServer3DRenderingServerHandler, "set_aabb", 259215842)
+  methodbind.ptrcall(self, [getPtr aabb])
 proc registerVirtual_setAabb*[T: PhysicsServer3DRenderingServerHandler](Self: typedesc[T]) =
   Self.vmethods[newStringName"_set_aabb"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[PhysicsServer3DRenderingServerHandler](p_instance).setAabb(p_args[0].decode(AABB))
-
-proc setVertex*(self: PhysicsServer3DRenderingServerHandler; vertexId: int32; vertex: Vector3): void =
-  expandMethodBind(className PhysicsServer3DRenderingServerHandler, "set_vertex", 1530502735)
-  methodbind.ptrcall(self, [getPtr vertexId, getPtr vertex])
-
-proc setNormal*(self: PhysicsServer3DRenderingServerHandler; vertexId: int32; normal: Vector3): void =
-  expandMethodBind(className PhysicsServer3DRenderingServerHandler, "set_normal", 1530502735)
-  methodbind.ptrcall(self, [getPtr vertexId, getPtr normal])
-
-proc setAabb*(self: PhysicsServer3DRenderingServerHandler; aabb: AABB): void =
-  expandMethodBind(className PhysicsServer3DRenderingServerHandler, "set_aabb", 259215842)
-  methodbind.ptrcall(self, [getPtr aabb])

--- a/src/gdext/classes/gdresource.nim
+++ b/src/gdext/classes/gdresource.nim
@@ -6,22 +6,32 @@ import gdrefcounted; export gdrefcounted
 
 expandOnClassImported(Resource, RefCounted)
 
-method setupLocalToScene*(self: Resource): void {.base.} = (discard)
+method setupLocalToScene*(self: Resource): void {.base.} =
+  expandMethodBind(className Resource, "setup_local_to_scene", 3218959716)
+  methodbind.ptrcall(self, [])
 proc registerVirtual_setupLocalToScene*[T: Resource](Self: typedesc[T]) =
   Self.vmethods[newStringName"_setup_local_to_scene"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Resource](p_instance).setupLocalToScene()
 
-method getRid*(self: Resource): RID {.base.} = (discard)
+method getRid*(self: Resource): RID {.base.} =
+  expandMethodBind(className Resource, "get_rid", 2944877500)
+  var ret: encoded RID
+  methodbind.ptrcall(self, [], addr ret)
+  (addr ret).decode_result(RID)
 proc registerVirtual_getRid*[T: Resource](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_rid"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Resource](p_instance).getRid().encode(r_ret)
 
-method resetState*(self: Resource): void {.base.} = (discard)
+method resetState*(self: Resource): void {.base.} =
+  expandMethodBind(className Resource, "reset_state", 3218959716)
+  methodbind.ptrcall(self, [])
 proc registerVirtual_resetState*[T: Resource](Self: typedesc[T]) =
   Self.vmethods[newStringName"_reset_state"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Resource](p_instance).resetState()
 
-method setPathCache*(self: Resource; path: String): void {.base.} = (discard)
+method setPathCache*(self: Resource; path: String): void {.base.} =
+  expandMethodBind(className Resource, "set_path_cache", 83702148)
+  methodbind.ptrcall(self, [getPtr path])
 proc registerVirtual_setPathCache*[T: Resource](Self: typedesc[T]) =
   Self.vmethods[newStringName"_set_path_cache"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Resource](p_instance).setPathCache(p_args[0].decode(String))
@@ -40,10 +50,6 @@ proc getPath*(self: Resource): String =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(String)
 
-proc setPathCache*(self: Resource; path: String): void =
-  expandMethodBind(className Resource, "set_path_cache", 83702148)
-  methodbind.ptrcall(self, [getPtr path])
-
 proc setName*(self: Resource; name: String): void =
   expandMethodBind(className Resource, "set_name", 83702148)
   methodbind.ptrcall(self, [getPtr name])
@@ -53,12 +59,6 @@ proc getName*(self: Resource): String =
   var ret: encoded String
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(String)
-
-proc getRid*(self: Resource): RID =
-  expandMethodBind(className Resource, "get_rid", 2944877500)
-  var ret: encoded RID
-  methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(RID)
 
 proc setLocalToScene*(self: Resource; enable: bool): void =
   expandMethodBind(className Resource, "set_local_to_scene", 2586408642)
@@ -75,14 +75,6 @@ proc getLocalScene*(self: Resource): Node =
   var ret: encoded Node
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Node)
-
-proc setupLocalToScene*(self: Resource): void =
-  expandMethodBind(className Resource, "setup_local_to_scene", 3218959716)
-  methodbind.ptrcall(self, [])
-
-proc resetState*(self: Resource): void =
-  expandMethodBind(className Resource, "reset_state", 3218959716)
-  methodbind.ptrcall(self, [])
 
 proc setIdForPath*(self: Resource; path: String; id: String): void =
   expandMethodBind(className Resource, "set_id_for_path", 3186203200)

--- a/src/gdext/classes/gdstylebox.nim
+++ b/src/gdext/classes/gdstylebox.nim
@@ -6,7 +6,9 @@ import gdresource; export gdresource
 
 expandOnClassImported(StyleBox, Resource)
 
-method draw*(self: StyleBox; toCanvasItem: RID; rect: Rect2): void {.base.} = (discard)
+method draw*(self: StyleBox; canvasItem: RID; rect: Rect2): void {.base.} =
+  expandMethodBind(className StyleBox, "draw", 2275962004)
+  methodbind.ptrcall(self, [getPtr canvasItem, getPtr rect])
 proc registerVirtual_draw*[T: StyleBox](Self: typedesc[T]) =
   Self.vmethods[newStringName"_draw"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[StyleBox](p_instance).draw(p_args[0].decode(RID), p_args[1].decode(Rect2))
@@ -16,21 +18,23 @@ proc registerVirtual_getDrawRect*[T: StyleBox](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_draw_rect"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[StyleBox](p_instance).getDrawRect(p_args[0].decode(Rect2)).encode(r_ret)
 
-method getMinimumSize*(self: StyleBox): Vector2 {.base.} = (discard)
-proc registerVirtual_getMinimumSize*[T: StyleBox](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_get_minimum_size"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[StyleBox](p_instance).getMinimumSize().encode(r_ret)
-
-method testMask*(self: StyleBox; point: Vector2; rect: Rect2): bool {.base.} = (discard)
-proc registerVirtual_testMask*[T: StyleBox](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_test_mask"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[StyleBox](p_instance).testMask(p_args[0].decode(Vector2), p_args[1].decode(Rect2)).encode(r_ret)
-
-proc getMinimumSize*(self: StyleBox): Vector2 =
+method getMinimumSize*(self: StyleBox): Vector2 {.base.} =
   expandMethodBind(className StyleBox, "get_minimum_size", 3341600327)
   var ret: encoded Vector2
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Vector2)
+proc registerVirtual_getMinimumSize*[T: StyleBox](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_get_minimum_size"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[StyleBox](p_instance).getMinimumSize().encode(r_ret)
+
+method testMask*(self: StyleBox; point: Vector2; rect: Rect2): bool {.base.} =
+  expandMethodBind(className StyleBox, "test_mask", 3735564539)
+  var ret: encoded bool
+  methodbind.ptrcall(self, [getPtr point, getPtr rect], addr ret)
+  (addr ret).decode_result(bool)
+proc registerVirtual_testMask*[T: StyleBox](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_test_mask"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[StyleBox](p_instance).testMask(p_args[0].decode(Vector2), p_args[1].decode(Rect2)).encode(r_ret)
 
 proc setContentMargin*(self: StyleBox; margin: Side; offset: Float): void =
   expandMethodBind(className StyleBox, "set_content_margin", 4290182280)
@@ -58,21 +62,11 @@ proc getOffset*(self: StyleBox): Vector2 =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Vector2)
 
-proc draw*(self: StyleBox; canvasItem: RID; rect: Rect2): void =
-  expandMethodBind(className StyleBox, "draw", 2275962004)
-  methodbind.ptrcall(self, [getPtr canvasItem, getPtr rect])
-
 proc getCurrentItemDrawn*(self: StyleBox): CanvasItem =
   expandMethodBind(className StyleBox, "get_current_item_drawn", 3213695180)
   var ret: encoded CanvasItem
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(CanvasItem)
-
-proc testMask*(self: StyleBox; point: Vector2; rect: Rect2): bool =
-  expandMethodBind(className StyleBox, "test_mask", 3735564539)
-  var ret: encoded bool
-  methodbind.ptrcall(self, [getPtr point, getPtr rect], addr ret)
-  (addr ret).decode_result(bool)
 
 template contentMarginLeft*(self: StyleBox): untyped = self.getContentMargin(Side(0))
 template `contentMarginLeft=`*(self: StyleBox; value) = self.setContentMargin(Side(0), value)

--- a/src/gdext/classes/gdsyntaxhighlighter.nim
+++ b/src/gdext/classes/gdsyntaxhighlighter.nim
@@ -6,34 +6,28 @@ import gdresource; export gdresource
 
 expandOnClassImported(SyntaxHighlighter, Resource)
 
-method getLineSyntaxHighlighting*(self: SyntaxHighlighter; line: int32): Dictionary {.base.} = (discard)
-proc registerVirtual_getLineSyntaxHighlighting*[T: SyntaxHighlighter](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_get_line_syntax_highlighting"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[SyntaxHighlighter](p_instance).getLineSyntaxHighlighting(p_args[0].decode(int32)).encode(r_ret)
-
-method clearHighlightingCache*(self: SyntaxHighlighter): void {.base.} = (discard)
-proc registerVirtual_clearHighlightingCache*[T: SyntaxHighlighter](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_clear_highlighting_cache"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[SyntaxHighlighter](p_instance).clearHighlightingCache()
-
-method updateCache*(self: SyntaxHighlighter): void {.base.} = (discard)
-proc registerVirtual_updateCache*[T: SyntaxHighlighter](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_update_cache"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[SyntaxHighlighter](p_instance).updateCache()
-
-proc getLineSyntaxHighlighting*(self: SyntaxHighlighter; line: int32): Dictionary =
+method getLineSyntaxHighlighting*(self: SyntaxHighlighter; line: int32): Dictionary {.base.} =
   expandMethodBind(className SyntaxHighlighter, "get_line_syntax_highlighting", 3554694381)
   var ret: encoded Dictionary
   methodbind.ptrcall(self, [getPtr line], addr ret)
   (addr ret).decode_result(Dictionary)
+proc registerVirtual_getLineSyntaxHighlighting*[T: SyntaxHighlighter](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_get_line_syntax_highlighting"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[SyntaxHighlighter](p_instance).getLineSyntaxHighlighting(p_args[0].decode(int32)).encode(r_ret)
 
-proc updateCache*(self: SyntaxHighlighter): void =
-  expandMethodBind(className SyntaxHighlighter, "update_cache", 3218959716)
-  methodbind.ptrcall(self, [])
-
-proc clearHighlightingCache*(self: SyntaxHighlighter): void =
+method clearHighlightingCache*(self: SyntaxHighlighter): void {.base.} =
   expandMethodBind(className SyntaxHighlighter, "clear_highlighting_cache", 3218959716)
   methodbind.ptrcall(self, [])
+proc registerVirtual_clearHighlightingCache*[T: SyntaxHighlighter](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_clear_highlighting_cache"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[SyntaxHighlighter](p_instance).clearHighlightingCache()
+
+method updateCache*(self: SyntaxHighlighter): void {.base.} =
+  expandMethodBind(className SyntaxHighlighter, "update_cache", 3218959716)
+  methodbind.ptrcall(self, [])
+proc registerVirtual_updateCache*[T: SyntaxHighlighter](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_update_cache"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[SyntaxHighlighter](p_instance).updateCache()
 
 proc getTextEdit*(self: SyntaxHighlighter): TextEdit =
   expandMethodBind(className SyntaxHighlighter, "get_text_edit", 1893027089)

--- a/src/gdext/classes/gdtextedit.nim
+++ b/src/gdext/classes/gdtextedit.nim
@@ -11,27 +11,37 @@ proc registerVirtual_handleUnicodeInput*[T: TextEdit](Self: typedesc[T]) =
   Self.vmethods[newStringName"_handle_unicode_input"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextEdit](p_instance).handleUnicodeInput(p_args[0].decode(int32), p_args[1].decode(int32))
 
-method backspace*(self: TextEdit; caretIndex: int32): void {.base.} = (discard)
+method backspace*(self: TextEdit; caretIndex: int32 = -1): void {.base.} =
+  expandMethodBind(className TextEdit, "backspace", 1025054187)
+  methodbind.ptrcall(self, [getPtr caretIndex])
 proc registerVirtual_backspace*[T: TextEdit](Self: typedesc[T]) =
   Self.vmethods[newStringName"_backspace"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextEdit](p_instance).backspace(p_args[0].decode(int32))
 
-method cut*(self: TextEdit; caretIndex: int32): void {.base.} = (discard)
+method cut*(self: TextEdit; caretIndex: int32 = -1): void {.base.} =
+  expandMethodBind(className TextEdit, "cut", 1025054187)
+  methodbind.ptrcall(self, [getPtr caretIndex])
 proc registerVirtual_cut*[T: TextEdit](Self: typedesc[T]) =
   Self.vmethods[newStringName"_cut"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextEdit](p_instance).cut(p_args[0].decode(int32))
 
-method copy*(self: TextEdit; caretIndex: int32): void {.base.} = (discard)
+method copy*(self: TextEdit; caretIndex: int32 = -1): void {.base.} =
+  expandMethodBind(className TextEdit, "copy", 1025054187)
+  methodbind.ptrcall(self, [getPtr caretIndex])
 proc registerVirtual_copy*[T: TextEdit](Self: typedesc[T]) =
   Self.vmethods[newStringName"_copy"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextEdit](p_instance).copy(p_args[0].decode(int32))
 
-method paste*(self: TextEdit; caretIndex: int32): void {.base.} = (discard)
+method paste*(self: TextEdit; caretIndex: int32 = -1): void {.base.} =
+  expandMethodBind(className TextEdit, "paste", 1025054187)
+  methodbind.ptrcall(self, [getPtr caretIndex])
 proc registerVirtual_paste*[T: TextEdit](Self: typedesc[T]) =
   Self.vmethods[newStringName"_paste"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextEdit](p_instance).paste(p_args[0].decode(int32))
 
-method pastePrimaryClipboard*(self: TextEdit; caretIndex: int32): void {.base.} = (discard)
+method pastePrimaryClipboard*(self: TextEdit; caretIndex: int32 = -1): void {.base.} =
+  expandMethodBind(className TextEdit, "paste_primary_clipboard", 1025054187)
+  methodbind.ptrcall(self, [getPtr caretIndex])
 proc registerVirtual_pastePrimaryClipboard*[T: TextEdit](Self: typedesc[T]) =
   Self.vmethods[newStringName"_paste_primary_clipboard"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextEdit](p_instance).pastePrimaryClipboard(p_args[0].decode(int32))
@@ -331,26 +341,6 @@ proc getNextVisibleLineIndexOffsetFrom*(self: TextEdit; line: int32; wrapIndex: 
   var ret: encoded Vector2i
   methodbind.ptrcall(self, [getPtr line, getPtr wrapIndex, getPtr visibleAmount], addr ret)
   (addr ret).decode_result(Vector2i)
-
-proc backspace*(self: TextEdit; caretIndex: int32 = -1): void =
-  expandMethodBind(className TextEdit, "backspace", 1025054187)
-  methodbind.ptrcall(self, [getPtr caretIndex])
-
-proc cut*(self: TextEdit; caretIndex: int32 = -1): void =
-  expandMethodBind(className TextEdit, "cut", 1025054187)
-  methodbind.ptrcall(self, [getPtr caretIndex])
-
-proc copy*(self: TextEdit; caretIndex: int32 = -1): void =
-  expandMethodBind(className TextEdit, "copy", 1025054187)
-  methodbind.ptrcall(self, [getPtr caretIndex])
-
-proc paste*(self: TextEdit; caretIndex: int32 = -1): void =
-  expandMethodBind(className TextEdit, "paste", 1025054187)
-  methodbind.ptrcall(self, [getPtr caretIndex])
-
-proc pastePrimaryClipboard*(self: TextEdit; caretIndex: int32 = -1): void =
-  expandMethodBind(className TextEdit, "paste_primary_clipboard", 1025054187)
-  methodbind.ptrcall(self, [getPtr caretIndex])
 
 proc startAction*(self: TextEdit; action: TextEdit_EditAction): void =
   expandMethodBind(className TextEdit, "start_action", 2834827583)

--- a/src/gdext/classes/gdtexture2d.nim
+++ b/src/gdext/classes/gdtexture2d.nim
@@ -6,12 +6,20 @@ import gdtexture; export gdtexture
 
 expandOnClassImported(Texture2D, Texture)
 
-method getWidth*(self: Texture2D): int32 {.base.} = (discard)
+method getWidth*(self: Texture2D): int32 {.base.} =
+  expandMethodBind(className Texture2D, "get_width", 3905245786)
+  var ret: encoded int32
+  methodbind.ptrcall(self, [], addr ret)
+  (addr ret).decode_result(int32)
 proc registerVirtual_getWidth*[T: Texture2D](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_width"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Texture2D](p_instance).getWidth().encode(r_ret)
 
-method getHeight*(self: Texture2D): int32 {.base.} = (discard)
+method getHeight*(self: Texture2D): int32 {.base.} =
+  expandMethodBind(className Texture2D, "get_height", 3905245786)
+  var ret: encoded int32
+  methodbind.ptrcall(self, [], addr ret)
+  (addr ret).decode_result(int32)
 proc registerVirtual_getHeight*[T: Texture2D](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_height"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Texture2D](p_instance).getHeight().encode(r_ret)
@@ -21,61 +29,41 @@ proc registerVirtual_isPixelOpaque*[T: Texture2D](Self: typedesc[T]) =
   Self.vmethods[newStringName"_is_pixel_opaque"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Texture2D](p_instance).isPixelOpaque(p_args[0].decode(int32), p_args[1].decode(int32)).encode(r_ret)
 
-method hasAlpha*(self: Texture2D): bool {.base.} = (discard)
+method hasAlpha*(self: Texture2D): bool {.base.} =
+  expandMethodBind(className Texture2D, "has_alpha", 36873697)
+  var ret: encoded bool
+  methodbind.ptrcall(self, [], addr ret)
+  (addr ret).decode_result(bool)
 proc registerVirtual_hasAlpha*[T: Texture2D](Self: typedesc[T]) =
   Self.vmethods[newStringName"_has_alpha"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Texture2D](p_instance).hasAlpha().encode(r_ret)
 
-method draw*(self: Texture2D; toCanvasItem: RID; pos: Vector2; modulate: Color; transpose: bool): void {.base.} = (discard)
+method draw*(self: Texture2D; canvasItem: RID; position: Vector2; modulate: Color = color(1, 1, 1, 1); transpose: bool = false): void {.base.} =
+  expandMethodBind(className Texture2D, "draw", 2729649137)
+  methodbind.ptrcall(self, [getPtr canvasItem, getPtr position, getPtr modulate, getPtr transpose])
 proc registerVirtual_draw*[T: Texture2D](Self: typedesc[T]) =
   Self.vmethods[newStringName"_draw"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Texture2D](p_instance).draw(p_args[0].decode(RID), p_args[1].decode(Vector2), p_args[2].decode(Color), p_args[3].decode(bool))
 
-method drawRect*(self: Texture2D; toCanvasItem: RID; rect: Rect2; tile: bool; modulate: Color; transpose: bool): void {.base.} = (discard)
+method drawRect*(self: Texture2D; canvasItem: RID; rect: Rect2; tile: bool; modulate: Color = color(1, 1, 1, 1); transpose: bool = false): void {.base.} =
+  expandMethodBind(className Texture2D, "draw_rect", 3499451691)
+  methodbind.ptrcall(self, [getPtr canvasItem, getPtr rect, getPtr tile, getPtr modulate, getPtr transpose])
 proc registerVirtual_drawRect*[T: Texture2D](Self: typedesc[T]) =
   Self.vmethods[newStringName"_draw_rect"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Texture2D](p_instance).drawRect(p_args[0].decode(RID), p_args[1].decode(Rect2), p_args[2].decode(bool), p_args[3].decode(Color), p_args[4].decode(bool))
 
-method drawRectRegion*(self: Texture2D; toCanvasItem: RID; rect: Rect2; srcRect: Rect2; modulate: Color; transpose: bool; clipUv: bool): void {.base.} = (discard)
+method drawRectRegion*(self: Texture2D; canvasItem: RID; rect: Rect2; srcRect: Rect2; modulate: Color = color(1, 1, 1, 1); transpose: bool = false; clipUv: bool = true): void {.base.} =
+  expandMethodBind(className Texture2D, "draw_rect_region", 2963678660)
+  methodbind.ptrcall(self, [getPtr canvasItem, getPtr rect, getPtr srcRect, getPtr modulate, getPtr transpose, getPtr clipUv])
 proc registerVirtual_drawRectRegion*[T: Texture2D](Self: typedesc[T]) =
   Self.vmethods[newStringName"_draw_rect_region"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Texture2D](p_instance).drawRectRegion(p_args[0].decode(RID), p_args[1].decode(Rect2), p_args[2].decode(Rect2), p_args[3].decode(Color), p_args[4].decode(bool), p_args[5].decode(bool))
-
-proc getWidth*(self: Texture2D): int32 =
-  expandMethodBind(className Texture2D, "get_width", 3905245786)
-  var ret: encoded int32
-  methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(int32)
-
-proc getHeight*(self: Texture2D): int32 =
-  expandMethodBind(className Texture2D, "get_height", 3905245786)
-  var ret: encoded int32
-  methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(int32)
 
 proc getSize*(self: Texture2D): Vector2 =
   expandMethodBind(className Texture2D, "get_size", 3341600327)
   var ret: encoded Vector2
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Vector2)
-
-proc hasAlpha*(self: Texture2D): bool =
-  expandMethodBind(className Texture2D, "has_alpha", 36873697)
-  var ret: encoded bool
-  methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(bool)
-
-proc draw*(self: Texture2D; canvasItem: RID; position: Vector2; modulate: Color = color(1, 1, 1, 1); transpose: bool = false): void =
-  expandMethodBind(className Texture2D, "draw", 2729649137)
-  methodbind.ptrcall(self, [getPtr canvasItem, getPtr position, getPtr modulate, getPtr transpose])
-
-proc drawRect*(self: Texture2D; canvasItem: RID; rect: Rect2; tile: bool; modulate: Color = color(1, 1, 1, 1); transpose: bool = false): void =
-  expandMethodBind(className Texture2D, "draw_rect", 3499451691)
-  methodbind.ptrcall(self, [getPtr canvasItem, getPtr rect, getPtr tile, getPtr modulate, getPtr transpose])
-
-proc drawRectRegion*(self: Texture2D; canvasItem: RID; rect: Rect2; srcRect: Rect2; modulate: Color = color(1, 1, 1, 1); transpose: bool = false; clipUv: bool = true): void =
-  expandMethodBind(className Texture2D, "draw_rect_region", 2963678660)
-  methodbind.ptrcall(self, [getPtr canvasItem, getPtr rect, getPtr srcRect, getPtr modulate, getPtr transpose, getPtr clipUv])
 
 proc getImage*(self: Texture2D): gdref Image =
   expandMethodBind(className Texture2D, "get_image", 4190603485)

--- a/src/gdext/classes/gdtexture3d.nim
+++ b/src/gdext/classes/gdtexture3d.nim
@@ -6,71 +6,59 @@ import gdtexture; export gdtexture
 
 expandOnClassImported(Texture3D, Texture)
 
-method getFormat*(self: Texture3D): Image_Format {.base.} = (discard)
-proc registerVirtual_getFormat*[T: Texture3D](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_get_format"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[Texture3D](p_instance).getFormat().encode(r_ret)
-
-method getWidth*(self: Texture3D): int32 {.base.} = (discard)
-proc registerVirtual_getWidth*[T: Texture3D](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_get_width"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[Texture3D](p_instance).getWidth().encode(r_ret)
-
-method getHeight*(self: Texture3D): int32 {.base.} = (discard)
-proc registerVirtual_getHeight*[T: Texture3D](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_get_height"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[Texture3D](p_instance).getHeight().encode(r_ret)
-
-method getDepth*(self: Texture3D): int32 {.base.} = (discard)
-proc registerVirtual_getDepth*[T: Texture3D](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_get_depth"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[Texture3D](p_instance).getDepth().encode(r_ret)
-
-method hasMipmaps*(self: Texture3D): bool {.base.} = (discard)
-proc registerVirtual_hasMipmaps*[T: Texture3D](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_has_mipmaps"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[Texture3D](p_instance).hasMipmaps().encode(r_ret)
-
-method getData*(self: Texture3D): TypedArray[gdref Image] {.base.} = (discard)
-proc registerVirtual_getData*[T: Texture3D](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_get_data"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[Texture3D](p_instance).getData().encode(r_ret)
-
-proc getFormat*(self: Texture3D): Image_Format =
+method getFormat*(self: Texture3D): Image_Format {.base.} =
   expandMethodBind(className Texture3D, "get_format", 3847873762)
   var ret: encoded Image_Format
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Image_Format)
+proc registerVirtual_getFormat*[T: Texture3D](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_get_format"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[Texture3D](p_instance).getFormat().encode(r_ret)
 
-proc getWidth*(self: Texture3D): int32 =
+method getWidth*(self: Texture3D): int32 {.base.} =
   expandMethodBind(className Texture3D, "get_width", 3905245786)
   var ret: encoded int32
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(int32)
+proc registerVirtual_getWidth*[T: Texture3D](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_get_width"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[Texture3D](p_instance).getWidth().encode(r_ret)
 
-proc getHeight*(self: Texture3D): int32 =
+method getHeight*(self: Texture3D): int32 {.base.} =
   expandMethodBind(className Texture3D, "get_height", 3905245786)
   var ret: encoded int32
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(int32)
+proc registerVirtual_getHeight*[T: Texture3D](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_get_height"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[Texture3D](p_instance).getHeight().encode(r_ret)
 
-proc getDepth*(self: Texture3D): int32 =
+method getDepth*(self: Texture3D): int32 {.base.} =
   expandMethodBind(className Texture3D, "get_depth", 3905245786)
   var ret: encoded int32
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(int32)
+proc registerVirtual_getDepth*[T: Texture3D](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_get_depth"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[Texture3D](p_instance).getDepth().encode(r_ret)
 
-proc hasMipmaps*(self: Texture3D): bool =
+method hasMipmaps*(self: Texture3D): bool {.base.} =
   expandMethodBind(className Texture3D, "has_mipmaps", 36873697)
   var ret: encoded bool
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
+proc registerVirtual_hasMipmaps*[T: Texture3D](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_has_mipmaps"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[Texture3D](p_instance).hasMipmaps().encode(r_ret)
 
-proc getData*(self: Texture3D): TypedArray[gdref Image] =
+method getData*(self: Texture3D): TypedArray[gdref Image] {.base.} =
   expandMethodBind(className Texture3D, "get_data", 3995934104)
   var ret: encoded TypedArray[gdref Image]
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(TypedArray[gdref Image])
+proc registerVirtual_getData*[T: Texture3D](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_get_data"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[Texture3D](p_instance).getData().encode(r_ret)
 
 proc createPlaceholder*(self: Texture3D): gdref Resource =
   expandMethodBind(className Texture3D, "create_placeholder", 121922552)

--- a/src/gdext/classes/gdtexturelayered.nim
+++ b/src/gdext/classes/gdtexturelayered.nim
@@ -6,79 +6,65 @@ import gdtexture; export gdtexture
 
 expandOnClassImported(TextureLayered, Texture)
 
-method getFormat*(self: TextureLayered): Image_Format {.base.} = (discard)
-proc registerVirtual_getFormat*[T: TextureLayered](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_get_format"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[TextureLayered](p_instance).getFormat().encode(r_ret)
-
-method getLayeredType*(self: TextureLayered): uint32 {.base.} = (discard)
-proc registerVirtual_getLayeredType*[T: TextureLayered](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_get_layered_type"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[TextureLayered](p_instance).getLayeredType().encode(r_ret)
-
-method getWidth*(self: TextureLayered): int32 {.base.} = (discard)
-proc registerVirtual_getWidth*[T: TextureLayered](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_get_width"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[TextureLayered](p_instance).getWidth().encode(r_ret)
-
-method getHeight*(self: TextureLayered): int32 {.base.} = (discard)
-proc registerVirtual_getHeight*[T: TextureLayered](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_get_height"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[TextureLayered](p_instance).getHeight().encode(r_ret)
-
-method getLayers*(self: TextureLayered): int32 {.base.} = (discard)
-proc registerVirtual_getLayers*[T: TextureLayered](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_get_layers"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[TextureLayered](p_instance).getLayers().encode(r_ret)
-
-method hasMipmaps*(self: TextureLayered): bool {.base.} = (discard)
-proc registerVirtual_hasMipmaps*[T: TextureLayered](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_has_mipmaps"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[TextureLayered](p_instance).hasMipmaps().encode(r_ret)
-
-method getLayerData*(self: TextureLayered; layerIndex: int32): gdref Image {.base.} = (discard)
-proc registerVirtual_getLayerData*[T: TextureLayered](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_get_layer_data"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[TextureLayered](p_instance).getLayerData(p_args[0].decode(int32)).encode(r_ret)
-
-proc getFormat*(self: TextureLayered): Image_Format =
+method getFormat*(self: TextureLayered): Image_Format {.base.} =
   expandMethodBind(className TextureLayered, "get_format", 3847873762)
   var ret: encoded Image_Format
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Image_Format)
+proc registerVirtual_getFormat*[T: TextureLayered](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_get_format"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[TextureLayered](p_instance).getFormat().encode(r_ret)
 
-proc getLayeredType*(self: TextureLayered): TextureLayered_LayeredType =
+method getLayeredType*(self: TextureLayered): uint32 {.base.} =
   expandMethodBind(className TextureLayered, "get_layered_type", 518123893)
-  var ret: encoded TextureLayered_LayeredType
+  var ret: encoded uint32
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TextureLayered_LayeredType)
+  (addr ret).decode_result(uint32)
+proc registerVirtual_getLayeredType*[T: TextureLayered](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_get_layered_type"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[TextureLayered](p_instance).getLayeredType().encode(r_ret)
 
-proc getWidth*(self: TextureLayered): int32 =
+method getWidth*(self: TextureLayered): int32 {.base.} =
   expandMethodBind(className TextureLayered, "get_width", 3905245786)
   var ret: encoded int32
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(int32)
+proc registerVirtual_getWidth*[T: TextureLayered](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_get_width"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[TextureLayered](p_instance).getWidth().encode(r_ret)
 
-proc getHeight*(self: TextureLayered): int32 =
+method getHeight*(self: TextureLayered): int32 {.base.} =
   expandMethodBind(className TextureLayered, "get_height", 3905245786)
   var ret: encoded int32
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(int32)
+proc registerVirtual_getHeight*[T: TextureLayered](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_get_height"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[TextureLayered](p_instance).getHeight().encode(r_ret)
 
-proc getLayers*(self: TextureLayered): int32 =
+method getLayers*(self: TextureLayered): int32 {.base.} =
   expandMethodBind(className TextureLayered, "get_layers", 3905245786)
   var ret: encoded int32
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(int32)
+proc registerVirtual_getLayers*[T: TextureLayered](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_get_layers"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[TextureLayered](p_instance).getLayers().encode(r_ret)
 
-proc hasMipmaps*(self: TextureLayered): bool =
+method hasMipmaps*(self: TextureLayered): bool {.base.} =
   expandMethodBind(className TextureLayered, "has_mipmaps", 36873697)
   var ret: encoded bool
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
+proc registerVirtual_hasMipmaps*[T: TextureLayered](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_has_mipmaps"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[TextureLayered](p_instance).hasMipmaps().encode(r_ret)
 
-proc getLayerData*(self: TextureLayered; layer: int32): gdref Image =
+method getLayerData*(self: TextureLayered; layer: int32): gdref Image {.base.} =
   expandMethodBind(className TextureLayered, "get_layer_data", 3655284255)
   var ret: encoded gdref Image
   methodbind.ptrcall(self, [getPtr layer], addr ret)
   (addr ret).decode_result(gdref Image)
+proc registerVirtual_getLayerData*[T: TextureLayered](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_get_layer_data"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[TextureLayered](p_instance).getLayerData(p_args[0].decode(int32)).encode(r_ret)

--- a/src/gdext/classes/gdtranslation.nim
+++ b/src/gdext/classes/gdtranslation.nim
@@ -6,12 +6,20 @@ import gdresource; export gdresource
 
 expandOnClassImported(Translation, Resource)
 
-method getPluralMessage*(self: Translation; srcMessage: StringName; srcPluralMessage: StringName; n: int32; context: StringName): StringName {.base.} = (discard)
+method getPluralMessage*(self: Translation; srcMessage: StringName; srcPluralMessage: StringName; n: int32; context: StringName = default(StringName)): StringName {.base.} =
+  expandMethodBind(className Translation, "get_plural_message", 229954002)
+  var ret: encoded StringName
+  methodbind.ptrcall(self, [getPtr srcMessage, getPtr srcPluralMessage, getPtr n, getPtr context], addr ret)
+  (addr ret).decode_result(StringName)
 proc registerVirtual_getPluralMessage*[T: Translation](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_plural_message"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Translation](p_instance).getPluralMessage(p_args[0].decode(StringName), p_args[1].decode(StringName), p_args[2].decode(int32), p_args[3].decode(StringName)).encode(r_ret)
 
-method getMessage*(self: Translation; srcMessage: StringName; context: StringName): StringName {.base.} = (discard)
+method getMessage*(self: Translation; srcMessage: StringName; context: StringName = default(StringName)): StringName {.base.} =
+  expandMethodBind(className Translation, "get_message", 1829228469)
+  var ret: encoded StringName
+  methodbind.ptrcall(self, [getPtr srcMessage, getPtr context], addr ret)
+  (addr ret).decode_result(StringName)
 proc registerVirtual_getMessage*[T: Translation](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_message"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Translation](p_instance).getMessage(p_args[0].decode(StringName), p_args[1].decode(StringName)).encode(r_ret)
@@ -33,18 +41,6 @@ proc addMessage*(self: Translation; srcMessage: StringName; xlatedMessage: Strin
 proc addPluralMessage*(self: Translation; srcMessage: StringName; xlatedMessages: PackedStringArray; context: StringName = default(StringName)): void =
   expandMethodBind(className Translation, "add_plural_message", 2356982266)
   methodbind.ptrcall(self, [getPtr srcMessage, getPtr xlatedMessages, getPtr context])
-
-proc getMessage*(self: Translation; srcMessage: StringName; context: StringName = default(StringName)): StringName =
-  expandMethodBind(className Translation, "get_message", 1829228469)
-  var ret: encoded StringName
-  methodbind.ptrcall(self, [getPtr srcMessage, getPtr context], addr ret)
-  (addr ret).decode_result(StringName)
-
-proc getPluralMessage*(self: Translation; srcMessage: StringName; srcPluralMessage: StringName; n: int32; context: StringName = default(StringName)): StringName =
-  expandMethodBind(className Translation, "get_plural_message", 229954002)
-  var ret: encoded StringName
-  methodbind.ptrcall(self, [getPtr srcMessage, getPtr srcPluralMessage, getPtr n, getPtr context], addr ret)
-  (addr ret).decode_result(StringName)
 
 proc eraseMessage*(self: Translation; srcMessage: StringName; context: StringName = default(StringName)): void =
   expandMethodBind(className Translation, "erase_message", 3959009644)

--- a/src/gdext/classes/gdvisualinstance3d.nim
+++ b/src/gdext/classes/gdvisualinstance3d.nim
@@ -6,7 +6,11 @@ import gdnode3d; export gdnode3d
 
 expandOnClassImported(VisualInstance3D, Node3D)
 
-method getAabb*(self: VisualInstance3D): AABB {.base.} = (discard)
+method getAabb*(self: VisualInstance3D): AABB {.base.} =
+  expandMethodBind(className VisualInstance3D, "get_aabb", 1068685055)
+  var ret: encoded AABB
+  methodbind.ptrcall(self, [], addr ret)
+  (addr ret).decode_result(AABB)
 proc registerVirtual_getAabb*[T: VisualInstance3D](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_aabb"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[VisualInstance3D](p_instance).getAabb().encode(r_ret)
@@ -66,12 +70,6 @@ proc isSortingUseAabbCenter*(self: VisualInstance3D): bool =
   var ret: encoded bool
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
-
-proc getAabb*(self: VisualInstance3D): AABB =
-  expandMethodBind(className VisualInstance3D, "get_aabb", 1068685055)
-  var ret: encoded AABB
-  methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(AABB)
 
 template layers*(self: VisualInstance3D): untyped = self.getLayerMask()
 template `layers=`*(self: VisualInstance3D; value) = self.setLayerMask(value)

--- a/src/gdext/classes/gdwindow.nim
+++ b/src/gdext/classes/gdwindow.nim
@@ -9,7 +9,11 @@ expandOnClassImported(Window, Viewport)
 const NotificationVisibilityChanged* = 30
 const NotificationThemeChanged* = 32
 
-method getContentsMinimumSize*(self: Window): Vector2 {.base.} = (discard)
+method getContentsMinimumSize*(self: Window): Vector2 {.base.} =
+  expandMethodBind(className Window, "get_contents_minimum_size", 3341600327)
+  var ret: encoded Vector2
+  methodbind.ptrcall(self, [], addr ret)
+  (addr ret).decode_result(Vector2)
 proc registerVirtual_getContentsMinimumSize*[T: Window](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_contents_minimum_size"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Window](p_instance).getContentsMinimumSize().encode(r_ret)
@@ -227,12 +231,6 @@ proc isEmbedded*(self: Window): bool =
   var ret: encoded bool
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
-
-proc getContentsMinimumSize*(self: Window): Vector2 =
-  expandMethodBind(className Window, "get_contents_minimum_size", 3341600327)
-  var ret: encoded Vector2
-  methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Vector2)
 
 proc setForceNative*(self: Window; forceNative: bool): void =
   expandMethodBind(className Window, "set_force_native", 2586408642)

--- a/src/gdext/classes/gdxrinterfaceextension.nim
+++ b/src/gdext/classes/gdxrinterfaceextension.nim
@@ -151,38 +151,32 @@ proc registerVirtual_getCameraFeedId*[T: XRInterfaceExtension](Self: typedesc[T]
   Self.vmethods[newStringName"_get_camera_feed_id"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[XRInterfaceExtension](p_instance).getCameraFeedId().encode(r_ret)
 
-method getColorTexture*(self: XRInterfaceExtension): RID {.base.} = (discard)
-proc registerVirtual_getColorTexture*[T: XRInterfaceExtension](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_get_color_texture"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[XRInterfaceExtension](p_instance).getColorTexture().encode(r_ret)
-
-method getDepthTexture*(self: XRInterfaceExtension): RID {.base.} = (discard)
-proc registerVirtual_getDepthTexture*[T: XRInterfaceExtension](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_get_depth_texture"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[XRInterfaceExtension](p_instance).getDepthTexture().encode(r_ret)
-
-method getVelocityTexture*(self: XRInterfaceExtension): RID {.base.} = (discard)
-proc registerVirtual_getVelocityTexture*[T: XRInterfaceExtension](Self: typedesc[T]) =
-  Self.vmethods[newStringName"_get_velocity_texture"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[XRInterfaceExtension](p_instance).getVelocityTexture().encode(r_ret)
-
-proc getColorTexture*(self: XRInterfaceExtension): RID =
+method getColorTexture*(self: XRInterfaceExtension): RID {.base.} =
   expandMethodBind(className XRInterfaceExtension, "get_color_texture", 529393457)
   var ret: encoded RID
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(RID)
+proc registerVirtual_getColorTexture*[T: XRInterfaceExtension](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_get_color_texture"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[XRInterfaceExtension](p_instance).getColorTexture().encode(r_ret)
 
-proc getDepthTexture*(self: XRInterfaceExtension): RID =
+method getDepthTexture*(self: XRInterfaceExtension): RID {.base.} =
   expandMethodBind(className XRInterfaceExtension, "get_depth_texture", 529393457)
   var ret: encoded RID
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(RID)
+proc registerVirtual_getDepthTexture*[T: XRInterfaceExtension](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_get_depth_texture"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[XRInterfaceExtension](p_instance).getDepthTexture().encode(r_ret)
 
-proc getVelocityTexture*(self: XRInterfaceExtension): RID =
+method getVelocityTexture*(self: XRInterfaceExtension): RID {.base.} =
   expandMethodBind(className XRInterfaceExtension, "get_velocity_texture", 529393457)
   var ret: encoded RID
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(RID)
+proc registerVirtual_getVelocityTexture*[T: XRInterfaceExtension](Self: typedesc[T]) =
+  Self.vmethods[newStringName"_get_velocity_texture"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
+    errproof: cast[XRInterfaceExtension](p_instance).getVelocityTexture().encode(r_ret)
 
 proc addBlit*(self: XRInterfaceExtension; renderTarget: RID; srcRect: Rect2; dstRect: Rect2i; useLayer: bool; layer: uint32; applyLensDistortion: bool; eyeCenter: Vector2; k1: float64; k2: float64; upscale: float64; aspectRatio: float64): void =
   expandMethodBind(className XRInterfaceExtension, "add_blit", 258596971)


### PR DESCRIPTION
## Summary

This change resolves long-standing identifier conflicts in gdext-nim, ensuring that all Godot API functions can be called correctly from Nim.

## Background

Nim does not allow identifiers to begin with an underscore (`_`), which conflicts with Godot’s naming convention.
In Godot, a common pattern is to define both a public function `A` and a virtual function `_A` to enable polymorphism.
Previously, gdext-nim avoided this issue by removing the leading underscore from virtual function names.
However, this approach introduced a critical side effect.

For some APIs, both `proc A` and `method A` existed after this renaming, leading to compile-time ambiguities whenever both were visible.
This issue remained latent because it only occurred when such functions were explicitly called.

## Solution

This update unifies conflicting definitions by ensuring that:

- When both `proc A` and `method A` share the same signature, copy the code from `proc A` to `method A` and delete `proc A`.
- The resulting single method A behaves correctly and maintains full compatibility with Godot’s virtual call mechanism.

Because all of Godot’s virtual functions have empty default implementations, this consolidation should not cause any behavioral issues.

## Example

Previously, `Control.getTooltip` was implemented as:

```nim
method getTooltip*(self: Control; atPosition: Vector2): String {.base.} = (discard)

proc getTooltip*(self: Control; atPosition: Vector2 = vector2(0, 0)): String =
  expandMethodBind(className Control, "get_tooltip", 2895288280)
  var ret: encoded String
  methodbind.ptrcall(self, [getPtr atPosition], addr ret)
  (addr ret).decode_result(String)
```

After this change, it is unified into a single definition:

```nim
method getTooltip*(self: Control; atPosition: Vector2 = vector2(0, 0)): String {.base.} =
  expandMethodBind(className Control, "get_tooltip", 2895288280)
  var ret: encoded String
  methodbind.ptrcall(self, [getPtr atPosition], addr ret)
  (addr ret).decode_result(String)
```

Functions that only define virtual methods (e.g., `Node.ready`) remain unaffected.

## Impact

- Eliminates identifier conflicts between `proc` and `method` definitions.
- Prevents compile-time ambiguities when calling Godot API functions.
- Aligns gdext-nim more closely with Godot’s intended virtual method structure.