### PR TITLE
[Breaking] Replace `TypedArray[T]` with `Array[T]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Use gdextwiz to create, build, and run your GDExtension projects from the comman
 
 * OS: Linux (Arch) — Author | Mac M2 — @ArikRahman
 * Engine: Godot 4.5.stable.arch_linux | Homebrew Godot 4.4.1 arm64-apple-darwin24.5.0
-* Nim: 2.0.12 | 2.0.14 | 2.0.16 | 2.2.0 | 2.2.2 | 2.2.4 | 2.2.6
+* Nim: 2.2.0 | 2.2.2 | 2.2.4 | 2.2.6
 * CC: gcc version 15.1.1 20250425 (GCC) | clang version 17.0.0
 
 

--- a/coronation/src/coronation/config.nim
+++ b/coronation/src/coronation/config.nim
@@ -530,12 +530,14 @@ const ignoreConf: Table[TypeSym, IgnoreConf] = toTable {
   ts"Rect2i": IgnoreConf(
     constructor: {0..4},
   ),
+  ts"Array": IgnoreConf(
+    constructor: {0..1},
+  ),
 }
 
 proc getignore*(ts: TypeSym): IgnoreConf = ignoreConf.getOrDefault(ts)
 
 const NilUnsafeVariant* = [
   TypeSym"Array",
-  TypeSym"TypedArray",
   TypeSym"Dictionary",
 ]

--- a/coronation/src/coronation/operators/arguments.nim
+++ b/coronation/src/coronation/operators/arguments.nim
@@ -52,21 +52,34 @@ method name*(param: RenderableSelfArgument): VariableSym =
 # Default-Value Calculation #
 # ===========================
 
-proc dbModify*(typeSym: TypeSym): string =
-  let class = classDB.getOrDefault(typeSym, nil)
-  if class == nil: return $typesym
-  if class.json.isRefCounted:
-    "gdref " & $typeSym
+proc dbModify*(typeSym: TypeSym; lookupRefCounted: bool = true): string =
+  if $typeSym == "":
+    "Variant"
+  elif lookupRefCounted:
+    let class = classDB.getOrDefault(typeSym, nil)
+    if class != nil and class.json.isRefCounted:
+      "gdref " & $typeSym
+    else:
+      $typeSym
   else:
     $typeSym
 
+proc dbModify*(param: RenderableParamBase; overrideSym = default(TypeSym); lookupRefCounted: bool = true): string =
+  if overrideSym != TypeSym"":
+    result = dbModify(overrideSym, lookupRefCounted)
+  else:
+    result = dbModify(param.typeSym, lookupRefCounted)
+  if param.typeSym == TypeSym"Array":
+    result.add "["
+    result.add $dbModify param.info.metaType
+    if param.info.metaType == TypeSym"Array":
+      result.add "[Variant]"
+    result.add "]"
+
+
 proc `type`*(param: RenderableParamBase): string =
   var name = "ptr ".repeat(param.info.ptrdepth)
-  name.add dbModify param.typeSym
-  if param.typeSym == TypeSym"TypedArray":
-    name.add "["
-    name.add $dbModify param.info.metaType
-    name.add "]"
+  name.add dbModify param
 
   result = case param.info.attribute
   of ptaNake:
@@ -90,7 +103,7 @@ proc `type`*(param: RenderableSelfArgument): string =
     result.add "typedesc["
   elif param.info.isMutable:
     result.add "var "
-  result.add $param.typeSym
+  result.add dbModify(param, TypeSym"", false)
 
   if param.isStatic:
     result.add "]"
@@ -134,16 +147,10 @@ proc fixDefaultValue(arg: RenderableArgument; value: string) =
       value
 
   else:
-    const withGeneric = [TypeSym"TypedArray"]
-    proc constr(typ: TypeSym): string =
-      $constructorName(typesym) &
-      (if typ in withGeneric: "[" & dbModify(arg.info.metaType) & "]" else: "") &
-      "()"
-    proc constr(typ: TypeSym; expr: string): string =
-      result = $constructorName(typesym) &
-      (if typ in withGeneric: "[" & dbModify(arg.info.metaType) & "]" else: "") &
-      "(" & expr & ")"
-      result = result.multiReplace(("((", "("), ("))", ")"))
+    proc constr(typ: TypeSym; expr: string = ""): string =
+      [dbModify(arg, TypeSym constructorName(typ), false), "(", expr, ")"]
+        .join()
+        .multiReplace(("((", "("), ("))", ")"))
     proc drop(expr: string; typ: TypeSym): string =
       expr.replace($typ, "")
     case typesym
@@ -188,13 +195,6 @@ proc fixDefaultValue(arg: RenderableArgument; value: string) =
         typesym.constr(value.drop(typesym))
 
     of TypeSym"Array":
-      case value
-      of "[]":
-        typesym.constr()
-      else:
-        value
-
-    of TypeSym"TypedArray":
       typesym.constr()
 
     of TypeSym"Dictionary":
@@ -262,7 +262,7 @@ proc preconvert*(param: RenderableParamBase; basetype: Option[string]) =
       break
   if basetype.startsWith "typedarray::":
     param.info.metaType = basetype["typedarray::".len..^1].convert(TypeSym)
-    basetype = "TypedArray"
+    basetype = "Array"
 
   if basetype.find("void") != -1:
     basetype = "pointer"

--- a/coronation/src/coronation/operators/builtinclasses/constructors.nim
+++ b/coronation/src/coronation/operators/builtinclasses/constructors.nim
@@ -47,7 +47,7 @@ proc weave_constructor*(self: JsonBuiltinClass): Cloth =
         weave multiline:
           &"var {constr}: array[{self.constructors.len}, PtrConstructor]"
           &"proc load_{typesym}_constructor {{.execon: staticevents.init_engine.on_load_builtinclassConstructor.}} ="
-          &"  for i in {idxRange}:"
+          &"  for i in 0..{self.constructors.high}:"
           &"    {constr}[i] = interface_Variant_getPtrConstructor(VariantType_{typesym}, int32 i)"
       weave multiline:
         for i, constructor in self.constructors:

--- a/coronation/src/coronation/utils.nim
+++ b/coronation/src/coronation/utils.nim
@@ -27,7 +27,6 @@ method apply(style: Comment; data: Data): Data =
 
 const withNew = [
   TypeSym"Array",
-  TypeSym"TypedArray",
   TypeSym"PackedByteArray",
   TypeSym"PackedColorArray",
   TypeSym"PackedStringArray",

--- a/gdext.nimble
+++ b/gdext.nimble
@@ -13,7 +13,7 @@ binDir        = "bin"
 
 # Dependencies
 
-requires "nim >= 2.0.12"
+requires "nim >= 2.2.0"
 
 when fileExists("tasks.nims"):
   include "tasks.nims"

--- a/src/gdext/appearances.nim
+++ b/src/gdext/appearances.nim
@@ -116,7 +116,7 @@ proc appearance*(T: typedesc[range]): Appearance =
   Appearance(
     hint: propertyHintRange,
     hintstring: newGdString hintstring)
-proc appearance*[T](_: typedesc[TypedArray[T]]): Appearance =
+proc appearance*[T](_: typedesc[Array[T]]): Appearance =
   var elementApp = T.appearance
   let typ = T.variantType.ord
   let hint = (if elementApp.hint == propertyHintNone: "" else: "/" & $elementApp.hint.ord)

--- a/src/gdext/arraytools.nim
+++ b/src/gdext/arraytools.nim
@@ -170,30 +170,68 @@ iterator mpairs*[T: SomeBuiltins or Variant](arr: var Array[T]): (int, var T) =
 template toOpenArray*(arr: Array): openArray[Variant] =
   cast[UncheckedArray[Variant]](addr arr[0]).toOpenArray(0, arr.size-1)
 
-# func `+`*[T](left, right: TypedArray[T]): TypedArray[T] =
-#   TypedArray[T](left + right)
+proc size*[T](self: Array[T]): Int =
+  nilCheck self
+  self.wild.size()
+proc isEmpty*[T](self: Array[T]): bool =
+  nilCheck self
+  self.wild.isEmpty()
+proc clear*[T](self: var Array[T]): void =
+  nilCheck self
+  self.wild.clear()
+proc hash*[T](self: Array[T]): Hash =
+  nilCheck self
+  self.wild.hash()
+proc assign*[T,S](self: var Array[T]; other: Array[S]): void =
+  nilCheck self
+  nilCheck other
+  self.wild.assign(other.wild)
+proc assign*[T: not Variant; S: not T](self: var Array[T]; other: Array[S]): void {.error.}
 proc get*[T](self: Array[T]; index: Int): T =
   nilCheck self
   self.wild.get(index).get(T)
 proc set*[T](self: var Array[T]; index: Int; value: T): void =
   nilCheck self
   self.wild.set(index, variant value)
+proc set*[T: SomeProperty](self: var Array[Variant]; index: Int; value: T): void =
+  self.set(index, variant value)
 proc pushBack*[T](self: var Array[T]; value: T): void =
   nilCheck self
   self.wild.pushBack(variant value)
+proc pushBack*[T: SomeProperty](self: var Array[Variant]; value: T): void =
+  self.pushBack(variant value)
 proc pushFront*[T](self: var Array[T]; value: T): void =
   nilCheck self
   self.wild.pushFront(variant value)
+proc pushFront*[T: SomeProperty](self: var Array[Variant]; value: T): void =
+  self.pushFront(variant value)
 proc append*[T](self: var Array[T]; value: T): void =
   nilCheck self
   self.wild.append(variant value)
+proc append*[T: SomeProperty](self: var Array[Variant]; value: T): void =
+  self.append(variant value)
+proc appendArray*[T, S](self: var Array[T]; array: Array[S]): void =
+  nilCheck self
+  nilCheck array
+  self.wild.appendArray(array.wild)
+proc appendArray*[T: not Variant; S: not T](self: var Array[T]; array: Array[S]): void {.error.}
+proc resize*[T](self: var Array[T]; size: Int): Int =
+  nilCheck self
+  self.wild.resize(size)
 proc insert*[T](self: var Array[T]; position: Int; value: T): Int =
   nilCheck self
   self.wild.insert(position, variant value)
+proc insert*[T: SomeProperty](self: var Array[Variant]; index: Int; value: T): Int =
+  self.insert(index, variant value)
+proc removeAt*[T](self: var Array[T]; position: Int): void =
+  nilCheck self
+  self.wild.removeAt(position)
 proc fill*[T](self: var Array[T]; value: T): void =
   nilCheck self
   self.wild.fill(variant value)
-proc erase*[T](self: var Array[T]; value: T): void =
+proc fill*[T: SomeProperty](self: var Array[Variant]; value: T): void =
+  self.fill(variant value)
+proc erase*[T; S: SomeProperty](self: var Array[T]; value: S): void =
   nilCheck self
   self.wild.erase(variant value)
 proc front*[T](self: Array[T]): T =
@@ -205,18 +243,22 @@ proc back*[T](self: Array[T]): T =
 proc pickRandom*[T](self: Array[T]): T =
   nilCheck self
   self.wild.pickRandom().get(T)
-proc find*[T](self: Array[T]; what: T; `from`: Int = 0): Int =
+proc find*[T; S: SomeProperty](self: Array[T]; what: S; `from`: Int = 0): Int =
   nilCheck self
   self.wild.find(variant what, `from`)
-# proc findCustom*[T](self: TypedArray[T]; `method`: Callable; `from`: Int = 0): Int =
-proc rfind*[T](self: Array[T]; what: T; `from`: Int = -1): Int =
+proc findCustom*[T](self: Array[T]; `method`: Callable; `from`: Int = 0): Int =
   nilCheck self
-  self.wild.rFind(variant what, `from`)
-# proc rfindCustom*[T](self: TypedArray[T]; `method`: Callable; `from`: Int = -1): Int =
-proc count*[T](self: Array[T]; value: T): Int =
+  self.wild.findCustom(`method`, `from`)
+proc rfind*[T; S: SomeProperty](self: Array[T]; what: S; `from`: Int = -1): Int =
+  nilCheck self
+  self.wild.rfind(variant what, `from`)
+proc rfindCustom*[T](self: Array[T]; `method`: Callable; `from`: Int = -1): Int =
+  nilCheck self
+  self.wild.rfindCustom(`method`, `from`)
+proc count*[T; S: SomeProperty](self: Array[T]; value: S): Int =
   nilCheck self
   self.wild.count(variant value)
-proc has*[T](self: Array[T]; value: T): bool =
+proc has*[T; S: SomeProperty](self: Array[T]; value: S): bool =
   nilCheck self
   self.wild.has(variant value)
 proc popBack*[T](self: var Array[T]): T =
@@ -228,32 +270,76 @@ proc popFront*[T](self: var Array[T]): T =
 proc popAt*[T](self: var Array[T]; position: Int): T =
   nilCheck self
   self.wild.popAt(position).get(T)
-# proc sortCustom*[T](self: var TypedArray[T]; `func`: Callable): void =
-proc bsearch*[T](self: Array[T]; value: T; before: bool = true): Int =
+proc sort*[T](self: var Array[T]): void =
+  nilCheck self
+  self.wild.sort()
+proc sortCustom*[T](self: var Array[T]; `func`: Callable): void =
+  nilCheck self
+  self.wild.sortCustom(`func`)
+proc shuffle*[T](self: var Array[T]): void =
+  nilCheck self
+  self.wild.shuffle()
+proc bsearch*[T; S: SomeProperty](self: Array[T]; value: S; before: bool = true): Int =
   nilCheck self
   self.wild.bsearch(variant value, before)
-proc bsearchCustom*[T](self: Array[T]; value: T; `func`: Callable; before: bool = true): Int =
+proc bsearchCustom*[T; S: SomeProperty](self: Array[T]; value: S; `func`: Callable; before: bool = true): Int =
   nilCheck self
   self.wild.bsearchCustom(variant value, `func`, before)
+proc reverse*[T](self: var Array[T]): void =
+  nilCheck self
+  self.wild.reverse()
 proc duplicate*[T](self: Array[T]; deep: bool = false): Array[T] =
   nilCheck self
   self.wild.duplicate().specified(T)
+proc duplicateDeep*[T](self: Array[T]; deepSubresourcesMode: Int = 1): Array[T] =
+  nilCheck self
+  self.wild.duplicateDeep(deepSubresourcesMode).specified(T)
 proc slice*[T](self: Array[T]; begin: Int; `end`: Int = 2147483647; step: Int = 1; deep: bool = false): Array[T] =
   nilCheck self
   self.wild.slice(begin, `end`, step, deep).specified(T)
 proc filter*[T](self: Array[T]; `method`: Callable): Array[T] =
   nilCheck self
   self.wild.filter(`method`).specified(T)
-# proc map*[T](self: TypedArray[T]; `method`: Callable): Array =
-# proc reduce*[T](self: TypedArray[T]; `method`: Callable; accum: T = default(Variant)): Variant =
-# proc any*[T](self: TypedArray[T]; `method`: Callable): bool =
-# proc all*[T](self: TypedArray[T]; `method`: Callable): bool =
+proc map*[T](self: Array[T]; `method`: Callable): Array[T] =
+  nilCheck self
+  self.wild.map(`method`).specified(T)
+proc reduce*[T](self: Array[T]; `method`: Callable; accum: T = default(Variant)): T =
+  nilCheck self
+  self.wild.reduce(`method`, variant accum).get(T)
+proc any*[T](self: Array[T]; `method`: Callable): bool =
+  nilCheck self
+  self.wild.any(`method`)
+proc all*[T](self: Array[T]; `method`: Callable): bool =
+  nilCheck self
+  self.wild.all(`method`)
 proc max*[T](self: Array[T]): T =
   nilCheck self
   self.wild.max().get(T)
 proc min*[T](self: Array[T]): T =
   nilCheck self
   self.wild.min().get(T)
+proc isTyped*[T](self: Array[T]): bool =
+  nilCheck self
+  self.wild.isTyped()
+proc isSameTyped*[T,S](self: Array[T]; array: Array[S]): bool =
+  nilCheck self
+  nilCheck array
+  self.wild.isSameTyped(array.wild)
+proc getTypedBuiltin*[T](self: Array[T]): Int =
+  nilCheck self
+  self.wild.getTypedBuiltin()
+proc getTypedClassName*[T](self: Array[T]): StringName =
+  nilCheck self
+  self.wild.getTypedClassName()
+proc getTypedScript*[T](self: Array[T]): Variant =
+  nilCheck self
+  self.wild.getTypedScript()
+proc makeReadOnly*[T](self: var Array[T]): void =
+  nilCheck self
+  self.wild.makeReadOnly()
+proc isReadOnly*[T](self: Array[T]): bool =
+  nilCheck self
+  self.wild.isReadOnly()
 
 # PackedArray
 # ===========

--- a/src/gdext/arraytools.nim
+++ b/src/gdext/arraytools.nim
@@ -3,13 +3,6 @@
 ##
 ## A standard collection of Variants provided by Godot that holds values of any type whose conversion to Variant is supported.
 ##
-## TypedArray\[SomeVariant\]
-## =========================
-##
-## Array that to be statically typed. Internally, it is the same as Array since that uses Variant for the element type, but the type is statically checked. (Attempting to add a `Texture2D` to a `TypedArray[Node]` will result in a compile error.)
-##
-## A good alternative if you want to use Array's API under a static type system.
-##
 ## PackedArray
 ## ===========
 ##
@@ -67,12 +60,32 @@ include gdext/gen/gdpackedvector2array
 include gdext/gen/gdpackedvector3array
 include gdext/gen/gdpackedvector4array
 
-template checkBoundsIsNil(self) =
-  if cast[pointer](self) == nil:
-    raise newException(IndexDefect, "index out of bounds, the container is empty")
-template checkBounds(self: Array | TypedArray; index: int) =
-  checkBoundsIsNil self
-  let size = self.size
+proc wild[T](self: Array[T]): Array[Variant] =
+  when T is Variant:
+    return self
+  else:
+    return cast[ptr Array[Variant]](addr self)[]
+
+proc wild[T](self: var Array[T]): var Array[Variant] =
+  when T is Variant:
+    return self
+  else:
+    return cast[ptr Array[Variant]](addr self)[]
+
+proc specified[T](self: Array[Variant]; Type: typedesc[T]): Array[T] =
+  when T is Variant:
+    return self
+  else:
+    return cast[ptr Array[T]](addr self)[]
+
+proc specified[T](self: var Array[Variant]; Type: typedesc[T]): var Array[T] =
+  when T is Variant:
+    return self
+  else:
+    return cast[ptr Array[T]](addr self)[]
+
+template checkBounds[T](self: Array[T]; index: int) =
+  let size = self.wild.size
   if size == 0:
     raise newException(IndexDefect, "index out of bounds, the container is empty")
   if size <= index:
@@ -84,25 +97,52 @@ template checkBounds(self: PackedArray; index: int) =
   if size <= index:
     raise newException(IndexDefect, "index " & $index & " not in 0 .. " & $size.pred)
 
-proc `[]`*(self: Array; index: Natural): Variant =
+proc `[]`*[T](self: Array[T]; index: Natural): T =
+  nilCheck self
   checkBounds self, index
-  cast[ptr Variant](interface_Array_operatorIndexConst(addr self, index))[]
-proc `[]`*(self: var Array; index: Natural): var Variant =
-  checkBounds self, index
-  cast[ptr Variant](interface_Array_operatorIndex(addr self, index))[]
-proc `[]=`*(self: var Array; index: Natural; value: sink Variant) =
-  checkBounds self, index
-  `[]`(self, index) = value
+  cast[ptr Variant](interface_Array_operatorIndexConst(addr self, index))[].get(T)
 
-proc `[]`*[T](self: TypedArray[T]; index: Natural): T =
-  checkBounds self.Array, index
-  self.Array[index].get(T)
-proc `[]`*[T: SomeBuiltins](self: var TypedArray[T]; index: Natural): var T =
-  checkBounds self.Array, index
-  self.Array[index].getAddr(T)[]
-proc `[]=`*[T](self: var TypedArray[T]; index: Natural; value: sink T) =
-  checkBounds self.Array, index
-  `[]`(Array(self), index) = variant(value)
+proc `[]`*[T: SomeBuiltins or Variant](self: var Array[T]; index: Natural): var T =
+  nilCheck self
+  checkBounds self, index
+  when T is Variant:
+    cast[ptr Variant](interface_Array_operatorIndex(addr self, index))[]
+  else:
+    cast[ptr Variant](interface_Array_operatorIndex(addr self, index))[].getAddr(T)[]
+
+proc `[]=`*[T](self: var Array[T]; index: Natural; value: sink T) =
+  nilCheck self
+  checkBounds self, index
+  when T is Variant:
+    cast[ptr Variant](interface_Array_operatorIndex(addr self, index))[] = value
+  else:
+    cast[ptr Variant](interface_Array_operatorIndex(addr self, index))[] = variant value
+
+proc newArray*[T](): Array[T] =
+  Array_constr[0](addr result, nil)
+  when T isnot Variant:
+    result.setTyped(T.variantType, T.className, Variant())
+
+proc newArray*[T](`from`: Array[T]): Array[T] =
+  let argArr = [getPtr `from`]
+  Array_constr[1](addr result, addr argArr[0])
+
+proc newArray*[T](arr: Array[Variant]): Array[T] =
+  newArray(arr, Int T.variantType, T.className, Variant()).specified(T)
+
+proc newArray*[T](len: Natural): Array[T] =
+  result = newArray[T]()
+  discard result.wild.resize(Int len)
+
+proc newArray*[T](s: openArray[T]): Array[T] =
+  result = newArray[T](s.len)
+  for i in 0..<s.len:
+    result[i] = s[i]
+
+func `==`*[T, S](a: Array[T]; b: Array[S]): bool = a.wild == b.wild
+func `<`*[T, S](a: Array[T]; b: Array[S]): bool = a.wild < b.wild
+func `<=`*[T, S](a: Array[T]; b: Array[S]): bool = a.wild <= b.wild
+func `+`*[T](a: Array[T]; b: Array[T]): Array[T] = a.wild + b.wild
 
 proc `[]`*[T](self: PackedArray[T]; index: Natural): T =
   checkBounds self, index
@@ -117,201 +157,103 @@ proc `[]=`*[T](self: var PackedArray[T]; index: Natural; value: sink T) =
 # Array
 # =====
 
-proc newArray*(len: Natural): Array =
-  result = newArray()
-  discard result.resize(len)
+iterator items*[T](arr: Array[T]): T =
+  for i in 0..<arr.wild.size: yield arr[i]
+iterator pairs*[T](arr: Array[T]): (int, T) =
+  for i in 0..<arr.wild.size: yield (int i, arr[i])
 
-proc newArray*[T](s: openArray[T]): Array =
-  result = newArray(s.len)
-  for i in 0..<s.len:
-    result[i] = variant s[i]
-
-iterator items*(arr: Array): Variant =
-  for i in 0..<arr.size: yield arr[i]
-iterator pairs*(arr: Array): (int, Variant) =
-  for i in 0..<arr.size: yield (int i, arr[i])
-
-iterator mitems*(arr: var Array): var Variant =
-  for i in 0..<arr.size: yield arr[i]
-iterator mpairs*(arr: var Array): (int, var Variant) =
-  for i in 0..<arr.size: yield (int i, arr[i])
+iterator mitems*[T: SomeBuiltins or Variant](arr: var Array[T]): var T =
+  for i in 0..<arr.wild.size: yield arr[i]
+iterator mpairs*[T: SomeBuiltins or Variant](arr: var Array[T]): (int, var T) =
+  for i in 0..<arr.wild.size: yield (int i, arr[i])
 
 template toOpenArray*(arr: Array): openArray[Variant] =
   cast[UncheckedArray[Variant]](addr arr[0]).toOpenArray(0, arr.size-1)
 
-# TypedArray
-# ==========
-
-proc newTypedArray*[T](arr: Array): TypedArray[T] =
-  TypedArray[T] newArray(arr, Int T.variantType, T.className, Variant())
-
-proc newTypedArray*[T](arr: TypedArray[T]): TypedArray[T] =
-  TypedArray[T] newArray(arr.Array)
-
-proc newTypedArray*[T](): TypedArray[T] =
-  result = TypedArray[T] newArray()
-  result.Array.setTyped(T.variantType, T.className, Variant())
-
-proc newTypedArray*[T](len: Natural): TypedArray[T] =
-  result = newTypedArray[T]()
-  discard result.Array.resize(len)
-
-proc newTypedArray*[T](s: openArray[T]): TypedArray[T] =
-  result = newTypedArray[T](s.len)
-  for i in 0..<s.len:
-    result[i] = s[i]
-
-template typedArray*[T](arr: Array): TypedArray[T] {.deprecated: "use newTypedArray instead".} =
-  newTypedArray[T](arr)
-template typedArray*[T](): TypedArray[T] {.deprecated: "use newTypedArray instead".} =
-  newTypedArray[T]()
-template typedArray*[T](len: Natural): TypedArray[T] {.deprecated: "use newTypedArray instead".} =
-  newTypedArray[T](len)
-
-iterator items*[T](arr: TypedArray[T]): T =
-  for i in 0..<arr.size: yield arr[i]
-iterator pairs*[T](arr: TypedArray[T]): (int, T) =
-  for i in 0..<arr.size: yield (int i, arr[i])
-
-iterator mitems*[T](arr: var TypedArray[T]): var T =
-  when T is Object or T is GdRef:
-    {.error: "mutable items for " & $T & " is unavailable; use items instead".}
-  for v in arr.Array.mitems: yield v.getAddr(T)[]
-iterator mpairs*[T](arr: var TypedArray[T]): (int, var T) =
-  when T is Object or T is GdRef:
-    {.error: "mutable pairs for " & $T & " is unavailable; use pairs instead".}
-  for i, v in arr.Array.mpairs: yield (i, v.getAddr(T)[])
-
-
 # func `+`*[T](left, right: TypedArray[T]): TypedArray[T] =
 #   TypedArray[T](left + right)
-proc get*[T](self: var TypedArray[T]; index: Int): T =
+proc get*[T](self: Array[T]; index: Int): T =
   nilCheck self
-  self.Array.get(index).get(T)
-proc get*[T](self: TypedArray[T]; index: Int): T =
+  self.wild.get(index).get(T)
+proc set*[T](self: var Array[T]; index: Int; value: T): void =
   nilCheck self
-  self.Array.get(index).get(T)
-proc set*[T](self: var TypedArray[T]; index: Int; value: T): void =
+  self.wild.set(index, variant value)
+proc pushBack*[T](self: var Array[T]; value: T): void =
   nilCheck self
-  self.Array.set(index, variant value)
-proc pushBack*[T](self: var TypedArray[T]; value: T): void =
+  self.wild.pushBack(variant value)
+proc pushFront*[T](self: var Array[T]; value: T): void =
   nilCheck self
-  self.Array.pushBack(variant value)
-proc pushFront*[T](self: var TypedArray[T]; value: T): void =
+  self.wild.pushFront(variant value)
+proc append*[T](self: var Array[T]; value: T): void =
   nilCheck self
-  self.Array.pushFront(variant value)
-proc append*[T](self: var TypedArray[T]; value: T): void =
+  self.wild.append(variant value)
+proc insert*[T](self: var Array[T]; position: Int; value: T): Int =
   nilCheck self
-  self.Array.append(variant value)
-proc insert*[T](self: var TypedArray[T]; position: Int; value: T): Int =
+  self.wild.insert(position, variant value)
+proc fill*[T](self: var Array[T]; value: T): void =
   nilCheck self
-  self.Array.insert(position, variant value)
-proc fill*[T](self: var TypedArray[T]; value: T): void =
+  self.wild.fill(variant value)
+proc erase*[T](self: var Array[T]; value: T): void =
   nilCheck self
-  self.Array.fill(variant value)
-proc erase*[T](self: var TypedArray[T]; value: T): void =
+  self.wild.erase(variant value)
+proc front*[T](self: Array[T]): T =
   nilCheck self
-  self.Array.erase(variant value)
-proc front*[T](self: var TypedArray[T]): T =
+  self.wild.front().get(T)
+proc back*[T](self: Array[T]): T =
   nilCheck self
-  self.Array.front().get(T)
-proc front*[T](self: TypedArray[T]): T =
+  self.wild.back().get(T)
+proc pickRandom*[T](self: Array[T]): T =
   nilCheck self
-  self.Array.front().get(T)
-proc back*[T](self: var TypedArray[T]): T =
+  self.wild.pickRandom().get(T)
+proc find*[T](self: Array[T]; what: T; `from`: Int = 0): Int =
   nilCheck self
-  self.Array.back().get(T)
-proc back*[T](self: TypedArray[T]): T =
-  nilCheck self
-  self.Array.back().get(T)
-proc pickRandom*[T](self: var TypedArray[T]): T =
-  nilCheck self
-  self.Array.pickRandom().get(T)
-proc pickRandom*[T](self: TypedArray[T]): T =
-  nilCheck self
-  self.Array.pickRandom().get(T)
-proc find*[T](self: var TypedArray[T]; what: T; `from`: Int = 0): Int =
-  nilCheck self
-  self.Array.find(variant what, `from`)
-proc find*[T](self: TypedArray[T]; what: T; `from`: Int = 0): Int =
-  nilCheck self
-  self.Array.find(variant what, `from`)
+  self.wild.find(variant what, `from`)
 # proc findCustom*[T](self: TypedArray[T]; `method`: Callable; `from`: Int = 0): Int =
-proc rfind*[T](self: var TypedArray[T]; what: T; `from`: Int = -1): Int =
+proc rfind*[T](self: Array[T]; what: T; `from`: Int = -1): Int =
   nilCheck self
-  self.Array.rFind(variant what, `from`)
-proc rfind*[T](self: TypedArray[T]; what: T; `from`: Int = -1): Int =
-  nilCheck self
-  self.Array.rFind(variant what, `from`)
+  self.wild.rFind(variant what, `from`)
 # proc rfindCustom*[T](self: TypedArray[T]; `method`: Callable; `from`: Int = -1): Int =
-proc count*[T](self: var TypedArray[T]; value: T): Int =
+proc count*[T](self: Array[T]; value: T): Int =
   nilCheck self
-  self.Array.count(variant value)
-proc count*[T](self: TypedArray[T]; value: T): Int =
+  self.wild.count(variant value)
+proc has*[T](self: Array[T]; value: T): bool =
   nilCheck self
-  self.Array.count(variant value)
-proc has*[T](self: var TypedArray[T]; value: T): bool =
+  self.wild.has(variant value)
+proc popBack*[T](self: var Array[T]): T =
   nilCheck self
-  self.Array.has(variant value)
-proc has*[T](self: TypedArray[T]; value: T): bool =
+  self.wild.popBack().get(T)
+proc popFront*[T](self: var Array[T]): T =
   nilCheck self
-  self.Array.has(variant value)
-proc popBack*[T](self: var TypedArray[T]): T =
+  self.wild.popFront().get(T)
+proc popAt*[T](self: var Array[T]; position: Int): T =
   nilCheck self
-  self.Array.popBack().get(T)
-proc popFront*[T](self: var TypedArray[T]): T =
-  nilCheck self
-  self.Array.popFront().get(T)
-proc popAt*[T](self: var TypedArray[T]; position: Int): T =
-  nilCheck self
-  self.Array.popAt(position).get(T)
+  self.wild.popAt(position).get(T)
 # proc sortCustom*[T](self: var TypedArray[T]; `func`: Callable): void =
-proc bsearch*[T](self: var TypedArray[T]; value: T; before: bool = true): Int =
+proc bsearch*[T](self: Array[T]; value: T; before: bool = true): Int =
   nilCheck self
-  self.Array.bsearch(variant value, before)
-proc bsearch*[T](self: TypedArray[T]; value: T; before: bool = true): Int =
+  self.wild.bsearch(variant value, before)
+proc bsearchCustom*[T](self: Array[T]; value: T; `func`: Callable; before: bool = true): Int =
   nilCheck self
-  self.Array.bsearch(variant value, before)
-proc bsearchCustom*[T](self: var TypedArray[T]; value: T; `func`: Callable; before: bool = true): Int =
+  self.wild.bsearchCustom(variant value, `func`, before)
+proc duplicate*[T](self: Array[T]; deep: bool = false): Array[T] =
   nilCheck self
-  self.Array.bsearchCustom(variant value, `func`, before)
-proc bsearchCustom*[T](self: TypedArray[T]; value: T; `func`: Callable; before: bool = true): Int =
+  self.wild.duplicate().specified(T)
+proc slice*[T](self: Array[T]; begin: Int; `end`: Int = 2147483647; step: Int = 1; deep: bool = false): Array[T] =
   nilCheck self
-  self.Array.bsearchCustom(variant value, `func`, before)
-proc duplicate*[T](self: var TypedArray[T]; deep: bool = false): TypedArray[T] =
+  self.wild.slice(begin, `end`, step, deep).specified(T)
+proc filter*[T](self: Array[T]; `method`: Callable): Array[T] =
   nilCheck self
-  TypedArray[T](self.Array.duplicate())
-proc duplicate*[T](self: TypedArray[T]; deep: bool = false): TypedArray[T] =
-  nilCheck self
-  TypedArray[T](self.Array.duplicate())
-proc slice*[T](self: var TypedArray[T]; begin: Int; `end`: Int = 2147483647; step: Int = 1; deep: bool = false): TypedArray[T] =
-  nilCheck self
-  TypedArray[T](self.Array.slice(begin, `end`, step, deep))
-proc slice*[T](self: TypedArray[T]; begin: Int; `end`: Int = 2147483647; step: Int = 1; deep: bool = false): TypedArray[T] =
-  nilCheck self
-  TypedArray[T](self.Array.slice(begin, `end`, step, deep))
-proc filter*[T](self: var TypedArray[T]; `method`: Callable): TypedArray[T] =
-  nilCheck self
-  TypedArray[T](self.Array.filter(`method`))
-proc filter*[T](self: TypedArray[T]; `method`: Callable): TypedArray[T] =
-  nilCheck self
-  TypedArray[T](self.Array.filter(`method`))
+  self.wild.filter(`method`).specified(T)
 # proc map*[T](self: TypedArray[T]; `method`: Callable): Array =
 # proc reduce*[T](self: TypedArray[T]; `method`: Callable; accum: T = default(Variant)): Variant =
 # proc any*[T](self: TypedArray[T]; `method`: Callable): bool =
 # proc all*[T](self: TypedArray[T]; `method`: Callable): bool =
-proc max*[T](self: var TypedArray[T]): T =
+proc max*[T](self: Array[T]): T =
   nilCheck self
-  self.Array.max().get(T)
-proc max*[T](self: TypedArray[T]): T =
+  self.wild.max().get(T)
+proc min*[T](self: Array[T]): T =
   nilCheck self
-  self.Array.max().get(T)
-proc min*[T](self: var TypedArray[T]): T =
-  nilCheck self
-  self.Array.min().get(T)
-proc min*[T](self: TypedArray[T]): T =
-  nilCheck self
-  self.Array.min().get(T)
+  self.wild.min().get(T)
 
 # PackedArray
 # ===========
@@ -407,38 +349,23 @@ proc `@`*[T](arr: PackedArray[T]): seq[T] =
 {.push, inline.}
 
 # `&`
-func `&`*(x, y: Array): Array = x + y
-func `&`*[T](x, y: TypedArray[T]): TypedArray[T] = x + y
+func `&`*[T](x, y: Array[T]): Array[T] = x + y
 func `&`*[T](x, y: PackedArray[T]) = x + y
 
 # []
-proc `[]`*(arr: Array; index: BackwardsIndex): Variant =
-  checkBoundsIsNil arr
-  arr[arr.size - int(index)]
-proc `[]`*[T](arr: TypedArray[T]; index: BackwardsIndex): T =
-  checkBoundsIsNil arr
+proc `[]`*[T](arr: Array[T]; index: BackwardsIndex): T =
   arr[arr.size - int(index)]
 proc `[]`*[T](arr: PackedArray[T]; index: BackwardsIndex): T =
   arr[arr.size - int(index)]
 
 # var []
-proc `[]`*(arr: var Array; index: BackwardsIndex): var Variant =
-  checkBoundsIsNil arr
+proc `[]`*[T: SomeBuiltins or Variant](arr: var Array[T]; index: BackwardsIndex): var T =
   arr[arr.size - int(index)]
-proc `[]`*[T: not Object and not RefCounted](arr: var TypedArray[T]; index: BackwardsIndex): var T =
-  checkBoundsIsNil arr
-  arr.Array[arr.size - int(index)].getAddr(T)[]
 proc `[]`*[T](arr: var PackedArray[T]; index: BackwardsIndex): var T =
   arr[arr.size - int(index)]
 
 # [] slice
-proc `[]`*[U, V: Ordinal](arr: Array, x: HSlice[U, V]): Array =
-  checkBoundsIsNil arr
-  when U is BackwardsIndex or V is BackwardsIndex:
-    let size = arr.size
-  arr.slice((size ^^* x.a), succ(size ^^* x.b))
-proc `[]`*[T; U, V: Ordinal](arr: TypedArray[T], x: HSlice[U, V]): TypedArray[T] =
-  checkBoundsIsNil arr
+proc `[]`*[T; U, V: Ordinal](arr: Array[T], x: HSlice[U, V]): Array[T] =
   when U is BackwardsIndex or V is BackwardsIndex:
     let size = arr.size
   arr.slice((size ^^* x.a), succ(size ^^* x.b))
@@ -448,64 +375,42 @@ proc `[]`*[T; U, V: Ordinal](arr: PackedArray[T], x: HSlice[U, V]): PackedArray[
   arr.slice((size ^^* x.a), succ(size ^^* x.b))
 
 # []=
-proc `[]=`*(arr: var Array; index: BackwardsIndex; value: Variant) =
-  checkBoundsIsNil arr
-  arr[arr.size - int(index)] = value
-proc `[]=`*[T](arr: var TypedArray[T]; index: BackwardsIndex; value: T) =
-  checkBoundsIsNil arr
+proc `[]=`*[T](arr: var Array[T]; index: BackwardsIndex; value: T) =
   arr[arr.size - int(index)] = value
 proc `[]=`*[T](arr: var PackedArray[T]; index: BackwardsIndex; value: T) =
   arr[arr.size - int(index)] = value
 
 # contains
-proc contains*(arr: Array; value: Variant): bool =
+proc contains*[T](arr: Array[T]; value: T): bool =
   arr.has(value)
-proc contains*(arr: var Array; value: Variant): bool =
-  arr.has(value)
-proc contains*[T: SomeProperty](arr: Array; value: T): bool =
+proc contains*[T: SomeProperty](arr: Array[Variant]; value: T): bool =
   arr.has(variant value)
-proc contains*[T: SomeProperty](arr: var Array; value: T): bool =
-  arr.has(variant value)
-proc contains*[T](arr: TypedArray[T]; value: T): bool =
-  arr.has(value)
-proc contains*[T](arr: var TypedArray[T]; value: T): bool =
-  arr.has(value)
 proc contains*[T](arr: PackedArray[T]; item: T): bool =
   arr.toOpenArray.contains item
 
 # setLen
 proc setLen*(arr: var Array; newlen: int) =
-  discard arr.resize(newlen)
-template setLen(arr: var TypedArray; newlen: int) =
-  arr.Array.setLen(newlen)
+  discard arr.wild.resize(newlen)
 proc setLen*(arr: var PackedArray; newlen: int) =
   discard arr.resize(newlen)
 
 # len
-proc len*(arr: Array): int = int arr.size
-proc len*(arr: var Array): int = int arr.size
-proc len*(arr: TypedArray): int = int arr.Array.len
-proc len*(arr: var TypedArray): int = int arr.Array.len
+proc len*(arr: Array): int = int arr.wild.size
 proc len*(arr: PackedArray): int = int arr.size
 
 # high
-proc high*(arr: Array): int = int arr.size.pred
-proc high*(arr: var Array): int = int arr.size.pred
+proc high*(arr: Array): int = int arr.wild.size.pred
 proc high*(arr: PackedArray): int = int arr.size.pred
-proc high*(arr: var PackedArray): int = int arr.size.pred
 
 # low
 proc low*(arr: Array): int = 0
 proc low*(arr: PackedArray): int = 0
 
 # add
-proc add*(self: var Array; value: Variant) =
+proc add*[T](self: var Array[T]; value: T) =
   append(self, value)
-proc add*(self: var Array; array: Array) =
+proc add*[T](self: var Array[T]; array: Array[T]) =
   appendArray(self, array)
-
-proc add*[T](self: var TypedArray[T]; value: T) =
-  append(self, value)
 
 proc add*[T](self: var PackedArray[T]; value: T) =
   discard append(self, value)
@@ -520,8 +425,7 @@ proc delete*[T](self: var PackedArray[T]; index: Natural) =
   self.removeAt(index)
 
 # pop
-proc pop*(self: var Array): Variant = self.popBack
-proc pop*[T](self: var TypedArray[T]): T = self.popBack
+proc pop*[T](self: var Array[T]): T = self.popBack
 proc pop*[T](self: var PackedArray[T]): T = self.popBack
 
 # grow
@@ -536,48 +440,24 @@ proc pop*[T](self: var PackedArray[T]): T = self.popBack
 # Ports
 # -----
 
-proc newArray(s: var Array; size: Natural) =
-  privateAccess Array
-  if s.cowdata.isNil:
-    s = newArray(size)
-  else:
-    clear s
-    discard s.resize(size)
-proc newTypedArray[T](s: var TypedArray[T]; size: Natural) =
-  privateAccess Array
-  if s.Array.cowdata.isNil:
-    s = newTypedArray[T](size)
-  else:
-    clear s.Array
-    discard s.Array.resize(size)
+proc newArray[T](s: var Array[T]; size: Natural) =
+  clear s
+  discard s.resize(size)
 
 proc newPackedArray(s: var PackedArray; size: int) =
   clear s
   discard s.resize(size)
 
 
-proc `&`*(x: Array; y: Variant): Array =
+proc `&`*[T](x: Array[T]; y: T): Array[T] =
   let size = x.size
-  newArray(result, size + 1)
+  newArray[T](result, size + 1)
   for i in 0..<size:
     result[i] = x[i]
   result[size] = y
-proc `&`*(x: Variant; y: Array): Array =
+proc `&`*[T](x: T; y: Array[T]): Array[T] =
   let size = y.size
-  newArray(result, size + 1)
-  result[0] = x
-  for i in 0..<size:
-    result[1+i] = y[i]
-
-proc `&`*[T](x: TypedArray; y: T): TypedArray[T] =
-  let size = x.size
-  newTypedArray(result, size + 1)
-  for i in 0..<size:
-    result[i] = x[i]
-  result[size] = y
-proc `&`*[T](x: T; y: TypedArray): TypedArray[T] =
-  let size = y.size
-  newTypedArray(result, size + 1)
+  newArray[T](result, size + 1)
   result[0] = x
   for i in 0..<size:
     result[1+i] = y[i]
@@ -614,15 +494,7 @@ template spliceImpl(s, a, L, b: typed): untyped =
   for i in 0 ..< b.len: s[a+i] = b[i]
   # for i in 1 ..< b.len: s.set(a+i, b.get(i))
 
-proc `[]=`*[U, V: Ordinal](s: var Array; x: HSlice[U, V]; b: Array) =
-  let a = s ^^ x.a
-  let L = (s ^^ x.b) - a + 1
-  if L == b.len:
-    for i in 0 ..< L: s[i+a] = b[i]
-  else:
-    spliceImpl(s, a, L, b)
-
-proc `[]=`*[T; U, V: Ordinal](s: var TypedArray[T]; x: HSlice[U, V]; b: TypedArray[T]) =
+proc `[]=`*[T; U, V: Ordinal](s: var Array[T]; x: HSlice[U, V]; b: Array[T]) =
   let a = s ^^ x.a
   let L = (s ^^ x.b) - a + 1
   if L == b.len:

--- a/src/gdext/builtinindex.nim
+++ b/src/gdext/builtinindex.nim
@@ -95,8 +95,6 @@ type
     cowdata: pointer
   Dictionary* {.byref.} = object
     cowdata: pointer
-  Array* {.byref.} = object
-    cowdata: pointer
 
   PackedByteArray* = PackedArray[byte]
   PackedInt32Array* = PackedArray[int32]
@@ -127,7 +125,8 @@ type
   Callable* {.byref.} = object
     `method`: StringName
     `object`: ObjectID
-  TypedArray*[T: SomeProperty] = distinct Array
+  Array*[T: SomeProperty] {.byref.} = object
+    cowdata: pointer
 
   SomePackedArray* =
     PackedByteArray    |
@@ -188,8 +187,6 @@ type
 
   SomeProperty* = concept x, type t
     t.variantType is VariantType
-    variant(x) is Variant
-    compiles(Variant().get(t))
 
   AltInt* = int|int32|int16|int8|uint64|uint32|uint16|uint8
   AltFloat* = float32
@@ -236,8 +233,6 @@ template variantType*(_: typedesc[PackedVector2Array]): VariantType = VariantTyp
 template variantType*(_: typedesc[PackedVector3Array]): VariantType = VariantType_PackedVector3Array
 template variantType*(_: typedesc[PackedVector4Array]): VariantType = VariantType_PackedVector4Array
 template variantType*(_: typedesc[PackedColorArray]): VariantType = VariantType_PackedColorArray
-
-template variantType*(_: typedesc[TypedArray]): VariantType = VariantType_Array
 
 # Object
 
@@ -344,10 +339,10 @@ proc `=copy`*(dst: var Dictionary; src: Dictionary) =
 proc dup*(src: Array): Array =
   let argPtr = cast[pointer](addr src)
   typeConstructor[VariantTypeArray](addr result, addr argPtr)
-proc `=destroy`*(val {.bycopy.}: Array) {.raises: [Exception].} =
+proc `=destroy`*[T](val {.bycopy.}: Array[T]) {.raises: [Exception].} =
   if val.cowdata.isNil: return
   typeDestructor[VariantTypeArray](addr val)
-proc `=copy`*(dst: var Array; src: Array) =
+proc `=copy`*[T](dst: var Array[T]; src: Array[T]) =
   if dst == src: return
   `=destroy` dst
   wasMoved dst

--- a/src/gdext/classes/gdanimation.nim
+++ b/src/gdext/classes/gdanimation.nim
@@ -232,11 +232,11 @@ proc methodTrackGetName*(self: Animation; trackIdx: int32; keyIdx: int32): Strin
   methodbind.ptrcall(self, [getPtr trackIdx, getPtr keyIdx], addr ret)
   (addr ret).decode_result(StringName)
 
-proc methodTrackGetParams*(self: Animation; trackIdx: int32; keyIdx: int32): Array =
+proc methodTrackGetParams*(self: Animation; trackIdx: int32; keyIdx: int32): Array[Variant] =
   expandMethodBind(className Animation, "method_track_get_params", 2345056839)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr trackIdx, getPtr keyIdx], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc bezierTrackInsertKey*(self: Animation; trackIdx: int32; time: float64; value: Float; inHandle: Vector2 = vector2(0, 0); outHandle: Vector2 = vector2(0, 0)): int32 =
   expandMethodBind(className Animation, "bezier_track_insert_key", 3656773645)

--- a/src/gdext/classes/gdanimationlibrary.nim
+++ b/src/gdext/classes/gdanimationlibrary.nim
@@ -32,11 +32,11 @@ proc getAnimation*(self: AnimationLibrary; name: StringName): gdref Animation =
   methodbind.ptrcall(self, [getPtr name], addr ret)
   (addr ret).decode_result(gdref Animation)
 
-proc getAnimationList*(self: AnimationLibrary): TypedArray[StringName] =
+proc getAnimationList*(self: AnimationLibrary): Array[StringName] =
   expandMethodBind(className AnimationLibrary, "get_animation_list", 3995934104)
-  var ret: encoded TypedArray[StringName]
+  var ret: encoded Array[StringName]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[StringName])
+  (addr ret).decode_result(Array[StringName])
 
 proc getAnimationListSize*(self: AnimationLibrary): int32 =
   expandMethodBind(className AnimationLibrary, "get_animation_list_size", 3905245786)

--- a/src/gdext/classes/gdanimationmixer.nim
+++ b/src/gdext/classes/gdanimationmixer.nim
@@ -37,11 +37,11 @@ proc getAnimationLibrary*(self: AnimationMixer; name: StringName): gdref Animati
   methodbind.ptrcall(self, [getPtr name], addr ret)
   (addr ret).decode_result(gdref AnimationLibrary)
 
-proc getAnimationLibraryList*(self: AnimationMixer): TypedArray[StringName] =
+proc getAnimationLibraryList*(self: AnimationMixer): Array[StringName] =
   expandMethodBind(className AnimationMixer, "get_animation_library_list", 3995934104)
-  var ret: encoded TypedArray[StringName]
+  var ret: encoded Array[StringName]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[StringName])
+  (addr ret).decode_result(Array[StringName])
 
 proc hasAnimation*(self: AnimationMixer; name: StringName): bool =
   expandMethodBind(className AnimationMixer, "has_animation", 2619796661)

--- a/src/gdext/classes/gdanimationnode.nim
+++ b/src/gdext/classes/gdanimationnode.nim
@@ -11,7 +11,7 @@ proc registerVirtual_getChildNodes*[T: AnimationNode](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_child_nodes"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[AnimationNode](p_instance).getChildNodes().encode(r_ret)
 
-method getParameterList*(self: AnimationNode): Array {.base.} = (discard)
+method getParameterList*(self: AnimationNode): Array[Variant] {.base.} = (discard)
 proc registerVirtual_getParameterList*[T: AnimationNode](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_parameter_list"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[AnimationNode](p_instance).getParameterList().encode(r_ret)

--- a/src/gdext/classes/gdanimationnodeblendtree.nim
+++ b/src/gdext/classes/gdanimationnodeblendtree.nim
@@ -45,11 +45,11 @@ proc disconnectNode*(self: AnimationNodeBlendTree; inputNode: StringName; inputI
   expandMethodBind(className AnimationNodeBlendTree, "disconnect_node", 2415702435)
   methodbind.ptrcall(self, [getPtr inputNode, getPtr inputIndex])
 
-proc getNodeList*(self: AnimationNodeBlendTree): TypedArray[StringName] =
+proc getNodeList*(self: AnimationNodeBlendTree): Array[StringName] =
   expandMethodBind(className AnimationNodeBlendTree, "get_node_list", 3995934104)
-  var ret: encoded TypedArray[StringName]
+  var ret: encoded Array[StringName]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[StringName])
+  (addr ret).decode_result(Array[StringName])
 
 proc setNodePosition*(self: AnimationNodeBlendTree; name: StringName; position: Vector2): void =
   expandMethodBind(className AnimationNodeBlendTree, "set_node_position", 1999414630)

--- a/src/gdext/classes/gdanimationnodestatemachine.nim
+++ b/src/gdext/classes/gdanimationnodestatemachine.nim
@@ -40,11 +40,11 @@ proc getNodeName*(self: AnimationNodeStateMachine; node: gdref AnimationNode): S
   methodbind.ptrcall(self, [getPtr node], addr ret)
   (addr ret).decode_result(StringName)
 
-proc getNodeList*(self: AnimationNodeStateMachine): TypedArray[StringName] =
+proc getNodeList*(self: AnimationNodeStateMachine): Array[StringName] =
   expandMethodBind(className AnimationNodeStateMachine, "get_node_list", 3995934104)
-  var ret: encoded TypedArray[StringName]
+  var ret: encoded Array[StringName]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[StringName])
+  (addr ret).decode_result(Array[StringName])
 
 proc setNodePosition*(self: AnimationNodeStateMachine; name: StringName; position: Vector2): void =
   expandMethodBind(className AnimationNodeStateMachine, "set_node_position", 1999414630)

--- a/src/gdext/classes/gdanimationnodestatemachineplayback.nim
+++ b/src/gdext/classes/gdanimationnodestatemachineplayback.nim
@@ -52,8 +52,8 @@ proc getFadingFromNode*(self: AnimationNodeStateMachinePlayback): StringName =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(StringName)
 
-proc getTravelPath*(self: AnimationNodeStateMachinePlayback): TypedArray[StringName] =
+proc getTravelPath*(self: AnimationNodeStateMachinePlayback): Array[StringName] =
   expandMethodBind(className AnimationNodeStateMachinePlayback, "get_travel_path", 3995934104)
-  var ret: encoded TypedArray[StringName]
+  var ret: encoded Array[StringName]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[StringName])
+  (addr ret).decode_result(Array[StringName])

--- a/src/gdext/classes/gdarea2d.nim
+++ b/src/gdext/classes/gdarea2d.nim
@@ -136,17 +136,17 @@ proc isMonitorable*(self: Area2D): bool =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
 
-proc getOverlappingBodies*(self: Area2D): TypedArray[Node2D] =
+proc getOverlappingBodies*(self: Area2D): Array[Node2D] =
   expandMethodBind(className Area2D, "get_overlapping_bodies", 3995934104)
-  var ret: encoded TypedArray[Node2D]
+  var ret: encoded Array[Node2D]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Node2D])
+  (addr ret).decode_result(Array[Node2D])
 
-proc getOverlappingAreas*(self: Area2D): TypedArray[Area2D] =
+proc getOverlappingAreas*(self: Area2D): Array[Area2D] =
   expandMethodBind(className Area2D, "get_overlapping_areas", 3995934104)
-  var ret: encoded TypedArray[Area2D]
+  var ret: encoded Array[Area2D]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Area2D])
+  (addr ret).decode_result(Array[Area2D])
 
 proc hasOverlappingBodies*(self: Area2D): bool =
   expandMethodBind(className Area2D, "has_overlapping_bodies", 36873697)

--- a/src/gdext/classes/gdarea3d.nim
+++ b/src/gdext/classes/gdarea3d.nim
@@ -166,17 +166,17 @@ proc isMonitoring*(self: Area3D): bool =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
 
-proc getOverlappingBodies*(self: Area3D): TypedArray[Node3D] =
+proc getOverlappingBodies*(self: Area3D): Array[Node3D] =
   expandMethodBind(className Area3D, "get_overlapping_bodies", 3995934104)
-  var ret: encoded TypedArray[Node3D]
+  var ret: encoded Array[Node3D]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Node3D])
+  (addr ret).decode_result(Array[Node3D])
 
-proc getOverlappingAreas*(self: Area3D): TypedArray[Area3D] =
+proc getOverlappingAreas*(self: Area3D): Array[Area3D] =
   expandMethodBind(className Area3D, "get_overlapping_areas", 3995934104)
-  var ret: encoded TypedArray[Area3D]
+  var ret: encoded Array[Area3D]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Area3D])
+  (addr ret).decode_result(Array[Area3D])
 
 proc hasOverlappingBodies*(self: Area3D): bool =
   expandMethodBind(className Area3D, "has_overlapping_bodies", 36873697)

--- a/src/gdext/classes/gdarraymesh.nim
+++ b/src/gdext/classes/gdarraymesh.nim
@@ -40,7 +40,7 @@ proc getBlendShapeMode*(self: ArrayMesh): Mesh_BlendShapeMode =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Mesh_BlendShapeMode)
 
-proc addSurfaceFromArrays*(self: ArrayMesh; primitive: Mesh_PrimitiveType; arrays: Array; blendShapes: TypedArray[Array] = newTypedArray[Array](); lods: Dictionary = newDictionary(); flags: set[Mesh_ArrayFormat] = {}): void =
+proc addSurfaceFromArrays*(self: ArrayMesh; primitive: Mesh_PrimitiveType; arrays: Array[Variant]; blendShapes: Array[Array[Variant]] = newArray[Array[Variant]](); lods: Dictionary = newDictionary(); flags: set[Mesh_ArrayFormat] = {}): void =
   expandMethodBind(className ArrayMesh, "add_surface_from_arrays", 1796411378)
   nilCheck arrays
   nilCheck blendShapes

--- a/src/gdext/classes/gdastargrid2d.nim
+++ b/src/gdext/classes/gdastargrid2d.nim
@@ -166,11 +166,11 @@ proc getPointPosition*(self: AStarGrid2D; id: Vector2i): Vector2 =
   methodbind.ptrcall(self, [getPtr id], addr ret)
   (addr ret).decode_result(Vector2)
 
-proc getPointDataInRegion*(self: AStarGrid2D; region: Rect2i): TypedArray[Dictionary] =
+proc getPointDataInRegion*(self: AStarGrid2D; region: Rect2i): Array[Dictionary] =
   expandMethodBind(className AStarGrid2D, "get_point_data_in_region", 3893818462)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr region], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc getPointPath*(self: AStarGrid2D; fromId: Vector2i; toId: Vector2i; allowPartialPath: bool = false): PackedVector2Array =
   expandMethodBind(className AStarGrid2D, "get_point_path", 1641925693)
@@ -178,11 +178,11 @@ proc getPointPath*(self: AStarGrid2D; fromId: Vector2i; toId: Vector2i; allowPar
   methodbind.ptrcall(self, [getPtr fromId, getPtr toId, getPtr allowPartialPath], addr ret)
   (addr ret).decode_result(PackedVector2Array)
 
-proc getIdPath*(self: AStarGrid2D; fromId: Vector2i; toId: Vector2i; allowPartialPath: bool = false): TypedArray[Vector2i] =
+proc getIdPath*(self: AStarGrid2D; fromId: Vector2i; toId: Vector2i; allowPartialPath: bool = false): Array[Vector2i] =
   expandMethodBind(className AStarGrid2D, "get_id_path", 1918132273)
-  var ret: encoded TypedArray[Vector2i]
+  var ret: encoded Array[Vector2i]
   methodbind.ptrcall(self, [getPtr fromId, getPtr toId, getPtr allowPartialPath], addr ret)
-  (addr ret).decode_result(TypedArray[Vector2i])
+  (addr ret).decode_result(Array[Vector2i])
 
 template region*(self: AStarGrid2D): untyped = self.getRegion()
 template `region=`*(self: AStarGrid2D; value) = self.setRegion(value)

--- a/src/gdext/classes/gdaudiostream.nim
+++ b/src/gdext/classes/gdaudiostream.nim
@@ -53,7 +53,7 @@ proc registerVirtual_getTags*[T: AudioStream](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_tags"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[AudioStream](p_instance).getTags().encode(r_ret)
 
-method getParameterList*(self: AudioStream): TypedArray[Dictionary] {.base.} = (discard)
+method getParameterList*(self: AudioStream): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_getParameterList*[T: AudioStream](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_parameter_list"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[AudioStream](p_instance).getParameterList().encode(r_ret)

--- a/src/gdext/classes/gdbitmap.nim
+++ b/src/gdext/classes/gdbitmap.nim
@@ -64,11 +64,11 @@ proc convertToImage*(self: BitMap): gdref Image =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(gdref Image)
 
-proc opaqueToPolygons*(self: BitMap; rect: Rect2i; epsilon: Float = 2.0): TypedArray[PackedVector2Array] =
+proc opaqueToPolygons*(self: BitMap; rect: Rect2i; epsilon: Float = 2.0): Array[PackedVector2Array] =
   expandMethodBind(className BitMap, "opaque_to_polygons", 48478126)
-  var ret: encoded TypedArray[PackedVector2Array]
+  var ret: encoded Array[PackedVector2Array]
   methodbind.ptrcall(self, [getPtr rect, getPtr epsilon], addr ret)
-  (addr ret).decode_result(TypedArray[PackedVector2Array])
+  (addr ret).decode_result(Array[PackedVector2Array])
 
 template data*(self: BitMap): untyped = self.getData()
 template `data=`*(self: BitMap; value) = self.setData(value)

--- a/src/gdext/classes/gdbuttongroup.nim
+++ b/src/gdext/classes/gdbuttongroup.nim
@@ -12,11 +12,11 @@ proc getPressedButton*(self: ButtonGroup): BaseButton =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(BaseButton)
 
-proc getButtons*(self: ButtonGroup): TypedArray[BaseButton] =
+proc getButtons*(self: ButtonGroup): Array[BaseButton] =
   expandMethodBind(className ButtonGroup, "get_buttons", 2915620761)
-  var ret: encoded TypedArray[BaseButton]
+  var ret: encoded Array[BaseButton]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[BaseButton])
+  (addr ret).decode_result(Array[BaseButton])
 
 proc setAllowUnpress*(self: ButtonGroup; enabled: bool): void =
   expandMethodBind(className ButtonGroup, "set_allow_unpress", 2586408642)

--- a/src/gdext/classes/gdcamera3d.nim
+++ b/src/gdext/classes/gdcamera3d.nim
@@ -224,11 +224,11 @@ proc getDopplerTracking*(self: Camera3D): Camera3D_DopplerTracking =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Camera3D_DopplerTracking)
 
-proc getFrustum*(self: Camera3D): TypedArray[Plane] =
+proc getFrustum*(self: Camera3D): Array[Plane] =
   expandMethodBind(className Camera3D, "get_frustum", 3995934104)
-  var ret: encoded TypedArray[Plane]
+  var ret: encoded Array[Plane]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Plane])
+  (addr ret).decode_result(Array[Plane])
 
 proc isPositionInFrustum*(self: Camera3D; worldPoint: Vector3): bool =
   expandMethodBind(className Camera3D, "is_position_in_frustum", 3108956480)

--- a/src/gdext/classes/gdcamerafeed.nim
+++ b/src/gdext/classes/gdcamerafeed.nim
@@ -86,11 +86,11 @@ proc getDatatype*(self: CameraFeed): CameraFeed_FeedDataType =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(CameraFeed_FeedDataType)
 
-proc getFormats*(self: CameraFeed): Array =
+proc getFormats*(self: CameraFeed): Array[Variant] =
   expandMethodBind(className CameraFeed, "get_formats", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc setFormat*(self: CameraFeed; index: int32; parameters: Dictionary): bool =
   expandMethodBind(className CameraFeed, "set_format", 31872775)

--- a/src/gdext/classes/gdcameraserver.nim
+++ b/src/gdext/classes/gdcameraserver.nim
@@ -28,11 +28,11 @@ proc getFeedCount*(self: CameraServer): int32 =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(int32)
 
-proc feeds*(self: CameraServer): TypedArray[gdref CameraFeed] =
+proc feeds*(self: CameraServer): Array[gdref CameraFeed] =
   expandMethodBind(className CameraServer, "feeds", 2915620761)
-  var ret: encoded TypedArray[gdref CameraFeed]
+  var ret: encoded Array[gdref CameraFeed]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref CameraFeed])
+  (addr ret).decode_result(Array[gdref CameraFeed])
 
 proc addFeed*(self: CameraServer; feed: gdref CameraFeed): void =
   expandMethodBind(className CameraServer, "add_feed", 3204782488)

--- a/src/gdext/classes/gdclassdb.nim
+++ b/src/gdext/classes/gdclassdb.nim
@@ -66,17 +66,17 @@ proc classGetSignal*(self: ClassDB; class: StringName; signal: StringName): Dict
   methodbind.ptrcall(self, [getPtr class, getPtr signal], addr ret)
   (addr ret).decode_result(Dictionary)
 
-proc classGetSignalList*(self: ClassDB; class: StringName; noInheritance: bool = false): TypedArray[Dictionary] =
+proc classGetSignalList*(self: ClassDB; class: StringName; noInheritance: bool = false): Array[Dictionary] =
   expandMethodBind(className ClassDB, "class_get_signal_list", 3504980660)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr class, getPtr noInheritance], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
-proc classGetPropertyList*(self: ClassDB; class: StringName; noInheritance: bool = false): TypedArray[Dictionary] =
+proc classGetPropertyList*(self: ClassDB; class: StringName; noInheritance: bool = false): Array[Dictionary] =
   expandMethodBind(className ClassDB, "class_get_property_list", 3504980660)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr class, getPtr noInheritance], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc classGetPropertyGetter*(self: ClassDB; class: StringName; property: StringName): StringName =
   expandMethodBind(className ClassDB, "class_get_property_getter", 3770832642)
@@ -120,11 +120,11 @@ proc classGetMethodArgumentCount*(self: ClassDB; class: StringName; `method`: St
   methodbind.ptrcall(self, [getPtr class, getPtr `method`, getPtr noInheritance], addr ret)
   (addr ret).decode_result(int32)
 
-proc classGetMethodList*(self: ClassDB; class: StringName; noInheritance: bool = false): TypedArray[Dictionary] =
+proc classGetMethodList*(self: ClassDB; class: StringName; noInheritance: bool = false): Array[Dictionary] =
   expandMethodBind(className ClassDB, "class_get_method_list", 3504980660)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr class, getPtr noInheritance], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc classCallStatic*(self: ClassDB; class: Variant; `method`: Variant; args: varargs[Variant, variant]): Variant =
   expandMethodBind(className ClassDB, "class_call_static", 3344196419)

--- a/src/gdext/classes/gdcodeedit.nim
+++ b/src/gdext/classes/gdcodeedit.nim
@@ -20,10 +20,10 @@ proc registerVirtual_requestCodeCompletion*[T: CodeEdit](Self: typedesc[T]) =
   Self.vmethods[newStringName"_request_code_completion"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[CodeEdit](p_instance).requestCodeCompletion(p_args[0].decode(bool))
 
-method filterCodeCompletionCandidates*(self: CodeEdit; candidates: TypedArray[Dictionary]): TypedArray[Dictionary] {.base.} = (discard)
+method filterCodeCompletionCandidates*(self: CodeEdit; candidates: Array[Dictionary]): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_filterCodeCompletionCandidates*[T: CodeEdit](Self: typedesc[T]) =
   Self.vmethods[newStringName"_filter_code_completion_candidates"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[CodeEdit](p_instance).filterCodeCompletionCandidates(p_args[0].decode(TypedArray[Dictionary])).encode(r_ret)
+    errproof: cast[CodeEdit](p_instance).filterCodeCompletionCandidates(p_args[0].decode(Array[Dictionary])).encode(r_ret)
 
 proc setIndentSize*(self: CodeEdit; size: int32): void =
   expandMethodBind(className CodeEdit, "set_indent_size", 1286410249)
@@ -55,16 +55,16 @@ proc isAutoIndentEnabled*(self: CodeEdit): bool =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
 
-proc setAutoIndentPrefixes*(self: CodeEdit; prefixes: TypedArray[String]): void =
+proc setAutoIndentPrefixes*(self: CodeEdit; prefixes: Array[String]): void =
   expandMethodBind(className CodeEdit, "set_auto_indent_prefixes", 381264803)
   nilCheck prefixes
   methodbind.ptrcall(self, [getPtr prefixes])
 
-proc getAutoIndentPrefixes*(self: CodeEdit): TypedArray[String] =
+proc getAutoIndentPrefixes*(self: CodeEdit): Array[String] =
   expandMethodBind(className CodeEdit, "get_auto_indent_prefixes", 3995934104)
-  var ret: encoded TypedArray[String]
+  var ret: encoded Array[String]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[String])
+  (addr ret).decode_result(Array[String])
 
 proc doIndent*(self: CodeEdit): void =
   expandMethodBind(className CodeEdit, "do_indent", 3218959716)
@@ -301,11 +301,11 @@ proc isLineFolded*(self: CodeEdit; line: int32): bool =
   methodbind.ptrcall(self, [getPtr line], addr ret)
   (addr ret).decode_result(bool)
 
-proc getFoldedLines*(self: CodeEdit): TypedArray[Int] =
+proc getFoldedLines*(self: CodeEdit): Array[Int] =
   expandMethodBind(className CodeEdit, "get_folded_lines", 3995934104)
-  var ret: encoded TypedArray[Int]
+  var ret: encoded Array[Int]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Int])
+  (addr ret).decode_result(Array[Int])
 
 proc createCodeRegion*(self: CodeEdit): void =
   expandMethodBind(className CodeEdit, "create_code_region", 3218959716)
@@ -353,7 +353,7 @@ proc hasStringDelimiter*(self: CodeEdit; startKey: String): bool =
   methodbind.ptrcall(self, [getPtr startKey], addr ret)
   (addr ret).decode_result(bool)
 
-proc setStringDelimiters*(self: CodeEdit; stringDelimiters: TypedArray[String]): void =
+proc setStringDelimiters*(self: CodeEdit; stringDelimiters: Array[String]): void =
   expandMethodBind(className CodeEdit, "set_string_delimiters", 381264803)
   nilCheck stringDelimiters
   methodbind.ptrcall(self, [getPtr stringDelimiters])
@@ -362,11 +362,11 @@ proc clearStringDelimiters*(self: CodeEdit): void =
   expandMethodBind(className CodeEdit, "clear_string_delimiters", 3218959716)
   methodbind.ptrcall(self, [])
 
-proc getStringDelimiters*(self: CodeEdit): TypedArray[String] =
+proc getStringDelimiters*(self: CodeEdit): Array[String] =
   expandMethodBind(className CodeEdit, "get_string_delimiters", 3995934104)
-  var ret: encoded TypedArray[String]
+  var ret: encoded Array[String]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[String])
+  (addr ret).decode_result(Array[String])
 
 proc isInString*(self: CodeEdit; line: int32; column: int32 = -1): int32 =
   expandMethodBind(className CodeEdit, "is_in_string", 688195400)
@@ -388,7 +388,7 @@ proc hasCommentDelimiter*(self: CodeEdit; startKey: String): bool =
   methodbind.ptrcall(self, [getPtr startKey], addr ret)
   (addr ret).decode_result(bool)
 
-proc setCommentDelimiters*(self: CodeEdit; commentDelimiters: TypedArray[String]): void =
+proc setCommentDelimiters*(self: CodeEdit; commentDelimiters: Array[String]): void =
   expandMethodBind(className CodeEdit, "set_comment_delimiters", 381264803)
   nilCheck commentDelimiters
   methodbind.ptrcall(self, [getPtr commentDelimiters])
@@ -397,11 +397,11 @@ proc clearCommentDelimiters*(self: CodeEdit): void =
   expandMethodBind(className CodeEdit, "clear_comment_delimiters", 3218959716)
   methodbind.ptrcall(self, [])
 
-proc getCommentDelimiters*(self: CodeEdit): TypedArray[String] =
+proc getCommentDelimiters*(self: CodeEdit): Array[String] =
   expandMethodBind(className CodeEdit, "get_comment_delimiters", 3995934104)
-  var ret: encoded TypedArray[String]
+  var ret: encoded Array[String]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[String])
+  (addr ret).decode_result(Array[String])
 
 proc isInComment*(self: CodeEdit; line: int32; column: int32 = -1): int32 =
   expandMethodBind(className CodeEdit, "is_in_comment", 688195400)
@@ -455,11 +455,11 @@ proc updateCodeCompletionOptions*(self: CodeEdit; force: bool): void =
   expandMethodBind(className CodeEdit, "update_code_completion_options", 2586408642)
   methodbind.ptrcall(self, [getPtr force])
 
-proc getCodeCompletionOptions*(self: CodeEdit): TypedArray[Dictionary] =
+proc getCodeCompletionOptions*(self: CodeEdit): Array[Dictionary] =
   expandMethodBind(className CodeEdit, "get_code_completion_options", 3995934104)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc getCodeCompletionOption*(self: CodeEdit; index: int32): Dictionary =
   expandMethodBind(className CodeEdit, "get_code_completion_option", 3485342025)
@@ -491,27 +491,27 @@ proc isCodeCompletionEnabled*(self: CodeEdit): bool =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
 
-proc setCodeCompletionPrefixes*(self: CodeEdit; prefixes: TypedArray[String]): void =
+proc setCodeCompletionPrefixes*(self: CodeEdit; prefixes: Array[String]): void =
   expandMethodBind(className CodeEdit, "set_code_completion_prefixes", 381264803)
   nilCheck prefixes
   methodbind.ptrcall(self, [getPtr prefixes])
 
-proc getCodeCompletionPrefixes*(self: CodeEdit): TypedArray[String] =
+proc getCodeCompletionPrefixes*(self: CodeEdit): Array[String] =
   expandMethodBind(className CodeEdit, "get_code_completion_prefixes", 3995934104)
-  var ret: encoded TypedArray[String]
+  var ret: encoded Array[String]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[String])
+  (addr ret).decode_result(Array[String])
 
-proc setLineLengthGuidelines*(self: CodeEdit; guidelineColumns: TypedArray[Int]): void =
+proc setLineLengthGuidelines*(self: CodeEdit; guidelineColumns: Array[Int]): void =
   expandMethodBind(className CodeEdit, "set_line_length_guidelines", 381264803)
   nilCheck guidelineColumns
   methodbind.ptrcall(self, [getPtr guidelineColumns])
 
-proc getLineLengthGuidelines*(self: CodeEdit): TypedArray[Int] =
+proc getLineLengthGuidelines*(self: CodeEdit): Array[Int] =
   expandMethodBind(className CodeEdit, "get_line_length_guidelines", 3995934104)
-  var ret: encoded TypedArray[Int]
+  var ret: encoded Array[Int]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Int])
+  (addr ret).decode_result(Array[Int])
 
 proc setSymbolLookupOnClickEnabled*(self: CodeEdit; enable: bool): void =
   expandMethodBind(className CodeEdit, "set_symbol_lookup_on_click_enabled", 2586408642)

--- a/src/gdext/classes/gdcompositor.nim
+++ b/src/gdext/classes/gdcompositor.nim
@@ -6,16 +6,16 @@ import gdresource; export gdresource
 
 expandOnClassImported(Compositor, Resource)
 
-proc setCompositorEffects*(self: Compositor; compositorEffects: TypedArray[gdref CompositorEffect]): void =
+proc setCompositorEffects*(self: Compositor; compositorEffects: Array[gdref CompositorEffect]): void =
   expandMethodBind(className Compositor, "set_compositor_effects", 381264803)
   nilCheck compositorEffects
   methodbind.ptrcall(self, [getPtr compositorEffects])
 
-proc getCompositorEffects*(self: Compositor): TypedArray[gdref CompositorEffect] =
+proc getCompositorEffects*(self: Compositor): Array[gdref CompositorEffect] =
   expandMethodBind(className Compositor, "get_compositor_effects", 3995934104)
-  var ret: encoded TypedArray[gdref CompositorEffect]
+  var ret: encoded Array[gdref CompositorEffect]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref CompositorEffect])
+  (addr ret).decode_result(Array[gdref CompositorEffect])
 
 template compositorEffects*(self: Compositor): untyped = self.getCompositorEffects()
 template `compositorEffects=`*(self: Compositor; value) = self.setCompositorEffects(value)

--- a/src/gdext/classes/gdcontrol.nim
+++ b/src/gdext/classes/gdcontrol.nim
@@ -23,10 +23,10 @@ proc registerVirtual_hasPoint*[T: Control](Self: typedesc[T]) =
   Self.vmethods[newStringName"_has_point"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Control](p_instance).hasPoint(p_args[0].decode(Vector2)).encode(r_ret)
 
-method structuredTextParser*(self: Control; args: Array; text: String): TypedArray[Vector3i] {.base.} = (discard)
+method structuredTextParser*(self: Control; args: Array[Variant]; text: String): Array[Vector3i] {.base.} = (discard)
 proc registerVirtual_structuredTextParser*[T: Control](Self: typedesc[T]) =
   Self.vmethods[newStringName"_structured_text_parser"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[Control](p_instance).structuredTextParser(p_args[0].decode(Array), p_args[1].decode(String)).encode(r_ret)
+    errproof: cast[Control](p_instance).structuredTextParser(p_args[0].decode(Array[Variant]), p_args[1].decode(String)).encode(r_ret)
 
 method getMinimumSize*(self: Control): Vector2 {.base.} =
   expandMethodBind(className Control, "get_minimum_size", 3341600327)
@@ -679,49 +679,49 @@ proc getAccessibilityLive*(self: Control): DisplayServer_AccessibilityLiveMode =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(DisplayServer_AccessibilityLiveMode)
 
-proc setAccessibilityControlsNodes*(self: Control; nodePath: TypedArray[NodePath]): void =
+proc setAccessibilityControlsNodes*(self: Control; nodePath: Array[NodePath]): void =
   expandMethodBind(className Control, "set_accessibility_controls_nodes", 381264803)
   nilCheck nodePath
   methodbind.ptrcall(self, [getPtr nodePath])
 
-proc getAccessibilityControlsNodes*(self: Control): TypedArray[NodePath] =
+proc getAccessibilityControlsNodes*(self: Control): Array[NodePath] =
   expandMethodBind(className Control, "get_accessibility_controls_nodes", 3995934104)
-  var ret: encoded TypedArray[NodePath]
+  var ret: encoded Array[NodePath]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[NodePath])
+  (addr ret).decode_result(Array[NodePath])
 
-proc setAccessibilityDescribedByNodes*(self: Control; nodePath: TypedArray[NodePath]): void =
+proc setAccessibilityDescribedByNodes*(self: Control; nodePath: Array[NodePath]): void =
   expandMethodBind(className Control, "set_accessibility_described_by_nodes", 381264803)
   nilCheck nodePath
   methodbind.ptrcall(self, [getPtr nodePath])
 
-proc getAccessibilityDescribedByNodes*(self: Control): TypedArray[NodePath] =
+proc getAccessibilityDescribedByNodes*(self: Control): Array[NodePath] =
   expandMethodBind(className Control, "get_accessibility_described_by_nodes", 3995934104)
-  var ret: encoded TypedArray[NodePath]
+  var ret: encoded Array[NodePath]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[NodePath])
+  (addr ret).decode_result(Array[NodePath])
 
-proc setAccessibilityLabeledByNodes*(self: Control; nodePath: TypedArray[NodePath]): void =
+proc setAccessibilityLabeledByNodes*(self: Control; nodePath: Array[NodePath]): void =
   expandMethodBind(className Control, "set_accessibility_labeled_by_nodes", 381264803)
   nilCheck nodePath
   methodbind.ptrcall(self, [getPtr nodePath])
 
-proc getAccessibilityLabeledByNodes*(self: Control): TypedArray[NodePath] =
+proc getAccessibilityLabeledByNodes*(self: Control): Array[NodePath] =
   expandMethodBind(className Control, "get_accessibility_labeled_by_nodes", 3995934104)
-  var ret: encoded TypedArray[NodePath]
+  var ret: encoded Array[NodePath]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[NodePath])
+  (addr ret).decode_result(Array[NodePath])
 
-proc setAccessibilityFlowToNodes*(self: Control; nodePath: TypedArray[NodePath]): void =
+proc setAccessibilityFlowToNodes*(self: Control; nodePath: Array[NodePath]): void =
   expandMethodBind(className Control, "set_accessibility_flow_to_nodes", 381264803)
   nilCheck nodePath
   methodbind.ptrcall(self, [getPtr nodePath])
 
-proc getAccessibilityFlowToNodes*(self: Control): TypedArray[NodePath] =
+proc getAccessibilityFlowToNodes*(self: Control): Array[NodePath] =
   expandMethodBind(className Control, "get_accessibility_flow_to_nodes", 3995934104)
-  var ret: encoded TypedArray[NodePath]
+  var ret: encoded Array[NodePath]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[NodePath])
+  (addr ret).decode_result(Array[NodePath])
 
 proc setMouseFilter*(self: Control; filter: Control_MouseFilter): void =
   expandMethodBind(className Control, "set_mouse_filter", 3891156122)

--- a/src/gdext/classes/gdcsgshape3d.nim
+++ b/src/gdext/classes/gdcsgshape3d.nim
@@ -108,11 +108,11 @@ proc isCalculatingTangents*(self: CSGShape3D): bool =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
 
-proc getMeshes*(self: CSGShape3D): Array =
+proc getMeshes*(self: CSGShape3D): Array[Variant] =
   expandMethodBind(className CSGShape3D, "get_meshes", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc bakeStaticMesh*(self: CSGShape3D): gdref ArrayMesh =
   expandMethodBind(className CSGShape3D, "bake_static_mesh", 1605880883)

--- a/src/gdext/classes/gddisplayserver.nim
+++ b/src/gdext/classes/gddisplayserver.nim
@@ -297,11 +297,11 @@ proc ttsIsPaused*(self: DisplayServer): bool =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
 
-proc ttsGetVoices*(self: DisplayServer): TypedArray[Dictionary] =
+proc ttsGetVoices*(self: DisplayServer): Array[Dictionary] =
   expandMethodBind(className DisplayServer, "tts_get_voices", 3995934104)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc ttsGetVoicesForLanguage*(self: DisplayServer; language: String): PackedStringArray =
   expandMethodBind(className DisplayServer, "tts_get_voices_for_language", 4291131558)
@@ -421,11 +421,11 @@ proc clipboardGetPrimary*(self: DisplayServer): String =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(String)
 
-proc getDisplayCutouts*(self: DisplayServer): TypedArray[Rect2] =
+proc getDisplayCutouts*(self: DisplayServer): Array[Rect2] =
   expandMethodBind(className DisplayServer, "get_display_cutouts", 3995934104)
-  var ret: encoded TypedArray[Rect2]
+  var ret: encoded Array[Rect2]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Rect2])
+  (addr ret).decode_result(Array[Rect2])
 
 proc getDisplaySafeArea*(self: DisplayServer): Rect2i =
   expandMethodBind(className DisplayServer, "get_display_safe_area", 410525958)
@@ -1183,7 +1183,7 @@ proc fileDialogShow*(self: DisplayServer; title: String; currentDirectory: Strin
   methodbind.ptrcall(self, [getPtr title, getPtr currentDirectory, getPtr filename, getPtr showHidden, getPtr mode, getPtr filters, getPtr callback, getPtr parentWindowId], addr ret)
   (addr ret).decode_result(Error)
 
-proc fileDialogWithOptionsShow*(self: DisplayServer; title: String; currentDirectory: String; root: String; filename: String; showHidden: bool; mode: DisplayServer_FileDialogMode; filters: PackedStringArray; options: TypedArray[Dictionary]; callback: Callable; parentWindowId: int32 = 0): Error =
+proc fileDialogWithOptionsShow*(self: DisplayServer; title: String; currentDirectory: String; root: String; filename: String; showHidden: bool; mode: DisplayServer_FileDialogMode; filters: PackedStringArray; options: Array[Dictionary]; callback: Callable; parentWindowId: int32 = 0): Error =
   expandMethodBind(className DisplayServer, "file_dialog_with_options_show", 1448789813)
   nilCheck options
   var ret: encoded Error

--- a/src/gdext/classes/gdeditordebuggerplugin.nim
+++ b/src/gdext/classes/gdeditordebuggerplugin.nim
@@ -16,10 +16,10 @@ proc registerVirtual_hasCapture*[T: EditorDebuggerPlugin](Self: typedesc[T]) =
   Self.vmethods[newStringName"_has_capture"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorDebuggerPlugin](p_instance).hasCapture(p_args[0].decode(String)).encode(r_ret)
 
-method capture*(self: EditorDebuggerPlugin; message: String; data: Array; sessionId: int32): bool {.base.} = (discard)
+method capture*(self: EditorDebuggerPlugin; message: String; data: Array[Variant]; sessionId: int32): bool {.base.} = (discard)
 proc registerVirtual_capture*[T: EditorDebuggerPlugin](Self: typedesc[T]) =
   Self.vmethods[newStringName"_capture"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[EditorDebuggerPlugin](p_instance).capture(p_args[0].decode(String), p_args[1].decode(Array), p_args[2].decode(int32)).encode(r_ret)
+    errproof: cast[EditorDebuggerPlugin](p_instance).capture(p_args[0].decode(String), p_args[1].decode(Array[Variant]), p_args[2].decode(int32)).encode(r_ret)
 
 method gotoScriptLine*(self: EditorDebuggerPlugin; script: gdref Script; line: int32): void {.base.} = (discard)
 proc registerVirtual_gotoScriptLine*[T: EditorDebuggerPlugin](Self: typedesc[T]) =
@@ -42,8 +42,8 @@ proc getSession*(self: EditorDebuggerPlugin; id: int32): gdref EditorDebuggerSes
   methodbind.ptrcall(self, [getPtr id], addr ret)
   (addr ret).decode_result(gdref EditorDebuggerSession)
 
-proc getSessions*(self: EditorDebuggerPlugin): Array =
+proc getSessions*(self: EditorDebuggerPlugin): Array[Variant] =
   expandMethodBind(className EditorDebuggerPlugin, "get_sessions", 2915620761)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])

--- a/src/gdext/classes/gdeditordebuggersession.nim
+++ b/src/gdext/classes/gdeditordebuggersession.nim
@@ -6,12 +6,12 @@ import gdrefcounted; export gdrefcounted
 
 expandOnClassImported(EditorDebuggerSession, RefCounted)
 
-proc sendMessage*(self: EditorDebuggerSession; message: String; data: Array = newArray()): void =
+proc sendMessage*(self: EditorDebuggerSession; message: String; data: Array[Variant] = newArray[Variant]()): void =
   expandMethodBind(className EditorDebuggerSession, "send_message", 85656714)
   nilCheck data
   methodbind.ptrcall(self, [getPtr message, getPtr data])
 
-proc toggleProfiler*(self: EditorDebuggerSession; profiler: String; enable: bool; data: Array = newArray()): void =
+proc toggleProfiler*(self: EditorDebuggerSession; profiler: String; enable: bool; data: Array[Variant] = newArray[Variant]()): void =
   expandMethodBind(className EditorDebuggerSession, "toggle_profiler", 1198443697)
   nilCheck data
   methodbind.ptrcall(self, [getPtr profiler, getPtr enable, getPtr data])

--- a/src/gdext/classes/gdeditorexportplatform.nim
+++ b/src/gdext/classes/gdeditorexportplatform.nim
@@ -24,11 +24,11 @@ proc findExportTemplate*(self: EditorExportPlatform; templateFileName: String): 
   methodbind.ptrcall(self, [getPtr templateFileName], addr ret)
   (addr ret).decode_result(Dictionary)
 
-proc getCurrentPresets*(self: EditorExportPlatform): Array =
+proc getCurrentPresets*(self: EditorExportPlatform): Array[Variant] =
   expandMethodBind(className EditorExportPlatform, "get_current_presets", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc savePack*(self: EditorExportPlatform; preset: gdref EditorExportPreset; debug: bool; path: String; embed: bool = false): Dictionary =
   expandMethodBind(className EditorExportPlatform, "save_pack", 3420080977)
@@ -134,7 +134,7 @@ proc getWorstMessageType*(self: EditorExportPlatform): EditorExportPlatform_Expo
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(EditorExportPlatform_ExportMessageType)
 
-proc sshRunOnRemote*(self: EditorExportPlatform; host: String; port: String; sshArg: PackedStringArray; cmdArgs: String; output: Array = newArray(); portFwd: int32 = -1): Error =
+proc sshRunOnRemote*(self: EditorExportPlatform; host: String; port: String; sshArg: PackedStringArray; cmdArgs: String; output: Array[Variant] = newArray[Variant](); portFwd: int32 = -1): Error =
   expandMethodBind(className EditorExportPlatform, "ssh_run_on_remote", 3163734797)
   nilCheck output
   var ret: encoded Error

--- a/src/gdext/classes/gdeditorexportplatformextension.nim
+++ b/src/gdext/classes/gdeditorexportplatformextension.nim
@@ -16,7 +16,7 @@ proc registerVirtual_isExecutable*[T: EditorExportPlatformExtension](Self: typed
   Self.vmethods[newStringName"_is_executable"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorExportPlatformExtension](p_instance).isExecutable(p_args[0].decode(String)).encode(r_ret)
 
-method getExportOptions*(self: EditorExportPlatformExtension): TypedArray[Dictionary] {.base.} = (discard)
+method getExportOptions*(self: EditorExportPlatformExtension): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_getExportOptions*[T: EditorExportPlatformExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_export_options"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorExportPlatformExtension](p_instance).getExportOptions().encode(r_ret)

--- a/src/gdext/classes/gdeditorexportplugin.nim
+++ b/src/gdext/classes/gdeditorexportplugin.nim
@@ -56,7 +56,7 @@ proc registerVirtual_endCustomizeResources*[T: EditorExportPlugin](Self: typedes
   Self.vmethods[newStringName"_end_customize_resources"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorExportPlugin](p_instance).endCustomizeResources()
 
-method getExportOptions*(self: EditorExportPlugin; platform: gdref EditorExportPlatform): TypedArray[Dictionary] {.base.} = (discard)
+method getExportOptions*(self: EditorExportPlugin; platform: gdref EditorExportPlatform): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_getExportOptions*[T: EditorExportPlugin](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_export_options"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorExportPlugin](p_instance).getExportOptions(p_args[0].decode(gdref EditorExportPlatform)).encode(r_ret)

--- a/src/gdext/classes/gdeditorimportplugin.nim
+++ b/src/gdext/classes/gdeditorimportplugin.nim
@@ -31,7 +31,7 @@ proc registerVirtual_getRecognizedExtensions*[T: EditorImportPlugin](Self: typed
   Self.vmethods[newStringName"_get_recognized_extensions"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorImportPlugin](p_instance).getRecognizedExtensions().encode(r_ret)
 
-method getImportOptions*(self: EditorImportPlugin; path: String; presetIndex: int32): TypedArray[Dictionary] {.base.} = (discard)
+method getImportOptions*(self: EditorImportPlugin; path: String; presetIndex: int32): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_getImportOptions*[T: EditorImportPlugin](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_import_options"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorImportPlugin](p_instance).getImportOptions(p_args[0].decode(String), p_args[1].decode(int32)).encode(r_ret)
@@ -66,10 +66,10 @@ proc registerVirtual_getOptionVisibility*[T: EditorImportPlugin](Self: typedesc[
   Self.vmethods[newStringName"_get_option_visibility"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorImportPlugin](p_instance).getOptionVisibility(p_args[0].decode(String), p_args[1].decode(StringName), p_args[2].decode(Dictionary)).encode(r_ret)
 
-method `import`*(self: EditorImportPlugin; sourceFile: String; savePath: String; options: Dictionary; platformVariants: TypedArray[String]; genFiles: TypedArray[String]): Error {.base.} = (discard)
+method `import`*(self: EditorImportPlugin; sourceFile: String; savePath: String; options: Dictionary; platformVariants: Array[String]; genFiles: Array[String]): Error {.base.} = (discard)
 proc registerVirtual_import*[T: EditorImportPlugin](Self: typedesc[T]) =
   Self.vmethods[newStringName"_import"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[EditorImportPlugin](p_instance).`import`(p_args[0].decode(String), p_args[1].decode(String), p_args[2].decode(Dictionary), p_args[3].decode(TypedArray[String]), p_args[4].decode(TypedArray[String])).encode(r_ret)
+    errproof: cast[EditorImportPlugin](p_instance).`import`(p_args[0].decode(String), p_args[1].decode(String), p_args[2].decode(Dictionary), p_args[3].decode(Array[String]), p_args[4].decode(Array[String])).encode(r_ret)
 
 method canImportThreaded*(self: EditorImportPlugin): bool {.base.} = (discard)
 proc registerVirtual_canImportThreaded*[T: EditorImportPlugin](Self: typedesc[T]) =

--- a/src/gdext/classes/gdeditorinterface.nim
+++ b/src/gdext/classes/gdeditorinterface.nim
@@ -58,12 +58,12 @@ proc getEditorUndoRedo*(self: EditorInterface): EditorUndoRedoManager =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(EditorUndoRedoManager)
 
-proc makeMeshPreviews*(self: EditorInterface; meshes: TypedArray[gdref Mesh]; previewSize: int32): TypedArray[gdref Texture2D] =
+proc makeMeshPreviews*(self: EditorInterface; meshes: Array[gdref Mesh]; previewSize: int32): Array[gdref Texture2D] =
   expandMethodBind(className EditorInterface, "make_mesh_previews", 878078554)
   nilCheck meshes
-  var ret: encoded TypedArray[gdref Texture2D]
+  var ret: encoded Array[gdref Texture2D]
   methodbind.ptrcall(self, [getPtr meshes, getPtr previewSize], addr ret)
-  (addr ret).decode_result(TypedArray[gdref Texture2D])
+  (addr ret).decode_result(Array[gdref Texture2D])
 
 proc setPluginEnabled*(self: EditorInterface; plugin: String; enabled: bool): void =
   expandMethodBind(className EditorInterface, "set_plugin_enabled", 2678287736)
@@ -163,7 +163,7 @@ proc setCurrentFeatureProfile*(self: EditorInterface; profileName: String): void
   expandMethodBind(className EditorInterface, "set_current_feature_profile", 83702148)
   methodbind.ptrcall(self, [getPtr profileName])
 
-proc popupNodeSelector*(self: EditorInterface; callback: Callable; validTypes: TypedArray[StringName] = newTypedArray[StringName](); currentValue: Node = default Node): void =
+proc popupNodeSelector*(self: EditorInterface; callback: Callable; validTypes: Array[StringName] = newArray[StringName](); currentValue: Node = default Node): void =
   expandMethodBind(className EditorInterface, "popup_node_selector", 2444591477)
   nilCheck validTypes
   methodbind.ptrcall(self, [getPtr callback, getPtr validTypes, getPtr currentValue])
@@ -176,12 +176,12 @@ proc popupMethodSelector*(self: EditorInterface; `object`: Object; callback: Cal
   expandMethodBind(className EditorInterface, "popup_method_selector", 3585505226)
   methodbind.ptrcall(self, [getPtr `object`, getPtr callback, getPtr currentValue])
 
-proc popupQuickOpen*(self: EditorInterface; callback: Callable; baseTypes: TypedArray[StringName] = newTypedArray[StringName]()): void =
+proc popupQuickOpen*(self: EditorInterface; callback: Callable; baseTypes: Array[StringName] = newArray[StringName]()): void =
   expandMethodBind(className EditorInterface, "popup_quick_open", 2271411043)
   nilCheck baseTypes
   methodbind.ptrcall(self, [getPtr callback, getPtr baseTypes])
 
-proc popupCreateDialog*(self: EditorInterface; callback: Callable; baseType: StringName = default(StringName); currentType: String = newGdString(); dialogTitle: String = newGdString(); typeBlocklist: TypedArray[StringName] = newTypedArray[StringName]()): void =
+proc popupCreateDialog*(self: EditorInterface; callback: Callable; baseType: StringName = default(StringName); currentType: String = newGdString(); dialogTitle: String = newGdString(); typeBlocklist: Array[StringName] = newArray[StringName]()): void =
   expandMethodBind(className EditorInterface, "popup_create_dialog", 495277124)
   nilCheck typeBlocklist
   methodbind.ptrcall(self, [getPtr callback, getPtr baseType, getPtr currentType, getPtr dialogTitle, getPtr typeBlocklist])
@@ -250,11 +250,11 @@ proc getOpenScenes*(self: EditorInterface): PackedStringArray =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(PackedStringArray)
 
-proc getOpenSceneRoots*(self: EditorInterface): TypedArray[Node] =
+proc getOpenSceneRoots*(self: EditorInterface): Array[Node] =
   expandMethodBind(className EditorInterface, "get_open_scene_roots", 3995934104)
-  var ret: encoded TypedArray[Node]
+  var ret: encoded Array[Node]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Node])
+  (addr ret).decode_result(Array[Node])
 
 proc getEditedSceneRoot*(self: EditorInterface): Node =
   expandMethodBind(className EditorInterface, "get_edited_scene_root", 3160264692)

--- a/src/gdext/classes/gdeditornode3dgizmo.nim
+++ b/src/gdext/classes/gdeditornode3dgizmo.nim
@@ -46,10 +46,10 @@ proc registerVirtual_subgizmosIntersectRay*[T: EditorNode3DGizmo](Self: typedesc
   Self.vmethods[newStringName"_subgizmos_intersect_ray"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorNode3DGizmo](p_instance).subgizmosIntersectRay(p_args[0].decode(Camera3D), p_args[1].decode(Vector2)).encode(r_ret)
 
-method subgizmosIntersectFrustum*(self: EditorNode3DGizmo; camera: Camera3D; frustum: TypedArray[Plane]): PackedInt32Array {.base.} = (discard)
+method subgizmosIntersectFrustum*(self: EditorNode3DGizmo; camera: Camera3D; frustum: Array[Plane]): PackedInt32Array {.base.} = (discard)
 proc registerVirtual_subgizmosIntersectFrustum*[T: EditorNode3DGizmo](Self: typedesc[T]) =
   Self.vmethods[newStringName"_subgizmos_intersect_frustum"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[EditorNode3DGizmo](p_instance).subgizmosIntersectFrustum(p_args[0].decode(Camera3D), p_args[1].decode(TypedArray[Plane])).encode(r_ret)
+    errproof: cast[EditorNode3DGizmo](p_instance).subgizmosIntersectFrustum(p_args[0].decode(Camera3D), p_args[1].decode(Array[Plane])).encode(r_ret)
 
 method setSubgizmoTransform*(self: EditorNode3DGizmo; id: int32; transform: Transform3D): void {.base.} = (discard)
 proc registerVirtual_setSubgizmoTransform*[T: EditorNode3DGizmo](Self: typedesc[T]) =
@@ -61,10 +61,10 @@ proc registerVirtual_getSubgizmoTransform*[T: EditorNode3DGizmo](Self: typedesc[
   Self.vmethods[newStringName"_get_subgizmo_transform"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorNode3DGizmo](p_instance).getSubgizmoTransform(p_args[0].decode(int32)).encode(r_ret)
 
-method commitSubgizmos*(self: EditorNode3DGizmo; ids: PackedInt32Array; restores: TypedArray[Transform3D]; cancel: bool): void {.base.} = (discard)
+method commitSubgizmos*(self: EditorNode3DGizmo; ids: PackedInt32Array; restores: Array[Transform3D]; cancel: bool): void {.base.} = (discard)
 proc registerVirtual_commitSubgizmos*[T: EditorNode3DGizmo](Self: typedesc[T]) =
   Self.vmethods[newStringName"_commit_subgizmos"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[EditorNode3DGizmo](p_instance).commitSubgizmos(p_args[0].decode(PackedInt32Array), p_args[1].decode(TypedArray[Transform3D]), p_args[2].decode(bool))
+    errproof: cast[EditorNode3DGizmo](p_instance).commitSubgizmos(p_args[0].decode(PackedInt32Array), p_args[1].decode(Array[Transform3D]), p_args[2].decode(bool))
 
 proc addLines*(self: EditorNode3DGizmo; lines: PackedVector3Array; material: gdref Material; billboard: bool = false; modulate: Color = color(1, 1, 1, 1)): void =
   expandMethodBind(className EditorNode3DGizmo, "add_lines", 2910971437)

--- a/src/gdext/classes/gdeditornode3dgizmoplugin.nim
+++ b/src/gdext/classes/gdeditornode3dgizmoplugin.nim
@@ -76,10 +76,10 @@ proc registerVirtual_subgizmosIntersectRay*[T: EditorNode3DGizmoPlugin](Self: ty
   Self.vmethods[newStringName"_subgizmos_intersect_ray"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorNode3DGizmoPlugin](p_instance).subgizmosIntersectRay(p_args[0].decode(gdref EditorNode3DGizmo), p_args[1].decode(Camera3D), p_args[2].decode(Vector2)).encode(r_ret)
 
-method subgizmosIntersectFrustum*(self: EditorNode3DGizmoPlugin; gizmo: gdref EditorNode3DGizmo; camera: Camera3D; frustumPlanes: TypedArray[Plane]): PackedInt32Array {.base.} = (discard)
+method subgizmosIntersectFrustum*(self: EditorNode3DGizmoPlugin; gizmo: gdref EditorNode3DGizmo; camera: Camera3D; frustumPlanes: Array[Plane]): PackedInt32Array {.base.} = (discard)
 proc registerVirtual_subgizmosIntersectFrustum*[T: EditorNode3DGizmoPlugin](Self: typedesc[T]) =
   Self.vmethods[newStringName"_subgizmos_intersect_frustum"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[EditorNode3DGizmoPlugin](p_instance).subgizmosIntersectFrustum(p_args[0].decode(gdref EditorNode3DGizmo), p_args[1].decode(Camera3D), p_args[2].decode(TypedArray[Plane])).encode(r_ret)
+    errproof: cast[EditorNode3DGizmoPlugin](p_instance).subgizmosIntersectFrustum(p_args[0].decode(gdref EditorNode3DGizmo), p_args[1].decode(Camera3D), p_args[2].decode(Array[Plane])).encode(r_ret)
 
 method getSubgizmoTransform*(self: EditorNode3DGizmoPlugin; gizmo: gdref EditorNode3DGizmo; subgizmoId: int32): Transform3D {.base.} = (discard)
 proc registerVirtual_getSubgizmoTransform*[T: EditorNode3DGizmoPlugin](Self: typedesc[T]) =
@@ -91,10 +91,10 @@ proc registerVirtual_setSubgizmoTransform*[T: EditorNode3DGizmoPlugin](Self: typ
   Self.vmethods[newStringName"_set_subgizmo_transform"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorNode3DGizmoPlugin](p_instance).setSubgizmoTransform(p_args[0].decode(gdref EditorNode3DGizmo), p_args[1].decode(int32), p_args[2].decode(Transform3D))
 
-method commitSubgizmos*(self: EditorNode3DGizmoPlugin; gizmo: gdref EditorNode3DGizmo; ids: PackedInt32Array; restores: TypedArray[Transform3D]; cancel: bool): void {.base.} = (discard)
+method commitSubgizmos*(self: EditorNode3DGizmoPlugin; gizmo: gdref EditorNode3DGizmo; ids: PackedInt32Array; restores: Array[Transform3D]; cancel: bool): void {.base.} = (discard)
 proc registerVirtual_commitSubgizmos*[T: EditorNode3DGizmoPlugin](Self: typedesc[T]) =
   Self.vmethods[newStringName"_commit_subgizmos"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[EditorNode3DGizmoPlugin](p_instance).commitSubgizmos(p_args[0].decode(gdref EditorNode3DGizmo), p_args[1].decode(PackedInt32Array), p_args[2].decode(TypedArray[Transform3D]), p_args[3].decode(bool))
+    errproof: cast[EditorNode3DGizmoPlugin](p_instance).commitSubgizmos(p_args[0].decode(gdref EditorNode3DGizmo), p_args[1].decode(PackedInt32Array), p_args[2].decode(Array[Transform3D]), p_args[3].decode(bool))
 
 proc createMaterial*(self: EditorNode3DGizmoPlugin; name: String; color: Color; billboard: bool = false; onTop: bool = false; useVertexColor: bool = false): void =
   expandMethodBind(className EditorNode3DGizmoPlugin, "create_material", 3486012546)

--- a/src/gdext/classes/gdeditorselection.nim
+++ b/src/gdext/classes/gdeditorselection.nim
@@ -18,20 +18,20 @@ proc removeNode*(self: EditorSelection; node: Node): void =
   expandMethodBind(className EditorSelection, "remove_node", 1078189570)
   methodbind.ptrcall(self, [getPtr node])
 
-proc getSelectedNodes*(self: EditorSelection): TypedArray[Node] =
+proc getSelectedNodes*(self: EditorSelection): Array[Node] =
   expandMethodBind(className EditorSelection, "get_selected_nodes", 2915620761)
-  var ret: encoded TypedArray[Node]
+  var ret: encoded Array[Node]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Node])
+  (addr ret).decode_result(Array[Node])
 
-proc getTopSelectedNodes*(self: EditorSelection): TypedArray[Node] =
+proc getTopSelectedNodes*(self: EditorSelection): Array[Node] =
   expandMethodBind(className EditorSelection, "get_top_selected_nodes", 2915620761)
-  var ret: encoded TypedArray[Node]
+  var ret: encoded Array[Node]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Node])
+  (addr ret).decode_result(Array[Node])
 
-proc getTransformableSelectedNodes*(self: EditorSelection): TypedArray[Node] =
+proc getTransformableSelectedNodes*(self: EditorSelection): Array[Node] =
   expandMethodBind(className EditorSelection, "get_transformable_selected_nodes", 2915620761)
-  var ret: encoded TypedArray[Node]
+  var ret: encoded Array[Node]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Node])
+  (addr ret).decode_result(Array[Node])

--- a/src/gdext/classes/gdeditorsettings.nim
+++ b/src/gdext/classes/gdeditorsettings.nim
@@ -67,7 +67,7 @@ proc getRecentDirs*(self: EditorSettings): PackedStringArray =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(PackedStringArray)
 
-proc setBuiltinActionOverride*(self: EditorSettings; name: String; actionsList: TypedArray[gdref InputEvent]): void =
+proc setBuiltinActionOverride*(self: EditorSettings; name: String; actionsList: Array[gdref InputEvent]): void =
   expandMethodBind(className EditorSettings, "set_builtin_action_override", 1209351045)
   nilCheck actionsList
   methodbind.ptrcall(self, [getPtr name, getPtr actionsList])

--- a/src/gdext/classes/gdeditortranslationparserplugin.nim
+++ b/src/gdext/classes/gdeditortranslationparserplugin.nim
@@ -6,7 +6,7 @@ import gdrefcounted; export gdrefcounted
 
 expandOnClassImported(EditorTranslationParserPlugin, RefCounted)
 
-method parseFile*(self: EditorTranslationParserPlugin; path: String): TypedArray[PackedStringArray] {.base.} = (discard)
+method parseFile*(self: EditorTranslationParserPlugin; path: String): Array[PackedStringArray] {.base.} = (discard)
 proc registerVirtual_parseFile*[T: EditorTranslationParserPlugin](Self: typedesc[T]) =
   Self.vmethods[newStringName"_parse_file"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorTranslationParserPlugin](p_instance).parseFile(p_args[0].decode(String)).encode(r_ret)

--- a/src/gdext/classes/gdeditorvcsinterface.nim
+++ b/src/gdext/classes/gdeditorvcsinterface.nim
@@ -16,7 +16,7 @@ proc registerVirtual_setCredentials*[T: EditorVCSInterface](Self: typedesc[T]) =
   Self.vmethods[newStringName"_set_credentials"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorVCSInterface](p_instance).setCredentials(p_args[0].decode(String), p_args[1].decode(String), p_args[2].decode(String), p_args[3].decode(String), p_args[4].decode(String))
 
-method getModifiedFilesData*(self: EditorVCSInterface): TypedArray[Dictionary] {.base.} = (discard)
+method getModifiedFilesData*(self: EditorVCSInterface): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_getModifiedFilesData*[T: EditorVCSInterface](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_modified_files_data"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorVCSInterface](p_instance).getModifiedFilesData().encode(r_ret)
@@ -41,7 +41,7 @@ proc registerVirtual_commit*[T: EditorVCSInterface](Self: typedesc[T]) =
   Self.vmethods[newStringName"_commit"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorVCSInterface](p_instance).commit(p_args[0].decode(String))
 
-method getDiff*(self: EditorVCSInterface; identifier: String; area: int32): TypedArray[Dictionary] {.base.} = (discard)
+method getDiff*(self: EditorVCSInterface; identifier: String; area: int32): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_getDiff*[T: EditorVCSInterface](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_diff"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorVCSInterface](p_instance).getDiff(p_args[0].decode(String), p_args[1].decode(int32)).encode(r_ret)
@@ -56,17 +56,17 @@ proc registerVirtual_getVcsName*[T: EditorVCSInterface](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_vcs_name"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorVCSInterface](p_instance).getVcsName().encode(r_ret)
 
-method getPreviousCommits*(self: EditorVCSInterface; maxCommits: int32): TypedArray[Dictionary] {.base.} = (discard)
+method getPreviousCommits*(self: EditorVCSInterface; maxCommits: int32): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_getPreviousCommits*[T: EditorVCSInterface](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_previous_commits"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorVCSInterface](p_instance).getPreviousCommits(p_args[0].decode(int32)).encode(r_ret)
 
-method getBranchList*(self: EditorVCSInterface): TypedArray[String] {.base.} = (discard)
+method getBranchList*(self: EditorVCSInterface): Array[String] {.base.} = (discard)
 proc registerVirtual_getBranchList*[T: EditorVCSInterface](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_branch_list"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorVCSInterface](p_instance).getBranchList().encode(r_ret)
 
-method getRemotes*(self: EditorVCSInterface): TypedArray[String] {.base.} = (discard)
+method getRemotes*(self: EditorVCSInterface): Array[String] {.base.} = (discard)
 proc registerVirtual_getRemotes*[T: EditorVCSInterface](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_remotes"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorVCSInterface](p_instance).getRemotes().encode(r_ret)
@@ -116,7 +116,7 @@ proc registerVirtual_fetch*[T: EditorVCSInterface](Self: typedesc[T]) =
   Self.vmethods[newStringName"_fetch"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorVCSInterface](p_instance).fetch(p_args[0].decode(String))
 
-method getLineDiff*(self: EditorVCSInterface; filePath: String; text: String): TypedArray[Dictionary] {.base.} = (discard)
+method getLineDiff*(self: EditorVCSInterface; filePath: String; text: String): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_getLineDiff*[T: EditorVCSInterface](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_line_diff"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[EditorVCSInterface](p_instance).getLineDiff(p_args[0].decode(String), p_args[1].decode(String)).encode(r_ret)
@@ -151,7 +151,7 @@ proc createStatusFile*(self: EditorVCSInterface; filePath: String; changeType: E
   methodbind.ptrcall(self, [getPtr filePath, getPtr changeType, getPtr area], addr ret)
   (addr ret).decode_result(Dictionary)
 
-proc addDiffHunksIntoDiffFile*(self: EditorVCSInterface; diffFile: Dictionary; diffHunks: TypedArray[Dictionary]): Dictionary =
+proc addDiffHunksIntoDiffFile*(self: EditorVCSInterface; diffFile: Dictionary; diffHunks: Array[Dictionary]): Dictionary =
   expandMethodBind(className EditorVCSInterface, "add_diff_hunks_into_diff_file", 4015243225)
   nilCheck diffFile
   nilCheck diffHunks
@@ -159,7 +159,7 @@ proc addDiffHunksIntoDiffFile*(self: EditorVCSInterface; diffFile: Dictionary; d
   methodbind.ptrcall(self, [getPtr diffFile, getPtr diffHunks], addr ret)
   (addr ret).decode_result(Dictionary)
 
-proc addLineDiffsIntoDiffHunk*(self: EditorVCSInterface; diffHunk: Dictionary; lineDiffs: TypedArray[Dictionary]): Dictionary =
+proc addLineDiffsIntoDiffHunk*(self: EditorVCSInterface; diffHunk: Dictionary; lineDiffs: Array[Dictionary]): Dictionary =
   expandMethodBind(className EditorVCSInterface, "add_line_diffs_into_diff_hunk", 4015243225)
   nilCheck diffHunk
   nilCheck lineDiffs

--- a/src/gdext/classes/gdenetconnection.nim
+++ b/src/gdext/classes/gdenetconnection.nim
@@ -28,11 +28,11 @@ proc connectToHost*(self: ENetConnection; address: String; port: int32; channels
   methodbind.ptrcall(self, [getPtr address, getPtr port, getPtr channels, getPtr data], addr ret)
   (addr ret).decode_result(gdref ENetPacketPeer)
 
-proc service*(self: ENetConnection; timeout: int32 = 0): Array =
+proc service*(self: ENetConnection; timeout: int32 = 0): Array[Variant] =
   expandMethodBind(className ENetConnection, "service", 2402345344)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr timeout], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc flush*(self: ENetConnection): void =
   expandMethodBind(className ENetConnection, "flush", 3218959716)
@@ -88,11 +88,11 @@ proc getLocalPort*(self: ENetConnection): int32 =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(int32)
 
-proc getPeers*(self: ENetConnection): TypedArray[gdref ENetPacketPeer] =
+proc getPeers*(self: ENetConnection): Array[gdref ENetPacketPeer] =
   expandMethodBind(className ENetConnection, "get_peers", 2915620761)
-  var ret: encoded TypedArray[gdref ENetPacketPeer]
+  var ret: encoded Array[gdref ENetPacketPeer]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref ENetPacketPeer])
+  (addr ret).decode_result(Array[gdref ENetPacketPeer])
 
 proc socketSend*(self: ENetConnection; destinationAddress: String; destinationPort: int32; packet: PackedByteArray): void =
   expandMethodBind(className ENetConnection, "socket_send", 1100646812)

--- a/src/gdext/classes/gdengine.nim
+++ b/src/gdext/classes/gdengine.nim
@@ -104,11 +104,11 @@ proc getAuthorInfo*(self: Engine): Dictionary =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Dictionary)
 
-proc getCopyrightInfo*(self: Engine): TypedArray[Dictionary] =
+proc getCopyrightInfo*(self: Engine): Array[Dictionary] =
   expandMethodBind(className Engine, "get_copyright_info", 3995934104)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc getDonorInfo*(self: Engine): Dictionary =
   expandMethodBind(className Engine, "get_donor_info", 3102165223)
@@ -190,11 +190,11 @@ proc getScriptLanguage*(self: Engine; index: int32): ScriptLanguage =
   methodbind.ptrcall(self, [getPtr index], addr ret)
   (addr ret).decode_result(ScriptLanguage)
 
-proc captureScriptBacktraces*(self: Engine; includeVariables: bool = false): TypedArray[gdref ScriptBacktrace] =
+proc captureScriptBacktraces*(self: Engine; includeVariables: bool = false): Array[gdref ScriptBacktrace] =
   expandMethodBind(className Engine, "capture_script_backtraces", 873284517)
-  var ret: encoded TypedArray[gdref ScriptBacktrace]
+  var ret: encoded Array[gdref ScriptBacktrace]
   methodbind.ptrcall(self, [getPtr includeVariables], addr ret)
-  (addr ret).decode_result(TypedArray[gdref ScriptBacktrace])
+  (addr ret).decode_result(Array[gdref ScriptBacktrace])
 
 proc isEditorHint*(self: Engine): bool =
   expandMethodBind(className Engine, "is_editor_hint", 36873697)

--- a/src/gdext/classes/gdenginedebugger.nim
+++ b/src/gdext/classes/gdenginedebugger.nim
@@ -32,12 +32,12 @@ proc hasProfiler*(self: EngineDebugger; name: StringName): bool =
   methodbind.ptrcall(self, [getPtr name], addr ret)
   (addr ret).decode_result(bool)
 
-proc profilerAddFrameData*(self: EngineDebugger; name: StringName; data: Array): void =
+proc profilerAddFrameData*(self: EngineDebugger; name: StringName; data: Array[Variant]): void =
   expandMethodBind(className EngineDebugger, "profiler_add_frame_data", 1895267858)
   nilCheck data
   methodbind.ptrcall(self, [getPtr name, getPtr data])
 
-proc profilerEnable*(self: EngineDebugger; name: StringName; enable: bool; arguments: Array = newArray()): void =
+proc profilerEnable*(self: EngineDebugger; name: StringName; enable: bool; arguments: Array[Variant] = newArray[Variant]()): void =
   expandMethodBind(className EngineDebugger, "profiler_enable", 3192561009)
   nilCheck arguments
   methodbind.ptrcall(self, [getPtr name, getPtr enable, getPtr arguments])
@@ -60,7 +60,7 @@ proc linePoll*(self: EngineDebugger): void =
   expandMethodBind(className EngineDebugger, "line_poll", 3218959716)
   methodbind.ptrcall(self, [])
 
-proc sendMessage*(self: EngineDebugger; message: String; data: Array): void =
+proc sendMessage*(self: EngineDebugger; message: String; data: Array[Variant]): void =
   expandMethodBind(className EngineDebugger, "send_message", 1209351045)
   nilCheck data
   methodbind.ptrcall(self, [getPtr message, getPtr data])

--- a/src/gdext/classes/gdengineprofiler.nim
+++ b/src/gdext/classes/gdengineprofiler.nim
@@ -6,15 +6,15 @@ import gdrefcounted; export gdrefcounted
 
 expandOnClassImported(EngineProfiler, RefCounted)
 
-method toggle*(self: EngineProfiler; enable: bool; options: Array): void {.base.} = (discard)
+method toggle*(self: EngineProfiler; enable: bool; options: Array[Variant]): void {.base.} = (discard)
 proc registerVirtual_toggle*[T: EngineProfiler](Self: typedesc[T]) =
   Self.vmethods[newStringName"_toggle"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[EngineProfiler](p_instance).toggle(p_args[0].decode(bool), p_args[1].decode(Array))
+    errproof: cast[EngineProfiler](p_instance).toggle(p_args[0].decode(bool), p_args[1].decode(Array[Variant]))
 
-method addFrame*(self: EngineProfiler; data: Array): void {.base.} = (discard)
+method addFrame*(self: EngineProfiler; data: Array[Variant]): void {.base.} = (discard)
 proc registerVirtual_addFrame*[T: EngineProfiler](Self: typedesc[T]) =
   Self.vmethods[newStringName"_add_frame"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[EngineProfiler](p_instance).addFrame(p_args[0].decode(Array))
+    errproof: cast[EngineProfiler](p_instance).addFrame(p_args[0].decode(Array[Variant]))
 
 method tick*(self: EngineProfiler; frameTime: float64; processTime: float64; physicsTime: float64; physicsFrameTime: float64): void {.base.} = (discard)
 proc registerVirtual_tick*[T: EngineProfiler](Self: typedesc[T]) =

--- a/src/gdext/classes/gdexpression.nim
+++ b/src/gdext/classes/gdexpression.nim
@@ -12,7 +12,7 @@ proc parse*(self: Expression; expression: String; inputNames: PackedStringArray 
   methodbind.ptrcall(self, [getPtr expression, getPtr inputNames], addr ret)
   (addr ret).decode_result(Error)
 
-proc execute*(self: Expression; inputs: Array = newArray(); baseInstance: Object = default Object; showError: bool = true; constCallsOnly: bool = false): Variant =
+proc execute*(self: Expression; inputs: Array[Variant] = newArray[Variant](); baseInstance: Object = default Object; showError: bool = true; constCallsOnly: bool = false): Variant =
   expandMethodBind(className Expression, "execute", 3712471238)
   nilCheck inputs
   var ret: encoded Variant

--- a/src/gdext/classes/gdfoldablegroup.nim
+++ b/src/gdext/classes/gdfoldablegroup.nim
@@ -12,11 +12,11 @@ proc getExpandedContainer*(self: FoldableGroup): FoldableContainer =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(FoldableContainer)
 
-proc getContainers*(self: FoldableGroup): TypedArray[FoldableContainer] =
+proc getContainers*(self: FoldableGroup): Array[FoldableContainer] =
   expandMethodBind(className FoldableGroup, "get_containers", 3995934104)
-  var ret: encoded TypedArray[FoldableContainer]
+  var ret: encoded Array[FoldableContainer]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[FoldableContainer])
+  (addr ret).decode_result(Array[FoldableContainer])
 
 proc setAllowFoldingAll*(self: FoldableGroup; enabled: bool): void =
   expandMethodBind(className FoldableGroup, "set_allow_folding_all", 2586408642)

--- a/src/gdext/classes/gdfont.nim
+++ b/src/gdext/classes/gdfont.nim
@@ -6,16 +6,16 @@ import gdresource; export gdresource
 
 expandOnClassImported(Font, Resource)
 
-proc setFallbacks*(self: Font; fallbacks: TypedArray[gdref Font]): void =
+proc setFallbacks*(self: Font; fallbacks: Array[gdref Font]): void =
   expandMethodBind(className Font, "set_fallbacks", 381264803)
   nilCheck fallbacks
   methodbind.ptrcall(self, [getPtr fallbacks])
 
-proc getFallbacks*(self: Font): TypedArray[gdref Font] =
+proc getFallbacks*(self: Font): Array[gdref Font] =
   expandMethodBind(className Font, "get_fallbacks", 3995934104)
-  var ret: encoded TypedArray[gdref Font]
+  var ret: encoded Array[gdref Font]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref Font])
+  (addr ret).decode_result(Array[gdref Font])
 
 proc findVariation*(self: Font; variationCoordinates: Dictionary; faceIndex: int32 = 0; strength: Float = 0.0; transform: Transform2D = transform2D(); spacingTop: int32 = 0; spacingBottom: int32 = 0; spacingSpace: int32 = 0; spacingGlyph: int32 = 0; baselineOffset: Float = 0.0): RID =
   expandMethodBind(className Font, "find_variation", 2553855095)
@@ -24,11 +24,11 @@ proc findVariation*(self: Font; variationCoordinates: Dictionary; faceIndex: int
   methodbind.ptrcall(self, [getPtr variationCoordinates, getPtr faceIndex, getPtr strength, getPtr transform, getPtr spacingTop, getPtr spacingBottom, getPtr spacingSpace, getPtr spacingGlyph, getPtr baselineOffset], addr ret)
   (addr ret).decode_result(RID)
 
-proc getRids*(self: Font): TypedArray[RID] =
+proc getRids*(self: Font): Array[RID] =
   expandMethodBind(className Font, "get_rids", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 proc getHeight*(self: Font; fontSize: int32 = 16): Float =
   expandMethodBind(className Font, "get_height", 378113874)

--- a/src/gdext/classes/gdfontfile.nim
+++ b/src/gdext/classes/gdfontfile.nim
@@ -212,11 +212,11 @@ proc removeCache*(self: FontFile; cacheIndex: int32): void =
   expandMethodBind(className FontFile, "remove_cache", 1286410249)
   methodbind.ptrcall(self, [getPtr cacheIndex])
 
-proc getSizeCacheList*(self: FontFile; cacheIndex: int32): TypedArray[Vector2i] =
+proc getSizeCacheList*(self: FontFile; cacheIndex: int32): Array[Vector2i] =
   expandMethodBind(className FontFile, "get_size_cache_list", 663333327)
-  var ret: encoded TypedArray[Vector2i]
+  var ret: encoded Array[Vector2i]
   methodbind.ptrcall(self, [getPtr cacheIndex], addr ret)
-  (addr ret).decode_result(TypedArray[Vector2i])
+  (addr ret).decode_result(Array[Vector2i])
 
 proc clearSizeCache*(self: FontFile; cacheIndex: int32): void =
   expandMethodBind(className FontFile, "clear_size_cache", 1286410249)
@@ -435,11 +435,11 @@ proc getGlyphTextureIdx*(self: FontFile; cacheIndex: int32; size: Vector2i; glyp
   methodbind.ptrcall(self, [getPtr cacheIndex, getPtr size, getPtr glyph], addr ret)
   (addr ret).decode_result(int32)
 
-proc getKerningList*(self: FontFile; cacheIndex: int32; size: int32): TypedArray[Vector2i] =
+proc getKerningList*(self: FontFile; cacheIndex: int32; size: int32): Array[Vector2i] =
   expandMethodBind(className FontFile, "get_kerning_list", 2345056839)
-  var ret: encoded TypedArray[Vector2i]
+  var ret: encoded Array[Vector2i]
   methodbind.ptrcall(self, [getPtr cacheIndex, getPtr size], addr ret)
-  (addr ret).decode_result(TypedArray[Vector2i])
+  (addr ret).decode_result(Array[Vector2i])
 
 proc clearKerningMap*(self: FontFile; cacheIndex: int32; size: int32): void =
   expandMethodBind(className FontFile, "clear_kerning_map", 3937882851)

--- a/src/gdext/classes/gdframebuffercacherd.nim
+++ b/src/gdext/classes/gdframebuffercacherd.nim
@@ -6,7 +6,7 @@ import gdobject; export gdobject
 
 expandOnClassImported(FramebufferCacheRD, Object)
 
-proc getCacheMultipass*(_: typedesc[FramebufferCacheRD]; textures: TypedArray[RID]; passes: TypedArray[gdref RDFramebufferPass]; views: uint32): RID =
+proc getCacheMultipass*(_: typedesc[FramebufferCacheRD]; textures: Array[RID]; passes: Array[gdref RDFramebufferPass]; views: uint32): RID =
   expandMethodBind(className FramebufferCacheRD, "get_cache_multipass", 3437881813)
   nilCheck textures
   nilCheck passes

--- a/src/gdext/classes/gdgeometry2d.nim
+++ b/src/gdext/classes/gdgeometry2d.nim
@@ -84,59 +84,59 @@ proc convexHull*(self: Geometry2D; points: PackedVector2Array): PackedVector2Arr
   methodbind.ptrcall(self, [getPtr points], addr ret)
   (addr ret).decode_result(PackedVector2Array)
 
-proc decomposePolygonInConvex*(self: Geometry2D; polygon: PackedVector2Array): TypedArray[PackedVector2Array] =
+proc decomposePolygonInConvex*(self: Geometry2D; polygon: PackedVector2Array): Array[PackedVector2Array] =
   expandMethodBind(className Geometry2D, "decompose_polygon_in_convex", 3982393695)
-  var ret: encoded TypedArray[PackedVector2Array]
+  var ret: encoded Array[PackedVector2Array]
   methodbind.ptrcall(self, [getPtr polygon], addr ret)
-  (addr ret).decode_result(TypedArray[PackedVector2Array])
+  (addr ret).decode_result(Array[PackedVector2Array])
 
-proc mergePolygons*(self: Geometry2D; polygonA: PackedVector2Array; polygonB: PackedVector2Array): TypedArray[PackedVector2Array] =
+proc mergePolygons*(self: Geometry2D; polygonA: PackedVector2Array; polygonB: PackedVector2Array): Array[PackedVector2Array] =
   expandMethodBind(className Geometry2D, "merge_polygons", 3637387053)
-  var ret: encoded TypedArray[PackedVector2Array]
+  var ret: encoded Array[PackedVector2Array]
   methodbind.ptrcall(self, [getPtr polygonA, getPtr polygonB], addr ret)
-  (addr ret).decode_result(TypedArray[PackedVector2Array])
+  (addr ret).decode_result(Array[PackedVector2Array])
 
-proc clipPolygons*(self: Geometry2D; polygonA: PackedVector2Array; polygonB: PackedVector2Array): TypedArray[PackedVector2Array] =
+proc clipPolygons*(self: Geometry2D; polygonA: PackedVector2Array; polygonB: PackedVector2Array): Array[PackedVector2Array] =
   expandMethodBind(className Geometry2D, "clip_polygons", 3637387053)
-  var ret: encoded TypedArray[PackedVector2Array]
+  var ret: encoded Array[PackedVector2Array]
   methodbind.ptrcall(self, [getPtr polygonA, getPtr polygonB], addr ret)
-  (addr ret).decode_result(TypedArray[PackedVector2Array])
+  (addr ret).decode_result(Array[PackedVector2Array])
 
-proc intersectPolygons*(self: Geometry2D; polygonA: PackedVector2Array; polygonB: PackedVector2Array): TypedArray[PackedVector2Array] =
+proc intersectPolygons*(self: Geometry2D; polygonA: PackedVector2Array; polygonB: PackedVector2Array): Array[PackedVector2Array] =
   expandMethodBind(className Geometry2D, "intersect_polygons", 3637387053)
-  var ret: encoded TypedArray[PackedVector2Array]
+  var ret: encoded Array[PackedVector2Array]
   methodbind.ptrcall(self, [getPtr polygonA, getPtr polygonB], addr ret)
-  (addr ret).decode_result(TypedArray[PackedVector2Array])
+  (addr ret).decode_result(Array[PackedVector2Array])
 
-proc excludePolygons*(self: Geometry2D; polygonA: PackedVector2Array; polygonB: PackedVector2Array): TypedArray[PackedVector2Array] =
+proc excludePolygons*(self: Geometry2D; polygonA: PackedVector2Array; polygonB: PackedVector2Array): Array[PackedVector2Array] =
   expandMethodBind(className Geometry2D, "exclude_polygons", 3637387053)
-  var ret: encoded TypedArray[PackedVector2Array]
+  var ret: encoded Array[PackedVector2Array]
   methodbind.ptrcall(self, [getPtr polygonA, getPtr polygonB], addr ret)
-  (addr ret).decode_result(TypedArray[PackedVector2Array])
+  (addr ret).decode_result(Array[PackedVector2Array])
 
-proc clipPolylineWithPolygon*(self: Geometry2D; polyline: PackedVector2Array; polygon: PackedVector2Array): TypedArray[PackedVector2Array] =
+proc clipPolylineWithPolygon*(self: Geometry2D; polyline: PackedVector2Array; polygon: PackedVector2Array): Array[PackedVector2Array] =
   expandMethodBind(className Geometry2D, "clip_polyline_with_polygon", 3637387053)
-  var ret: encoded TypedArray[PackedVector2Array]
+  var ret: encoded Array[PackedVector2Array]
   methodbind.ptrcall(self, [getPtr polyline, getPtr polygon], addr ret)
-  (addr ret).decode_result(TypedArray[PackedVector2Array])
+  (addr ret).decode_result(Array[PackedVector2Array])
 
-proc intersectPolylineWithPolygon*(self: Geometry2D; polyline: PackedVector2Array; polygon: PackedVector2Array): TypedArray[PackedVector2Array] =
+proc intersectPolylineWithPolygon*(self: Geometry2D; polyline: PackedVector2Array; polygon: PackedVector2Array): Array[PackedVector2Array] =
   expandMethodBind(className Geometry2D, "intersect_polyline_with_polygon", 3637387053)
-  var ret: encoded TypedArray[PackedVector2Array]
+  var ret: encoded Array[PackedVector2Array]
   methodbind.ptrcall(self, [getPtr polyline, getPtr polygon], addr ret)
-  (addr ret).decode_result(TypedArray[PackedVector2Array])
+  (addr ret).decode_result(Array[PackedVector2Array])
 
-proc offsetPolygon*(self: Geometry2D; polygon: PackedVector2Array; delta: Float; joinType: Geometry2D_PolyJoinType = joinSquare): TypedArray[PackedVector2Array] =
+proc offsetPolygon*(self: Geometry2D; polygon: PackedVector2Array; delta: Float; joinType: Geometry2D_PolyJoinType = joinSquare): Array[PackedVector2Array] =
   expandMethodBind(className Geometry2D, "offset_polygon", 1275354010)
-  var ret: encoded TypedArray[PackedVector2Array]
+  var ret: encoded Array[PackedVector2Array]
   methodbind.ptrcall(self, [getPtr polygon, getPtr delta, getPtr joinType], addr ret)
-  (addr ret).decode_result(TypedArray[PackedVector2Array])
+  (addr ret).decode_result(Array[PackedVector2Array])
 
-proc offsetPolyline*(self: Geometry2D; polyline: PackedVector2Array; delta: Float; joinType: Geometry2D_PolyJoinType = joinSquare; endType: Geometry2D_PolyEndType = endSquare): TypedArray[PackedVector2Array] =
+proc offsetPolyline*(self: Geometry2D; polyline: PackedVector2Array; delta: Float; joinType: Geometry2D_PolyJoinType = joinSquare; endType: Geometry2D_PolyEndType = endSquare): Array[PackedVector2Array] =
   expandMethodBind(className Geometry2D, "offset_polyline", 2328231778)
-  var ret: encoded TypedArray[PackedVector2Array]
+  var ret: encoded Array[PackedVector2Array]
   methodbind.ptrcall(self, [getPtr polyline, getPtr delta, getPtr joinType, getPtr endType], addr ret)
-  (addr ret).decode_result(TypedArray[PackedVector2Array])
+  (addr ret).decode_result(Array[PackedVector2Array])
 
 proc makeAtlas*(self: Geometry2D; sizes: PackedVector2Array): Dictionary =
   expandMethodBind(className Geometry2D, "make_atlas", 1337682371)
@@ -144,8 +144,8 @@ proc makeAtlas*(self: Geometry2D; sizes: PackedVector2Array): Dictionary =
   methodbind.ptrcall(self, [getPtr sizes], addr ret)
   (addr ret).decode_result(Dictionary)
 
-proc bresenhamLine*(self: Geometry2D; `from`: Vector2i; to: Vector2i): TypedArray[Vector2i] =
+proc bresenhamLine*(self: Geometry2D; `from`: Vector2i; to: Vector2i): Array[Vector2i] =
   expandMethodBind(className Geometry2D, "bresenham_line", 1989391000)
-  var ret: encoded TypedArray[Vector2i]
+  var ret: encoded Array[Vector2i]
   methodbind.ptrcall(self, [getPtr `from`, getPtr to], addr ret)
-  (addr ret).decode_result(TypedArray[Vector2i])
+  (addr ret).decode_result(Array[Vector2i])

--- a/src/gdext/classes/gdgeometry3d.nim
+++ b/src/gdext/classes/gdgeometry3d.nim
@@ -6,30 +6,30 @@ import gdobject; export gdobject
 
 expandOnClassImported(Geometry3D, Object)
 
-proc computeConvexMeshPoints*(self: Geometry3D; planes: TypedArray[Plane]): PackedVector3Array =
+proc computeConvexMeshPoints*(self: Geometry3D; planes: Array[Plane]): PackedVector3Array =
   expandMethodBind(className Geometry3D, "compute_convex_mesh_points", 1936902142)
   nilCheck planes
   var ret: encoded PackedVector3Array
   methodbind.ptrcall(self, [getPtr planes], addr ret)
   (addr ret).decode_result(PackedVector3Array)
 
-proc buildBoxPlanes*(self: Geometry3D; extents: Vector3): TypedArray[Plane] =
+proc buildBoxPlanes*(self: Geometry3D; extents: Vector3): Array[Plane] =
   expandMethodBind(className Geometry3D, "build_box_planes", 3622277145)
-  var ret: encoded TypedArray[Plane]
+  var ret: encoded Array[Plane]
   methodbind.ptrcall(self, [getPtr extents], addr ret)
-  (addr ret).decode_result(TypedArray[Plane])
+  (addr ret).decode_result(Array[Plane])
 
-proc buildCylinderPlanes*(self: Geometry3D; radius: Float; height: Float; sides: int32; axis: Vector3_Axis = axisZ): TypedArray[Plane] =
+proc buildCylinderPlanes*(self: Geometry3D; radius: Float; height: Float; sides: int32; axis: Vector3_Axis = axisZ): Array[Plane] =
   expandMethodBind(className Geometry3D, "build_cylinder_planes", 449920067)
-  var ret: encoded TypedArray[Plane]
+  var ret: encoded Array[Plane]
   methodbind.ptrcall(self, [getPtr radius, getPtr height, getPtr sides, getPtr axis], addr ret)
-  (addr ret).decode_result(TypedArray[Plane])
+  (addr ret).decode_result(Array[Plane])
 
-proc buildCapsulePlanes*(self: Geometry3D; radius: Float; height: Float; sides: int32; lats: int32; axis: Vector3_Axis = axisZ): TypedArray[Plane] =
+proc buildCapsulePlanes*(self: Geometry3D; radius: Float; height: Float; sides: int32; lats: int32; axis: Vector3_Axis = axisZ): Array[Plane] =
   expandMethodBind(className Geometry3D, "build_capsule_planes", 2113592876)
-  var ret: encoded TypedArray[Plane]
+  var ret: encoded Array[Plane]
   methodbind.ptrcall(self, [getPtr radius, getPtr height, getPtr sides, getPtr lats, getPtr axis], addr ret)
-  (addr ret).decode_result(TypedArray[Plane])
+  (addr ret).decode_result(Array[Plane])
 
 proc getClosestPointsBetweenSegments*(self: Geometry3D; p1: Vector3; p2: Vector3; q1: Vector3; q2: Vector3): PackedVector3Array =
   expandMethodBind(className Geometry3D, "get_closest_points_between_segments", 1056373962)
@@ -79,7 +79,7 @@ proc segmentIntersectsCylinder*(self: Geometry3D; `from`: Vector3; to: Vector3; 
   methodbind.ptrcall(self, [getPtr `from`, getPtr to, getPtr height, getPtr radius], addr ret)
   (addr ret).decode_result(PackedVector3Array)
 
-proc segmentIntersectsConvex*(self: Geometry3D; `from`: Vector3; to: Vector3; planes: TypedArray[Plane]): PackedVector3Array =
+proc segmentIntersectsConvex*(self: Geometry3D; `from`: Vector3; to: Vector3; planes: Array[Plane]): PackedVector3Array =
   expandMethodBind(className Geometry3D, "segment_intersects_convex", 537425332)
   nilCheck planes
   var ret: encoded PackedVector3Array

--- a/src/gdext/classes/gdgltfdocumentextension.nim
+++ b/src/gdext/classes/gdgltfdocumentextension.nim
@@ -36,10 +36,10 @@ proc registerVirtual_parseTextureJson*[T: GLTFDocumentExtension](Self: typedesc[
   Self.vmethods[newStringName"_parse_texture_json"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[GLTFDocumentExtension](p_instance).parseTextureJson(p_args[0].decode(gdref GLTFState), p_args[1].decode(Dictionary), p_args[2].decode(gdref GLTFTexture)).encode(r_ret)
 
-method importObjectModelProperty*(self: GLTFDocumentExtension; state: gdref GLTFState; splitJsonPointer: PackedStringArray; partialPaths: TypedArray[NodePath]): gdref GLTFObjectModelProperty {.base.} = (discard)
+method importObjectModelProperty*(self: GLTFDocumentExtension; state: gdref GLTFState; splitJsonPointer: PackedStringArray; partialPaths: Array[NodePath]): gdref GLTFObjectModelProperty {.base.} = (discard)
 proc registerVirtual_importObjectModelProperty*[T: GLTFDocumentExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_import_object_model_property"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[GLTFDocumentExtension](p_instance).importObjectModelProperty(p_args[0].decode(gdref GLTFState), p_args[1].decode(PackedStringArray), p_args[2].decode(TypedArray[NodePath])).encode(r_ret)
+    errproof: cast[GLTFDocumentExtension](p_instance).importObjectModelProperty(p_args[0].decode(gdref GLTFState), p_args[1].decode(PackedStringArray), p_args[2].decode(Array[NodePath])).encode(r_ret)
 
 method importPostParse*(self: GLTFDocumentExtension; state: gdref GLTFState): Error {.base.} = (discard)
 proc registerVirtual_importPostParse*[T: GLTFDocumentExtension](Self: typedesc[T]) =

--- a/src/gdext/classes/gdgltfmesh.nim
+++ b/src/gdext/classes/gdgltfmesh.nim
@@ -36,13 +36,13 @@ proc setBlendWeights*(self: GLTFMesh; blendWeights: PackedFloat32Array): void =
   expandMethodBind(className GLTFMesh, "set_blend_weights", 2899603908)
   methodbind.ptrcall(self, [getPtr blendWeights])
 
-proc getInstanceMaterials*(self: GLTFMesh): TypedArray[gdref Material] =
+proc getInstanceMaterials*(self: GLTFMesh): Array[gdref Material] =
   expandMethodBind(className GLTFMesh, "get_instance_materials", 2915620761)
-  var ret: encoded TypedArray[gdref Material]
+  var ret: encoded Array[gdref Material]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref Material])
+  (addr ret).decode_result(Array[gdref Material])
 
-proc setInstanceMaterials*(self: GLTFMesh; instanceMaterials: TypedArray[gdref Material]): void =
+proc setInstanceMaterials*(self: GLTFMesh; instanceMaterials: Array[gdref Material]): void =
   expandMethodBind(className GLTFMesh, "set_instance_materials", 381264803)
   nilCheck instanceMaterials
   methodbind.ptrcall(self, [getPtr instanceMaterials])

--- a/src/gdext/classes/gdgltfobjectmodelproperty.nim
+++ b/src/gdext/classes/gdgltfobjectmodelproperty.nim
@@ -40,11 +40,11 @@ proc setGodotToGltfExpression*(self: GLTFObjectModelProperty; godotToGltfExpr: g
   expandMethodBind(className GLTFObjectModelProperty, "set_godot_to_gltf_expression", 1815845073)
   methodbind.ptrcall(self, [getPtr godotToGltfExpr])
 
-proc getNodePaths*(self: GLTFObjectModelProperty): TypedArray[NodePath] =
+proc getNodePaths*(self: GLTFObjectModelProperty): Array[NodePath] =
   expandMethodBind(className GLTFObjectModelProperty, "get_node_paths", 3995934104)
-  var ret: encoded TypedArray[NodePath]
+  var ret: encoded Array[NodePath]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[NodePath])
+  (addr ret).decode_result(Array[NodePath])
 
 proc hasNodePaths*(self: GLTFObjectModelProperty): bool =
   expandMethodBind(className GLTFObjectModelProperty, "has_node_paths", 36873697)
@@ -52,7 +52,7 @@ proc hasNodePaths*(self: GLTFObjectModelProperty): bool =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
 
-proc setNodePaths*(self: GLTFObjectModelProperty; nodePaths: TypedArray[NodePath]): void =
+proc setNodePaths*(self: GLTFObjectModelProperty; nodePaths: Array[NodePath]): void =
   expandMethodBind(className GLTFObjectModelProperty, "set_node_paths", 381264803)
   nilCheck nodePaths
   methodbind.ptrcall(self, [getPtr nodePaths])
@@ -67,11 +67,11 @@ proc setObjectModelType*(self: GLTFObjectModelProperty; `type`: GLTFObjectModelP
   expandMethodBind(className GLTFObjectModelProperty, "set_object_model_type", 4108684086)
   methodbind.ptrcall(self, [getPtr `type`])
 
-proc getJsonPointers*(self: GLTFObjectModelProperty): TypedArray[PackedStringArray] =
+proc getJsonPointers*(self: GLTFObjectModelProperty): Array[PackedStringArray] =
   expandMethodBind(className GLTFObjectModelProperty, "get_json_pointers", 3995934104)
-  var ret: encoded TypedArray[PackedStringArray]
+  var ret: encoded Array[PackedStringArray]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[PackedStringArray])
+  (addr ret).decode_result(Array[PackedStringArray])
 
 proc hasJsonPointers*(self: GLTFObjectModelProperty): bool =
   expandMethodBind(className GLTFObjectModelProperty, "has_json_pointers", 36873697)
@@ -79,7 +79,7 @@ proc hasJsonPointers*(self: GLTFObjectModelProperty): bool =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
 
-proc setJsonPointers*(self: GLTFObjectModelProperty; jsonPointers: TypedArray[PackedStringArray]): void =
+proc setJsonPointers*(self: GLTFObjectModelProperty; jsonPointers: Array[PackedStringArray]): void =
   expandMethodBind(className GLTFObjectModelProperty, "set_json_pointers", 381264803)
   nilCheck jsonPointers
   methodbind.ptrcall(self, [getPtr jsonPointers])

--- a/src/gdext/classes/gdgltfskeleton.nim
+++ b/src/gdext/classes/gdgltfskeleton.nim
@@ -32,13 +32,13 @@ proc getGodotSkeleton*(self: GLTFSkeleton): Skeleton3D =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Skeleton3D)
 
-proc getUniqueNames*(self: GLTFSkeleton): TypedArray[String] =
+proc getUniqueNames*(self: GLTFSkeleton): Array[String] =
   expandMethodBind(className GLTFSkeleton, "get_unique_names", 2915620761)
-  var ret: encoded TypedArray[String]
+  var ret: encoded Array[String]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[String])
+  (addr ret).decode_result(Array[String])
 
-proc setUniqueNames*(self: GLTFSkeleton; uniqueNames: TypedArray[String]): void =
+proc setUniqueNames*(self: GLTFSkeleton; uniqueNames: Array[String]): void =
   expandMethodBind(className GLTFSkeleton, "set_unique_names", 381264803)
   nilCheck uniqueNames
   methodbind.ptrcall(self, [getPtr uniqueNames])

--- a/src/gdext/classes/gdgltfskin.nim
+++ b/src/gdext/classes/gdgltfskin.nim
@@ -26,13 +26,13 @@ proc setJointsOriginal*(self: GLTFSkin; jointsOriginal: PackedInt32Array): void 
   expandMethodBind(className GLTFSkin, "set_joints_original", 3614634198)
   methodbind.ptrcall(self, [getPtr jointsOriginal])
 
-proc getInverseBinds*(self: GLTFSkin): TypedArray[Transform3D] =
+proc getInverseBinds*(self: GLTFSkin): Array[Transform3D] =
   expandMethodBind(className GLTFSkin, "get_inverse_binds", 2915620761)
-  var ret: encoded TypedArray[Transform3D]
+  var ret: encoded Array[Transform3D]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Transform3D])
+  (addr ret).decode_result(Array[Transform3D])
 
-proc setInverseBinds*(self: GLTFSkin; inverseBinds: TypedArray[Transform3D]): void =
+proc setInverseBinds*(self: GLTFSkin; inverseBinds: Array[Transform3D]): void =
   expandMethodBind(className GLTFSkin, "set_inverse_binds", 381264803)
   nilCheck inverseBinds
   methodbind.ptrcall(self, [getPtr inverseBinds])

--- a/src/gdext/classes/gdgltfstate.nim
+++ b/src/gdext/classes/gdgltfstate.nim
@@ -88,57 +88,57 @@ proc setUseNamedSkinBinds*(self: GLTFState; useNamedSkinBinds: bool): void =
   expandMethodBind(className GLTFState, "set_use_named_skin_binds", 2586408642)
   methodbind.ptrcall(self, [getPtr useNamedSkinBinds])
 
-proc getNodes*(self: GLTFState): TypedArray[gdref GLTFNode] =
+proc getNodes*(self: GLTFState): Array[gdref GLTFNode] =
   expandMethodBind(className GLTFState, "get_nodes", 2915620761)
-  var ret: encoded TypedArray[gdref GLTFNode]
+  var ret: encoded Array[gdref GLTFNode]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref GLTFNode])
+  (addr ret).decode_result(Array[gdref GLTFNode])
 
-proc setNodes*(self: GLTFState; nodes: TypedArray[gdref GLTFNode]): void =
+proc setNodes*(self: GLTFState; nodes: Array[gdref GLTFNode]): void =
   expandMethodBind(className GLTFState, "set_nodes", 381264803)
   nilCheck nodes
   methodbind.ptrcall(self, [getPtr nodes])
 
-proc getBuffers*(self: GLTFState): TypedArray[PackedByteArray] =
+proc getBuffers*(self: GLTFState): Array[PackedByteArray] =
   expandMethodBind(className GLTFState, "get_buffers", 2915620761)
-  var ret: encoded TypedArray[PackedByteArray]
+  var ret: encoded Array[PackedByteArray]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[PackedByteArray])
+  (addr ret).decode_result(Array[PackedByteArray])
 
-proc setBuffers*(self: GLTFState; buffers: TypedArray[PackedByteArray]): void =
+proc setBuffers*(self: GLTFState; buffers: Array[PackedByteArray]): void =
   expandMethodBind(className GLTFState, "set_buffers", 381264803)
   nilCheck buffers
   methodbind.ptrcall(self, [getPtr buffers])
 
-proc getBufferViews*(self: GLTFState): TypedArray[gdref GLTFBufferView] =
+proc getBufferViews*(self: GLTFState): Array[gdref GLTFBufferView] =
   expandMethodBind(className GLTFState, "get_buffer_views", 2915620761)
-  var ret: encoded TypedArray[gdref GLTFBufferView]
+  var ret: encoded Array[gdref GLTFBufferView]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref GLTFBufferView])
+  (addr ret).decode_result(Array[gdref GLTFBufferView])
 
-proc setBufferViews*(self: GLTFState; bufferViews: TypedArray[gdref GLTFBufferView]): void =
+proc setBufferViews*(self: GLTFState; bufferViews: Array[gdref GLTFBufferView]): void =
   expandMethodBind(className GLTFState, "set_buffer_views", 381264803)
   nilCheck bufferViews
   methodbind.ptrcall(self, [getPtr bufferViews])
 
-proc getAccessors*(self: GLTFState): TypedArray[gdref GLTFAccessor] =
+proc getAccessors*(self: GLTFState): Array[gdref GLTFAccessor] =
   expandMethodBind(className GLTFState, "get_accessors", 2915620761)
-  var ret: encoded TypedArray[gdref GLTFAccessor]
+  var ret: encoded Array[gdref GLTFAccessor]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref GLTFAccessor])
+  (addr ret).decode_result(Array[gdref GLTFAccessor])
 
-proc setAccessors*(self: GLTFState; accessors: TypedArray[gdref GLTFAccessor]): void =
+proc setAccessors*(self: GLTFState; accessors: Array[gdref GLTFAccessor]): void =
   expandMethodBind(className GLTFState, "set_accessors", 381264803)
   nilCheck accessors
   methodbind.ptrcall(self, [getPtr accessors])
 
-proc getMeshes*(self: GLTFState): TypedArray[gdref GLTFMesh] =
+proc getMeshes*(self: GLTFState): Array[gdref GLTFMesh] =
   expandMethodBind(className GLTFState, "get_meshes", 2915620761)
-  var ret: encoded TypedArray[gdref GLTFMesh]
+  var ret: encoded Array[gdref GLTFMesh]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref GLTFMesh])
+  (addr ret).decode_result(Array[gdref GLTFMesh])
 
-proc setMeshes*(self: GLTFState; meshes: TypedArray[gdref GLTFMesh]): void =
+proc setMeshes*(self: GLTFState; meshes: Array[gdref GLTFMesh]): void =
   expandMethodBind(className GLTFState, "set_meshes", 381264803)
   nilCheck meshes
   methodbind.ptrcall(self, [getPtr meshes])
@@ -155,13 +155,13 @@ proc getAnimationPlayer*(self: GLTFState; idx: int32): AnimationPlayer =
   methodbind.ptrcall(self, [getPtr idx], addr ret)
   (addr ret).decode_result(AnimationPlayer)
 
-proc getMaterials*(self: GLTFState): TypedArray[gdref Material] =
+proc getMaterials*(self: GLTFState): Array[gdref Material] =
   expandMethodBind(className GLTFState, "get_materials", 2915620761)
-  var ret: encoded TypedArray[gdref Material]
+  var ret: encoded Array[gdref Material]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref Material])
+  (addr ret).decode_result(Array[gdref Material])
 
-proc setMaterials*(self: GLTFState; materials: TypedArray[gdref Material]): void =
+proc setMaterials*(self: GLTFState; materials: Array[gdref Material]): void =
   expandMethodBind(className GLTFState, "set_materials", 381264803)
   nilCheck materials
   methodbind.ptrcall(self, [getPtr materials])
@@ -206,101 +206,101 @@ proc setRootNodes*(self: GLTFState; rootNodes: PackedInt32Array): void =
   expandMethodBind(className GLTFState, "set_root_nodes", 3614634198)
   methodbind.ptrcall(self, [getPtr rootNodes])
 
-proc getTextures*(self: GLTFState): TypedArray[gdref GLTFTexture] =
+proc getTextures*(self: GLTFState): Array[gdref GLTFTexture] =
   expandMethodBind(className GLTFState, "get_textures", 2915620761)
-  var ret: encoded TypedArray[gdref GLTFTexture]
+  var ret: encoded Array[gdref GLTFTexture]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref GLTFTexture])
+  (addr ret).decode_result(Array[gdref GLTFTexture])
 
-proc setTextures*(self: GLTFState; textures: TypedArray[gdref GLTFTexture]): void =
+proc setTextures*(self: GLTFState; textures: Array[gdref GLTFTexture]): void =
   expandMethodBind(className GLTFState, "set_textures", 381264803)
   nilCheck textures
   methodbind.ptrcall(self, [getPtr textures])
 
-proc getTextureSamplers*(self: GLTFState): TypedArray[gdref GLTFTextureSampler] =
+proc getTextureSamplers*(self: GLTFState): Array[gdref GLTFTextureSampler] =
   expandMethodBind(className GLTFState, "get_texture_samplers", 2915620761)
-  var ret: encoded TypedArray[gdref GLTFTextureSampler]
+  var ret: encoded Array[gdref GLTFTextureSampler]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref GLTFTextureSampler])
+  (addr ret).decode_result(Array[gdref GLTFTextureSampler])
 
-proc setTextureSamplers*(self: GLTFState; textureSamplers: TypedArray[gdref GLTFTextureSampler]): void =
+proc setTextureSamplers*(self: GLTFState; textureSamplers: Array[gdref GLTFTextureSampler]): void =
   expandMethodBind(className GLTFState, "set_texture_samplers", 381264803)
   nilCheck textureSamplers
   methodbind.ptrcall(self, [getPtr textureSamplers])
 
-proc getImages*(self: GLTFState): TypedArray[gdref Texture2D] =
+proc getImages*(self: GLTFState): Array[gdref Texture2D] =
   expandMethodBind(className GLTFState, "get_images", 2915620761)
-  var ret: encoded TypedArray[gdref Texture2D]
+  var ret: encoded Array[gdref Texture2D]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref Texture2D])
+  (addr ret).decode_result(Array[gdref Texture2D])
 
-proc setImages*(self: GLTFState; images: TypedArray[gdref Texture2D]): void =
+proc setImages*(self: GLTFState; images: Array[gdref Texture2D]): void =
   expandMethodBind(className GLTFState, "set_images", 381264803)
   nilCheck images
   methodbind.ptrcall(self, [getPtr images])
 
-proc getSkins*(self: GLTFState): TypedArray[gdref GLTFSkin] =
+proc getSkins*(self: GLTFState): Array[gdref GLTFSkin] =
   expandMethodBind(className GLTFState, "get_skins", 2915620761)
-  var ret: encoded TypedArray[gdref GLTFSkin]
+  var ret: encoded Array[gdref GLTFSkin]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref GLTFSkin])
+  (addr ret).decode_result(Array[gdref GLTFSkin])
 
-proc setSkins*(self: GLTFState; skins: TypedArray[gdref GLTFSkin]): void =
+proc setSkins*(self: GLTFState; skins: Array[gdref GLTFSkin]): void =
   expandMethodBind(className GLTFState, "set_skins", 381264803)
   nilCheck skins
   methodbind.ptrcall(self, [getPtr skins])
 
-proc getCameras*(self: GLTFState): TypedArray[gdref GLTFCamera] =
+proc getCameras*(self: GLTFState): Array[gdref GLTFCamera] =
   expandMethodBind(className GLTFState, "get_cameras", 2915620761)
-  var ret: encoded TypedArray[gdref GLTFCamera]
+  var ret: encoded Array[gdref GLTFCamera]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref GLTFCamera])
+  (addr ret).decode_result(Array[gdref GLTFCamera])
 
-proc setCameras*(self: GLTFState; cameras: TypedArray[gdref GLTFCamera]): void =
+proc setCameras*(self: GLTFState; cameras: Array[gdref GLTFCamera]): void =
   expandMethodBind(className GLTFState, "set_cameras", 381264803)
   nilCheck cameras
   methodbind.ptrcall(self, [getPtr cameras])
 
-proc getLights*(self: GLTFState): TypedArray[gdref GLTFLight] =
+proc getLights*(self: GLTFState): Array[gdref GLTFLight] =
   expandMethodBind(className GLTFState, "get_lights", 2915620761)
-  var ret: encoded TypedArray[gdref GLTFLight]
+  var ret: encoded Array[gdref GLTFLight]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref GLTFLight])
+  (addr ret).decode_result(Array[gdref GLTFLight])
 
-proc setLights*(self: GLTFState; lights: TypedArray[gdref GLTFLight]): void =
+proc setLights*(self: GLTFState; lights: Array[gdref GLTFLight]): void =
   expandMethodBind(className GLTFState, "set_lights", 381264803)
   nilCheck lights
   methodbind.ptrcall(self, [getPtr lights])
 
-proc getUniqueNames*(self: GLTFState): TypedArray[String] =
+proc getUniqueNames*(self: GLTFState): Array[String] =
   expandMethodBind(className GLTFState, "get_unique_names", 2915620761)
-  var ret: encoded TypedArray[String]
+  var ret: encoded Array[String]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[String])
+  (addr ret).decode_result(Array[String])
 
-proc setUniqueNames*(self: GLTFState; uniqueNames: TypedArray[String]): void =
+proc setUniqueNames*(self: GLTFState; uniqueNames: Array[String]): void =
   expandMethodBind(className GLTFState, "set_unique_names", 381264803)
   nilCheck uniqueNames
   methodbind.ptrcall(self, [getPtr uniqueNames])
 
-proc getUniqueAnimationNames*(self: GLTFState): TypedArray[String] =
+proc getUniqueAnimationNames*(self: GLTFState): Array[String] =
   expandMethodBind(className GLTFState, "get_unique_animation_names", 2915620761)
-  var ret: encoded TypedArray[String]
+  var ret: encoded Array[String]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[String])
+  (addr ret).decode_result(Array[String])
 
-proc setUniqueAnimationNames*(self: GLTFState; uniqueAnimationNames: TypedArray[String]): void =
+proc setUniqueAnimationNames*(self: GLTFState; uniqueAnimationNames: Array[String]): void =
   expandMethodBind(className GLTFState, "set_unique_animation_names", 381264803)
   nilCheck uniqueAnimationNames
   methodbind.ptrcall(self, [getPtr uniqueAnimationNames])
 
-proc getSkeletons*(self: GLTFState): TypedArray[gdref GLTFSkeleton] =
+proc getSkeletons*(self: GLTFState): Array[gdref GLTFSkeleton] =
   expandMethodBind(className GLTFState, "get_skeletons", 2915620761)
-  var ret: encoded TypedArray[gdref GLTFSkeleton]
+  var ret: encoded Array[gdref GLTFSkeleton]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref GLTFSkeleton])
+  (addr ret).decode_result(Array[gdref GLTFSkeleton])
 
-proc setSkeletons*(self: GLTFState; skeletons: TypedArray[gdref GLTFSkeleton]): void =
+proc setSkeletons*(self: GLTFState; skeletons: Array[gdref GLTFSkeleton]): void =
   expandMethodBind(className GLTFState, "set_skeletons", 381264803)
   nilCheck skeletons
   methodbind.ptrcall(self, [getPtr skeletons])
@@ -325,13 +325,13 @@ proc setImportAsSkeletonBones*(self: GLTFState; importAsSkeletonBones: bool): vo
   expandMethodBind(className GLTFState, "set_import_as_skeleton_bones", 2586408642)
   methodbind.ptrcall(self, [getPtr importAsSkeletonBones])
 
-proc getAnimations*(self: GLTFState): TypedArray[gdref GLTFAnimation] =
+proc getAnimations*(self: GLTFState): Array[gdref GLTFAnimation] =
   expandMethodBind(className GLTFState, "get_animations", 2915620761)
-  var ret: encoded TypedArray[gdref GLTFAnimation]
+  var ret: encoded Array[gdref GLTFAnimation]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref GLTFAnimation])
+  (addr ret).decode_result(Array[gdref GLTFAnimation])
 
-proc setAnimations*(self: GLTFState; animations: TypedArray[gdref GLTFAnimation]): void =
+proc setAnimations*(self: GLTFState; animations: Array[gdref GLTFAnimation]): void =
   expandMethodBind(className GLTFState, "set_animations", 381264803)
   nilCheck animations
   methodbind.ptrcall(self, [getPtr animations])

--- a/src/gdext/classes/gdgraphedit.nim
+++ b/src/gdext/classes/gdgraphedit.nim
@@ -50,16 +50,16 @@ proc setConnectionActivity*(self: GraphEdit; fromNode: StringName; fromPort: int
   expandMethodBind(className GraphEdit, "set_connection_activity", 1141899943)
   methodbind.ptrcall(self, [getPtr fromNode, getPtr fromPort, getPtr toNode, getPtr toPort, getPtr amount])
 
-proc setConnections*(self: GraphEdit; connections: TypedArray[Dictionary]): void =
+proc setConnections*(self: GraphEdit; connections: Array[Dictionary]): void =
   expandMethodBind(className GraphEdit, "set_connections", 381264803)
   nilCheck connections
   methodbind.ptrcall(self, [getPtr connections])
 
-proc getConnectionList*(self: GraphEdit): TypedArray[Dictionary] =
+proc getConnectionList*(self: GraphEdit): Array[Dictionary] =
   expandMethodBind(className GraphEdit, "get_connection_list", 3995934104)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc getConnectionCount*(self: GraphEdit; fromNode: StringName; fromPort: int32): int32 =
   expandMethodBind(className GraphEdit, "get_connection_count", 861718734)
@@ -73,17 +73,17 @@ proc getClosestConnectionAtPoint*(self: GraphEdit; point: Vector2; maxDistance: 
   methodbind.ptrcall(self, [getPtr point, getPtr maxDistance], addr ret)
   (addr ret).decode_result(Dictionary)
 
-proc getConnectionListFromNode*(self: GraphEdit; node: StringName): TypedArray[Dictionary] =
+proc getConnectionListFromNode*(self: GraphEdit; node: StringName): Array[Dictionary] =
   expandMethodBind(className GraphEdit, "get_connection_list_from_node", 3147814860)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr node], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
-proc getConnectionsIntersectingWithRect*(self: GraphEdit; rect: Rect2): TypedArray[Dictionary] =
+proc getConnectionsIntersectingWithRect*(self: GraphEdit; rect: Rect2): Array[Dictionary] =
   expandMethodBind(className GraphEdit, "get_connections_intersecting_with_rect", 2709748719)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr rect], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc clearConnections*(self: GraphEdit): void =
   expandMethodBind(className GraphEdit, "clear_connections", 3218959716)
@@ -147,11 +147,11 @@ proc getElementFrame*(self: GraphEdit; element: StringName): GraphFrame =
   methodbind.ptrcall(self, [getPtr element], addr ret)
   (addr ret).decode_result(GraphFrame)
 
-proc getAttachedNodesOfFrame*(self: GraphEdit; frame: StringName): TypedArray[StringName] =
+proc getAttachedNodesOfFrame*(self: GraphEdit; frame: StringName): Array[StringName] =
   expandMethodBind(className GraphEdit, "get_attached_nodes_of_frame", 689397652)
-  var ret: encoded TypedArray[StringName]
+  var ret: encoded Array[StringName]
   methodbind.ptrcall(self, [getPtr frame], addr ret)
-  (addr ret).decode_result(TypedArray[StringName])
+  (addr ret).decode_result(Array[StringName])
 
 proc setPanningScheme*(self: GraphEdit; scheme: GraphEdit_PanningScheme): void =
   expandMethodBind(className GraphEdit, "set_panning_scheme", 18893313)

--- a/src/gdext/classes/gdgridmap.nim
+++ b/src/gdext/classes/gdgridmap.nim
@@ -212,29 +212,29 @@ proc clear*(self: GridMap): void =
   expandMethodBind(className GridMap, "clear", 3218959716)
   methodbind.ptrcall(self, [])
 
-proc getUsedCells*(self: GridMap): TypedArray[Vector3i] =
+proc getUsedCells*(self: GridMap): Array[Vector3i] =
   expandMethodBind(className GridMap, "get_used_cells", 3995934104)
-  var ret: encoded TypedArray[Vector3i]
+  var ret: encoded Array[Vector3i]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Vector3i])
+  (addr ret).decode_result(Array[Vector3i])
 
-proc getUsedCellsByItem*(self: GridMap; item: int32): TypedArray[Vector3i] =
+proc getUsedCellsByItem*(self: GridMap; item: int32): Array[Vector3i] =
   expandMethodBind(className GridMap, "get_used_cells_by_item", 663333327)
-  var ret: encoded TypedArray[Vector3i]
+  var ret: encoded Array[Vector3i]
   methodbind.ptrcall(self, [getPtr item], addr ret)
-  (addr ret).decode_result(TypedArray[Vector3i])
+  (addr ret).decode_result(Array[Vector3i])
 
-proc getMeshes*(self: GridMap): Array =
+proc getMeshes*(self: GridMap): Array[Variant] =
   expandMethodBind(className GridMap, "get_meshes", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
-proc getBakeMeshes*(self: GridMap): Array =
+proc getBakeMeshes*(self: GridMap): Array[Variant] =
   expandMethodBind(className GridMap, "get_bake_meshes", 2915620761)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc getBakeMeshInstance*(self: GridMap; idx: int32): RID =
   expandMethodBind(className GridMap, "get_bake_mesh_instance", 937000113)

--- a/src/gdext/classes/gdgridmapeditorplugin.nim
+++ b/src/gdext/classes/gdgridmapeditorplugin.nim
@@ -32,11 +32,11 @@ proc hasSelection*(self: GridMapEditorPlugin): bool =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
 
-proc getSelectedCells*(self: GridMapEditorPlugin): Array =
+proc getSelectedCells*(self: GridMapEditorPlugin): Array[Variant] =
   expandMethodBind(className GridMapEditorPlugin, "get_selected_cells", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc setSelectedPaletteItem*(self: GridMapEditorPlugin; item: int32): void =
   expandMethodBind(className GridMapEditorPlugin, "set_selected_palette_item", 998575451)

--- a/src/gdext/classes/gdimagetexture3d.nim
+++ b/src/gdext/classes/gdimagetexture3d.nim
@@ -6,14 +6,14 @@ import gdtexture3d; export gdtexture3d
 
 expandOnClassImported(ImageTexture3D, Texture3D)
 
-proc create*(self: ImageTexture3D; format: Image_Format; width: int32; height: int32; depth: int32; useMipmaps: bool; data: TypedArray[gdref Image]): Error =
+proc create*(self: ImageTexture3D; format: Image_Format; width: int32; height: int32; depth: int32; useMipmaps: bool; data: Array[gdref Image]): Error =
   expandMethodBind(className ImageTexture3D, "create", 1130379827)
   nilCheck data
   var ret: encoded Error
   methodbind.ptrcall(self, [getPtr format, getPtr width, getPtr height, getPtr depth, getPtr useMipmaps, getPtr data], addr ret)
   (addr ret).decode_result(Error)
 
-proc update*(self: ImageTexture3D; data: TypedArray[gdref Image]): void =
+proc update*(self: ImageTexture3D; data: Array[gdref Image]): void =
   expandMethodBind(className ImageTexture3D, "update", 381264803)
   nilCheck data
   methodbind.ptrcall(self, [getPtr data])

--- a/src/gdext/classes/gdimagetexturelayered.nim
+++ b/src/gdext/classes/gdimagetexturelayered.nim
@@ -6,7 +6,7 @@ import gdtexturelayered; export gdtexturelayered
 
 expandOnClassImported(ImageTextureLayered, TextureLayered)
 
-proc createFromImages*(self: ImageTextureLayered; images: TypedArray[gdref Image]): Error =
+proc createFromImages*(self: ImageTextureLayered; images: Array[gdref Image]): Error =
   expandMethodBind(className ImageTextureLayered, "create_from_images", 2785773503)
   nilCheck images
   var ret: encoded Error

--- a/src/gdext/classes/gdimportermesh.nim
+++ b/src/gdext/classes/gdimportermesh.nim
@@ -32,7 +32,7 @@ proc getBlendShapeMode*(self: ImporterMesh): Mesh_BlendShapeMode =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Mesh_BlendShapeMode)
 
-proc addSurface*(self: ImporterMesh; primitive: Mesh_PrimitiveType; arrays: Array; blendShapes: TypedArray[Array] = newTypedArray[Array](); lods: Dictionary = newDictionary(); material: gdref Material = default gdref Material; name: String = newGdString(); flags: uint64 = 0): void =
+proc addSurface*(self: ImporterMesh; primitive: Mesh_PrimitiveType; arrays: Array[Variant]; blendShapes: Array[Array[Variant]] = newArray[Array[Variant]](); lods: Dictionary = newDictionary(); material: gdref Material = default gdref Material; name: String = newGdString(); flags: uint64 = 0): void =
   expandMethodBind(className ImporterMesh, "add_surface", 1740448849)
   nilCheck arrays
   nilCheck blendShapes
@@ -57,17 +57,17 @@ proc getSurfaceName*(self: ImporterMesh; surfaceIdx: int32): String =
   methodbind.ptrcall(self, [getPtr surfaceIdx], addr ret)
   (addr ret).decode_result(String)
 
-proc getSurfaceArrays*(self: ImporterMesh; surfaceIdx: int32): Array =
+proc getSurfaceArrays*(self: ImporterMesh; surfaceIdx: int32): Array[Variant] =
   expandMethodBind(className ImporterMesh, "get_surface_arrays", 663333327)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr surfaceIdx], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
-proc getSurfaceBlendShapeArrays*(self: ImporterMesh; surfaceIdx: int32; blendShapeIdx: int32): Array =
+proc getSurfaceBlendShapeArrays*(self: ImporterMesh; surfaceIdx: int32; blendShapeIdx: int32): Array[Variant] =
   expandMethodBind(className ImporterMesh, "get_surface_blend_shape_arrays", 2345056839)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr surfaceIdx, getPtr blendShapeIdx], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc getSurfaceLodCount*(self: ImporterMesh; surfaceIdx: int32): int32 =
   expandMethodBind(className ImporterMesh, "get_surface_lod_count", 923996154)
@@ -107,7 +107,7 @@ proc setSurfaceMaterial*(self: ImporterMesh; surfaceIdx: int32; material: gdref 
   expandMethodBind(className ImporterMesh, "set_surface_material", 3671737478)
   methodbind.ptrcall(self, [getPtr surfaceIdx, getPtr material])
 
-proc generateLods*(self: ImporterMesh; normalMergeAngle: Float; normalSplitAngle: Float; boneTransformArray: Array): void =
+proc generateLods*(self: ImporterMesh; normalMergeAngle: Float; normalSplitAngle: Float; boneTransformArray: Array[Variant]): void =
   expandMethodBind(className ImporterMesh, "generate_lods", 2491878677)
   nilCheck boneTransformArray
   methodbind.ptrcall(self, [getPtr normalMergeAngle, getPtr normalSplitAngle, getPtr boneTransformArray])

--- a/src/gdext/classes/gdinput.nim
+++ b/src/gdext/classes/gdinput.nim
@@ -140,11 +140,11 @@ proc shouldIgnoreDevice*(self: Input; vendorId: int32; productId: int32): bool =
   methodbind.ptrcall(self, [getPtr vendorId, getPtr productId], addr ret)
   (addr ret).decode_result(bool)
 
-proc getConnectedJoypads*(self: Input): TypedArray[Int] =
+proc getConnectedJoypads*(self: Input): Array[Int] =
   expandMethodBind(className Input, "get_connected_joypads", 2915620761)
-  var ret: encoded TypedArray[Int]
+  var ret: encoded Array[Int]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Int])
+  (addr ret).decode_result(Array[Int])
 
 proc getJoyVibrationStrength*(self: Input; device: int32): Vector2 =
   expandMethodBind(className Input, "get_joy_vibration_strength", 3114997196)

--- a/src/gdext/classes/gdinputmap.nim
+++ b/src/gdext/classes/gdinputmap.nim
@@ -12,11 +12,11 @@ proc hasAction*(self: InputMap; action: StringName): bool =
   methodbind.ptrcall(self, [getPtr action], addr ret)
   (addr ret).decode_result(bool)
 
-proc getActions*(self: InputMap): TypedArray[StringName] =
+proc getActions*(self: InputMap): Array[StringName] =
   expandMethodBind(className InputMap, "get_actions", 2915620761)
-  var ret: encoded TypedArray[StringName]
+  var ret: encoded Array[StringName]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[StringName])
+  (addr ret).decode_result(Array[StringName])
 
 proc addAction*(self: InputMap; action: StringName; deadzone: Float = 0.2): void =
   expandMethodBind(className InputMap, "add_action", 1195233573)
@@ -60,11 +60,11 @@ proc actionEraseEvents*(self: InputMap; action: StringName): void =
   expandMethodBind(className InputMap, "action_erase_events", 3304788590)
   methodbind.ptrcall(self, [getPtr action])
 
-proc actionGetEvents*(self: InputMap; action: StringName): TypedArray[gdref InputEvent] =
+proc actionGetEvents*(self: InputMap; action: StringName): Array[gdref InputEvent] =
   expandMethodBind(className InputMap, "action_get_events", 689397652)
-  var ret: encoded TypedArray[gdref InputEvent]
+  var ret: encoded Array[gdref InputEvent]
   methodbind.ptrcall(self, [getPtr action], addr ret)
-  (addr ret).decode_result(TypedArray[gdref InputEvent])
+  (addr ret).decode_result(Array[gdref InputEvent])
 
 proc eventIsAction*(self: InputMap; event: gdref InputEvent; action: StringName; exactMatch: bool = false): bool =
   expandMethodBind(className InputMap, "event_is_action", 3193353650)

--- a/src/gdext/classes/gdip.nim
+++ b/src/gdext/classes/gdip.nim
@@ -39,11 +39,11 @@ proc getResolveItemAddress*(self: IP; id: int32): String =
   methodbind.ptrcall(self, [getPtr id], addr ret)
   (addr ret).decode_result(String)
 
-proc getResolveItemAddresses*(self: IP; id: int32): Array =
+proc getResolveItemAddresses*(self: IP; id: int32): Array[Variant] =
   expandMethodBind(className IP, "get_resolve_item_addresses", 663333327)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr id], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc eraseResolveItem*(self: IP; id: int32): void =
   expandMethodBind(className IP, "erase_resolve_item", 1286410249)
@@ -55,11 +55,11 @@ proc getLocalAddresses*(self: IP): PackedStringArray =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(PackedStringArray)
 
-proc getLocalInterfaces*(self: IP): TypedArray[Dictionary] =
+proc getLocalInterfaces*(self: IP): Array[Dictionary] =
   expandMethodBind(className IP, "get_local_interfaces", 3995934104)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc clearCache*(self: IP; hostname: String = newGdString()): void =
   expandMethodBind(className IP, "clear_cache", 3005725572)

--- a/src/gdext/classes/gdjavaclass.nim
+++ b/src/gdext/classes/gdjavaclass.nim
@@ -12,11 +12,11 @@ proc getJavaClassName*(self: JavaClass): String =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(String)
 
-proc getJavaMethodList*(self: JavaClass): TypedArray[Dictionary] =
+proc getJavaMethodList*(self: JavaClass): Array[Dictionary] =
   expandMethodBind(className JavaClass, "get_java_method_list", 3995934104)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc getJavaParentClass*(self: JavaClass): gdref JavaClass =
   expandMethodBind(className JavaClass, "get_java_parent_class", 541536347)

--- a/src/gdext/classes/gdlabel.nim
+++ b/src/gdext/classes/gdlabel.nim
@@ -240,16 +240,16 @@ proc getStructuredTextBidiOverride*(self: Label): TextServer_StructuredTextParse
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(TextServer_StructuredTextParser)
 
-proc setStructuredTextBidiOverrideOptions*(self: Label; args: Array): void =
+proc setStructuredTextBidiOverrideOptions*(self: Label; args: Array[Variant]): void =
   expandMethodBind(className Label, "set_structured_text_bidi_override_options", 381264803)
   nilCheck args
   methodbind.ptrcall(self, [getPtr args])
 
-proc getStructuredTextBidiOverrideOptions*(self: Label): Array =
+proc getStructuredTextBidiOverrideOptions*(self: Label): Array[Variant] =
   expandMethodBind(className Label, "get_structured_text_bidi_override_options", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc getCharacterBounds*(self: Label; pos: int32): Rect2 =
   expandMethodBind(className Label, "get_character_bounds", 3327874267)

--- a/src/gdext/classes/gdlabel3d.nim
+++ b/src/gdext/classes/gdlabel3d.nim
@@ -86,16 +86,16 @@ proc getStructuredTextBidiOverride*(self: Label3D): TextServer_StructuredTextPar
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(TextServer_StructuredTextParser)
 
-proc setStructuredTextBidiOverrideOptions*(self: Label3D; args: Array): void =
+proc setStructuredTextBidiOverrideOptions*(self: Label3D; args: Array[Variant]): void =
   expandMethodBind(className Label3D, "set_structured_text_bidi_override_options", 381264803)
   nilCheck args
   methodbind.ptrcall(self, [getPtr args])
 
-proc getStructuredTextBidiOverrideOptions*(self: Label3D): Array =
+proc getStructuredTextBidiOverrideOptions*(self: Label3D): Array[Variant] =
   expandMethodBind(className Label3D, "get_structured_text_bidi_override_options", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc setUppercase*(self: Label3D; enable: bool): void =
   expandMethodBind(className Label3D, "set_uppercase", 2586408642)

--- a/src/gdext/classes/gdlightmapgidata.nim
+++ b/src/gdext/classes/gdlightmapgidata.nim
@@ -6,27 +6,27 @@ import gdresource; export gdresource
 
 expandOnClassImported(LightmapGIData, Resource)
 
-proc setLightmapTextures*(self: LightmapGIData; lightTextures: TypedArray[gdref TextureLayered]): void =
+proc setLightmapTextures*(self: LightmapGIData; lightTextures: Array[gdref TextureLayered]): void =
   expandMethodBind(className LightmapGIData, "set_lightmap_textures", 381264803)
   nilCheck lightTextures
   methodbind.ptrcall(self, [getPtr lightTextures])
 
-proc getLightmapTextures*(self: LightmapGIData): TypedArray[gdref TextureLayered] =
+proc getLightmapTextures*(self: LightmapGIData): Array[gdref TextureLayered] =
   expandMethodBind(className LightmapGIData, "get_lightmap_textures", 3995934104)
-  var ret: encoded TypedArray[gdref TextureLayered]
+  var ret: encoded Array[gdref TextureLayered]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref TextureLayered])
+  (addr ret).decode_result(Array[gdref TextureLayered])
 
-proc setShadowmaskTextures*(self: LightmapGIData; shadowmaskTextures: TypedArray[gdref TextureLayered]): void =
+proc setShadowmaskTextures*(self: LightmapGIData; shadowmaskTextures: Array[gdref TextureLayered]): void =
   expandMethodBind(className LightmapGIData, "set_shadowmask_textures", 381264803)
   nilCheck shadowmaskTextures
   methodbind.ptrcall(self, [getPtr shadowmaskTextures])
 
-proc getShadowmaskTextures*(self: LightmapGIData): TypedArray[gdref TextureLayered] =
+proc getShadowmaskTextures*(self: LightmapGIData): Array[gdref TextureLayered] =
   expandMethodBind(className LightmapGIData, "get_shadowmask_textures", 3995934104)
-  var ret: encoded TypedArray[gdref TextureLayered]
+  var ret: encoded Array[gdref TextureLayered]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref TextureLayered])
+  (addr ret).decode_result(Array[gdref TextureLayered])
 
 proc setUsesSphericalHarmonics*(self: LightmapGIData; usesSphericalHarmonics: bool): void =
   expandMethodBind(className LightmapGIData, "set_uses_spherical_harmonics", 2586408642)

--- a/src/gdext/classes/gdlineedit.nim
+++ b/src/gdext/classes/gdlineedit.nim
@@ -156,16 +156,16 @@ proc getStructuredTextBidiOverride*(self: LineEdit): TextServer_StructuredTextPa
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(TextServer_StructuredTextParser)
 
-proc setStructuredTextBidiOverrideOptions*(self: LineEdit; args: Array): void =
+proc setStructuredTextBidiOverrideOptions*(self: LineEdit; args: Array[Variant]): void =
   expandMethodBind(className LineEdit, "set_structured_text_bidi_override_options", 381264803)
   nilCheck args
   methodbind.ptrcall(self, [getPtr args])
 
-proc getStructuredTextBidiOverrideOptions*(self: LineEdit): Array =
+proc getStructuredTextBidiOverrideOptions*(self: LineEdit): Array[Variant] =
   expandMethodBind(className LineEdit, "get_structured_text_bidi_override_options", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc setPlaceholder*(self: LineEdit; text: String): void =
   expandMethodBind(className LineEdit, "set_placeholder", 83702148)

--- a/src/gdext/classes/gdlinkbutton.nim
+++ b/src/gdext/classes/gdlinkbutton.nim
@@ -66,16 +66,16 @@ proc getStructuredTextBidiOverride*(self: LinkButton): TextServer_StructuredText
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(TextServer_StructuredTextParser)
 
-proc setStructuredTextBidiOverrideOptions*(self: LinkButton; args: Array): void =
+proc setStructuredTextBidiOverrideOptions*(self: LinkButton; args: Array[Variant]): void =
   expandMethodBind(className LinkButton, "set_structured_text_bidi_override_options", 381264803)
   nilCheck args
   methodbind.ptrcall(self, [getPtr args])
 
-proc getStructuredTextBidiOverrideOptions*(self: LinkButton): Array =
+proc getStructuredTextBidiOverrideOptions*(self: LinkButton): Array[Variant] =
   expandMethodBind(className LinkButton, "get_structured_text_bidi_override_options", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 template text*(self: LinkButton): untyped = self.getText()
 template `text=`*(self: LinkButton; value) = self.setText(value)

--- a/src/gdext/classes/gdlogger.nim
+++ b/src/gdext/classes/gdlogger.nim
@@ -6,10 +6,10 @@ import gdrefcounted; export gdrefcounted
 
 expandOnClassImported(Logger, RefCounted)
 
-method logError*(self: Logger; function: String; file: String; line: int32; code: String; rationale: String; editorNotify: bool; errorType: int32; scriptBacktraces: TypedArray[gdref ScriptBacktrace]): void {.base.} = (discard)
+method logError*(self: Logger; function: String; file: String; line: int32; code: String; rationale: String; editorNotify: bool; errorType: int32; scriptBacktraces: Array[gdref ScriptBacktrace]): void {.base.} = (discard)
 proc registerVirtual_logError*[T: Logger](Self: typedesc[T]) =
   Self.vmethods[newStringName"_log_error"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[Logger](p_instance).logError(p_args[0].decode(String), p_args[1].decode(String), p_args[2].decode(int32), p_args[3].decode(String), p_args[4].decode(String), p_args[5].decode(bool), p_args[6].decode(int32), p_args[7].decode(TypedArray[gdref ScriptBacktrace]))
+    errproof: cast[Logger](p_instance).logError(p_args[0].decode(String), p_args[1].decode(String), p_args[2].decode(int32), p_args[3].decode(String), p_args[4].decode(String), p_args[5].decode(bool), p_args[6].decode(int32), p_args[7].decode(Array[gdref ScriptBacktrace]))
 
 method logMessage*(self: Logger; message: String; error: bool): void {.base.} = (discard)
 proc registerVirtual_logMessage*[T: Logger](Self: typedesc[T]) =

--- a/src/gdext/classes/gdmesh.nim
+++ b/src/gdext/classes/gdmesh.nim
@@ -25,20 +25,20 @@ proc registerVirtual_surfaceGetArrayIndexLen*[T: Mesh](Self: typedesc[T]) =
   Self.vmethods[newStringName"_surface_get_array_index_len"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Mesh](p_instance).surfaceGetArrayIndexLen(p_args[0].decode(int32)).encode(r_ret)
 
-method surfaceGetArrays*(self: Mesh; surfIdx: int32): Array {.base.} =
+method surfaceGetArrays*(self: Mesh; surfIdx: int32): Array[Variant] {.base.} =
   expandMethodBind(className Mesh, "surface_get_arrays", 663333327)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr surfIdx], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 proc registerVirtual_surfaceGetArrays*[T: Mesh](Self: typedesc[T]) =
   Self.vmethods[newStringName"_surface_get_arrays"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Mesh](p_instance).surfaceGetArrays(p_args[0].decode(int32)).encode(r_ret)
 
-method surfaceGetBlendShapeArrays*(self: Mesh; surfIdx: int32): TypedArray[Array] {.base.} =
+method surfaceGetBlendShapeArrays*(self: Mesh; surfIdx: int32): Array[Array[Variant]] {.base.} =
   expandMethodBind(className Mesh, "surface_get_blend_shape_arrays", 663333327)
-  var ret: encoded TypedArray[Array]
+  var ret: encoded Array[Array[Variant]]
   methodbind.ptrcall(self, [getPtr surfIdx], addr ret)
-  (addr ret).decode_result(TypedArray[Array])
+  (addr ret).decode_result(Array[Array[Variant]])
 proc registerVirtual_surfaceGetBlendShapeArrays*[T: Mesh](Self: typedesc[T]) =
   Self.vmethods[newStringName"_surface_get_blend_shape_arrays"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Mesh](p_instance).surfaceGetBlendShapeArrays(p_args[0].decode(int32)).encode(r_ret)

--- a/src/gdext/classes/gdmeshlibrary.nim
+++ b/src/gdext/classes/gdmeshlibrary.nim
@@ -38,7 +38,7 @@ proc setItemNavigationLayers*(self: MeshLibrary; id: int32; navigationLayers: ui
   expandMethodBind(className MeshLibrary, "set_item_navigation_layers", 3937882851)
   methodbind.ptrcall(self, [getPtr id, getPtr navigationLayers])
 
-proc setItemShapes*(self: MeshLibrary; id: int32; shapes: Array): void =
+proc setItemShapes*(self: MeshLibrary; id: int32; shapes: Array[Variant]): void =
   expandMethodBind(className MeshLibrary, "set_item_shapes", 537221740)
   nilCheck shapes
   methodbind.ptrcall(self, [getPtr id, getPtr shapes])
@@ -89,11 +89,11 @@ proc getItemNavigationLayers*(self: MeshLibrary; id: int32): uint32 =
   methodbind.ptrcall(self, [getPtr id], addr ret)
   (addr ret).decode_result(uint32)
 
-proc getItemShapes*(self: MeshLibrary; id: int32): Array =
+proc getItemShapes*(self: MeshLibrary; id: int32): Array[Variant] =
   expandMethodBind(className MeshLibrary, "get_item_shapes", 663333327)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr id], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc getItemPreview*(self: MeshLibrary; id: int32): gdref Texture2D =
   expandMethodBind(className MeshLibrary, "get_item_preview", 3536238170)

--- a/src/gdext/classes/gdmultiplayerapi.nim
+++ b/src/gdext/classes/gdmultiplayerapi.nim
@@ -46,7 +46,7 @@ proc poll*(self: MultiplayerAPI): Error =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Error)
 
-proc rpc*(self: MultiplayerAPI; peer: int32; `object`: Object; `method`: StringName; arguments: Array = newArray()): Error =
+proc rpc*(self: MultiplayerAPI; peer: int32; `object`: Object; `method`: StringName; arguments: Array[Variant] = newArray[Variant]()): Error =
   expandMethodBind(className MultiplayerAPI, "rpc", 2077486355)
   nilCheck arguments
   var ret: encoded Error

--- a/src/gdext/classes/gdmultiplayerapiextension.nim
+++ b/src/gdext/classes/gdmultiplayerapiextension.nim
@@ -31,10 +31,10 @@ proc registerVirtual_getPeerIds*[T: MultiplayerAPIExtension](Self: typedesc[T]) 
   Self.vmethods[newStringName"_get_peer_ids"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[MultiplayerAPIExtension](p_instance).getPeerIds().encode(r_ret)
 
-method rpc*(self: MultiplayerAPIExtension; peer: int32; `object`: Object; `method`: StringName; args: Array): Error {.base.} = (discard)
+method rpc*(self: MultiplayerAPIExtension; peer: int32; `object`: Object; `method`: StringName; args: Array[Variant]): Error {.base.} = (discard)
 proc registerVirtual_rpc*[T: MultiplayerAPIExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_rpc"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[MultiplayerAPIExtension](p_instance).rpc(p_args[0].decode(int32), p_args[1].decode(Object), p_args[2].decode(StringName), p_args[3].decode(Array)).encode(r_ret)
+    errproof: cast[MultiplayerAPIExtension](p_instance).rpc(p_args[0].decode(int32), p_args[1].decode(Object), p_args[2].decode(StringName), p_args[3].decode(Array[Variant])).encode(r_ret)
 
 method getRemoteSenderId*(self: MultiplayerAPIExtension): int32 {.base.} = (discard)
 proc registerVirtual_getRemoteSenderId*[T: MultiplayerAPIExtension](Self: typedesc[T]) =

--- a/src/gdext/classes/gdnavigationmeshsourcegeometrydata2d.nim
+++ b/src/gdext/classes/gdnavigationmeshsourcegeometrydata2d.nim
@@ -16,34 +16,34 @@ proc hasData*(self: NavigationMeshSourceGeometryData2D): bool =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
 
-proc setTraversableOutlines*(self: NavigationMeshSourceGeometryData2D; traversableOutlines: TypedArray[PackedVector2Array]): void =
+proc setTraversableOutlines*(self: NavigationMeshSourceGeometryData2D; traversableOutlines: Array[PackedVector2Array]): void =
   expandMethodBind(className NavigationMeshSourceGeometryData2D, "set_traversable_outlines", 381264803)
   nilCheck traversableOutlines
   methodbind.ptrcall(self, [getPtr traversableOutlines])
 
-proc getTraversableOutlines*(self: NavigationMeshSourceGeometryData2D): TypedArray[PackedVector2Array] =
+proc getTraversableOutlines*(self: NavigationMeshSourceGeometryData2D): Array[PackedVector2Array] =
   expandMethodBind(className NavigationMeshSourceGeometryData2D, "get_traversable_outlines", 3995934104)
-  var ret: encoded TypedArray[PackedVector2Array]
+  var ret: encoded Array[PackedVector2Array]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[PackedVector2Array])
+  (addr ret).decode_result(Array[PackedVector2Array])
 
-proc setObstructionOutlines*(self: NavigationMeshSourceGeometryData2D; obstructionOutlines: TypedArray[PackedVector2Array]): void =
+proc setObstructionOutlines*(self: NavigationMeshSourceGeometryData2D; obstructionOutlines: Array[PackedVector2Array]): void =
   expandMethodBind(className NavigationMeshSourceGeometryData2D, "set_obstruction_outlines", 381264803)
   nilCheck obstructionOutlines
   methodbind.ptrcall(self, [getPtr obstructionOutlines])
 
-proc getObstructionOutlines*(self: NavigationMeshSourceGeometryData2D): TypedArray[PackedVector2Array] =
+proc getObstructionOutlines*(self: NavigationMeshSourceGeometryData2D): Array[PackedVector2Array] =
   expandMethodBind(className NavigationMeshSourceGeometryData2D, "get_obstruction_outlines", 3995934104)
-  var ret: encoded TypedArray[PackedVector2Array]
+  var ret: encoded Array[PackedVector2Array]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[PackedVector2Array])
+  (addr ret).decode_result(Array[PackedVector2Array])
 
-proc appendTraversableOutlines*(self: NavigationMeshSourceGeometryData2D; traversableOutlines: TypedArray[PackedVector2Array]): void =
+proc appendTraversableOutlines*(self: NavigationMeshSourceGeometryData2D; traversableOutlines: Array[PackedVector2Array]): void =
   expandMethodBind(className NavigationMeshSourceGeometryData2D, "append_traversable_outlines", 381264803)
   nilCheck traversableOutlines
   methodbind.ptrcall(self, [getPtr traversableOutlines])
 
-proc appendObstructionOutlines*(self: NavigationMeshSourceGeometryData2D; obstructionOutlines: TypedArray[PackedVector2Array]): void =
+proc appendObstructionOutlines*(self: NavigationMeshSourceGeometryData2D; obstructionOutlines: Array[PackedVector2Array]): void =
   expandMethodBind(className NavigationMeshSourceGeometryData2D, "append_obstruction_outlines", 381264803)
   nilCheck obstructionOutlines
   methodbind.ptrcall(self, [getPtr obstructionOutlines])
@@ -68,16 +68,16 @@ proc clearProjectedObstructions*(self: NavigationMeshSourceGeometryData2D): void
   expandMethodBind(className NavigationMeshSourceGeometryData2D, "clear_projected_obstructions", 3218959716)
   methodbind.ptrcall(self, [])
 
-proc setProjectedObstructions*(self: NavigationMeshSourceGeometryData2D; projectedObstructions: Array): void =
+proc setProjectedObstructions*(self: NavigationMeshSourceGeometryData2D; projectedObstructions: Array[Variant]): void =
   expandMethodBind(className NavigationMeshSourceGeometryData2D, "set_projected_obstructions", 381264803)
   nilCheck projectedObstructions
   methodbind.ptrcall(self, [getPtr projectedObstructions])
 
-proc getProjectedObstructions*(self: NavigationMeshSourceGeometryData2D): Array =
+proc getProjectedObstructions*(self: NavigationMeshSourceGeometryData2D): Array[Variant] =
   expandMethodBind(className NavigationMeshSourceGeometryData2D, "get_projected_obstructions", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc getBounds*(self: NavigationMeshSourceGeometryData2D): Rect2 =
   expandMethodBind(className NavigationMeshSourceGeometryData2D, "get_bounds", 3248174)

--- a/src/gdext/classes/gdnavigationmeshsourcegeometrydata3d.nim
+++ b/src/gdext/classes/gdnavigationmeshsourcegeometrydata3d.nim
@@ -44,7 +44,7 @@ proc addMesh*(self: NavigationMeshSourceGeometryData3D; mesh: gdref Mesh; xform:
   expandMethodBind(className NavigationMeshSourceGeometryData3D, "add_mesh", 975462459)
   methodbind.ptrcall(self, [getPtr mesh, getPtr xform])
 
-proc addMeshArray*(self: NavigationMeshSourceGeometryData3D; meshArray: Array; xform: Transform3D): void =
+proc addMeshArray*(self: NavigationMeshSourceGeometryData3D; meshArray: Array[Variant]; xform: Transform3D): void =
   expandMethodBind(className NavigationMeshSourceGeometryData3D, "add_mesh_array", 4235710913)
   nilCheck meshArray
   methodbind.ptrcall(self, [getPtr meshArray, getPtr xform])
@@ -65,16 +65,16 @@ proc clearProjectedObstructions*(self: NavigationMeshSourceGeometryData3D): void
   expandMethodBind(className NavigationMeshSourceGeometryData3D, "clear_projected_obstructions", 3218959716)
   methodbind.ptrcall(self, [])
 
-proc setProjectedObstructions*(self: NavigationMeshSourceGeometryData3D; projectedObstructions: Array): void =
+proc setProjectedObstructions*(self: NavigationMeshSourceGeometryData3D; projectedObstructions: Array[Variant]): void =
   expandMethodBind(className NavigationMeshSourceGeometryData3D, "set_projected_obstructions", 381264803)
   nilCheck projectedObstructions
   methodbind.ptrcall(self, [getPtr projectedObstructions])
 
-proc getProjectedObstructions*(self: NavigationMeshSourceGeometryData3D): Array =
+proc getProjectedObstructions*(self: NavigationMeshSourceGeometryData3D): Array[Variant] =
   expandMethodBind(className NavigationMeshSourceGeometryData3D, "get_projected_obstructions", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc getBounds*(self: NavigationMeshSourceGeometryData3D): AABB =
   expandMethodBind(className NavigationMeshSourceGeometryData3D, "get_bounds", 1021181044)

--- a/src/gdext/classes/gdnavigationpathqueryparameters2d.nim
+++ b/src/gdext/classes/gdnavigationpathqueryparameters2d.nim
@@ -96,27 +96,27 @@ proc getSimplifyEpsilon*(self: NavigationPathQueryParameters2D): Float =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Float)
 
-proc setIncludedRegions*(self: NavigationPathQueryParameters2D; regions: TypedArray[RID]): void =
+proc setIncludedRegions*(self: NavigationPathQueryParameters2D; regions: Array[RID]): void =
   expandMethodBind(className NavigationPathQueryParameters2D, "set_included_regions", 381264803)
   nilCheck regions
   methodbind.ptrcall(self, [getPtr regions])
 
-proc getIncludedRegions*(self: NavigationPathQueryParameters2D): TypedArray[RID] =
+proc getIncludedRegions*(self: NavigationPathQueryParameters2D): Array[RID] =
   expandMethodBind(className NavigationPathQueryParameters2D, "get_included_regions", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
-proc setExcludedRegions*(self: NavigationPathQueryParameters2D; regions: TypedArray[RID]): void =
+proc setExcludedRegions*(self: NavigationPathQueryParameters2D; regions: Array[RID]): void =
   expandMethodBind(className NavigationPathQueryParameters2D, "set_excluded_regions", 381264803)
   nilCheck regions
   methodbind.ptrcall(self, [getPtr regions])
 
-proc getExcludedRegions*(self: NavigationPathQueryParameters2D): TypedArray[RID] =
+proc getExcludedRegions*(self: NavigationPathQueryParameters2D): Array[RID] =
   expandMethodBind(className NavigationPathQueryParameters2D, "get_excluded_regions", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 proc setPathReturnMaxLength*(self: NavigationPathQueryParameters2D; length: Float): void =
   expandMethodBind(className NavigationPathQueryParameters2D, "set_path_return_max_length", 373806689)

--- a/src/gdext/classes/gdnavigationpathqueryparameters3d.nim
+++ b/src/gdext/classes/gdnavigationpathqueryparameters3d.nim
@@ -96,27 +96,27 @@ proc getSimplifyEpsilon*(self: NavigationPathQueryParameters3D): Float =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Float)
 
-proc setIncludedRegions*(self: NavigationPathQueryParameters3D; regions: TypedArray[RID]): void =
+proc setIncludedRegions*(self: NavigationPathQueryParameters3D; regions: Array[RID]): void =
   expandMethodBind(className NavigationPathQueryParameters3D, "set_included_regions", 381264803)
   nilCheck regions
   methodbind.ptrcall(self, [getPtr regions])
 
-proc getIncludedRegions*(self: NavigationPathQueryParameters3D): TypedArray[RID] =
+proc getIncludedRegions*(self: NavigationPathQueryParameters3D): Array[RID] =
   expandMethodBind(className NavigationPathQueryParameters3D, "get_included_regions", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
-proc setExcludedRegions*(self: NavigationPathQueryParameters3D; regions: TypedArray[RID]): void =
+proc setExcludedRegions*(self: NavigationPathQueryParameters3D; regions: Array[RID]): void =
   expandMethodBind(className NavigationPathQueryParameters3D, "set_excluded_regions", 381264803)
   nilCheck regions
   methodbind.ptrcall(self, [getPtr regions])
 
-proc getExcludedRegions*(self: NavigationPathQueryParameters3D): TypedArray[RID] =
+proc getExcludedRegions*(self: NavigationPathQueryParameters3D): Array[RID] =
   expandMethodBind(className NavigationPathQueryParameters3D, "get_excluded_regions", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 proc setPathReturnMaxLength*(self: NavigationPathQueryParameters3D; length: Float): void =
   expandMethodBind(className NavigationPathQueryParameters3D, "set_path_return_max_length", 373806689)

--- a/src/gdext/classes/gdnavigationpathqueryresult2d.nim
+++ b/src/gdext/classes/gdnavigationpathqueryresult2d.nim
@@ -26,16 +26,16 @@ proc getPathTypes*(self: NavigationPathQueryResult2D): PackedInt32Array =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(PackedInt32Array)
 
-proc setPathRids*(self: NavigationPathQueryResult2D; pathRids: TypedArray[RID]): void =
+proc setPathRids*(self: NavigationPathQueryResult2D; pathRids: Array[RID]): void =
   expandMethodBind(className NavigationPathQueryResult2D, "set_path_rids", 381264803)
   nilCheck pathRids
   methodbind.ptrcall(self, [getPtr pathRids])
 
-proc getPathRids*(self: NavigationPathQueryResult2D): TypedArray[RID] =
+proc getPathRids*(self: NavigationPathQueryResult2D): Array[RID] =
   expandMethodBind(className NavigationPathQueryResult2D, "get_path_rids", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 proc setPathOwnerIds*(self: NavigationPathQueryResult2D; pathOwnerIds: PackedInt64Array): void =
   expandMethodBind(className NavigationPathQueryResult2D, "set_path_owner_ids", 3709968205)

--- a/src/gdext/classes/gdnavigationpathqueryresult3d.nim
+++ b/src/gdext/classes/gdnavigationpathqueryresult3d.nim
@@ -26,16 +26,16 @@ proc getPathTypes*(self: NavigationPathQueryResult3D): PackedInt32Array =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(PackedInt32Array)
 
-proc setPathRids*(self: NavigationPathQueryResult3D; pathRids: TypedArray[RID]): void =
+proc setPathRids*(self: NavigationPathQueryResult3D; pathRids: Array[RID]): void =
   expandMethodBind(className NavigationPathQueryResult3D, "set_path_rids", 381264803)
   nilCheck pathRids
   methodbind.ptrcall(self, [getPtr pathRids])
 
-proc getPathRids*(self: NavigationPathQueryResult3D): TypedArray[RID] =
+proc getPathRids*(self: NavigationPathQueryResult3D): Array[RID] =
   expandMethodBind(className NavigationPathQueryResult3D, "get_path_rids", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 proc setPathOwnerIds*(self: NavigationPathQueryResult3D; pathOwnerIds: PackedInt64Array): void =
   expandMethodBind(className NavigationPathQueryResult3D, "set_path_owner_ids", 3709968205)

--- a/src/gdext/classes/gdnavigationserver2d.nim
+++ b/src/gdext/classes/gdnavigationserver2d.nim
@@ -6,11 +6,11 @@ import gdobject; export gdobject
 
 expandOnClassImported(NavigationServer2D, Object)
 
-proc getMaps*(self: NavigationServer2D): TypedArray[RID] =
+proc getMaps*(self: NavigationServer2D): Array[RID] =
   expandMethodBind(className NavigationServer2D, "get_maps", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 proc mapCreate*(self: NavigationServer2D): RID =
   expandMethodBind(className NavigationServer2D, "map_create", 529393457)
@@ -96,29 +96,29 @@ proc mapGetClosestPointOwner*(self: NavigationServer2D; map: RID; toPoint: Vecto
   methodbind.ptrcall(self, [getPtr map, getPtr toPoint], addr ret)
   (addr ret).decode_result(RID)
 
-proc mapGetLinks*(self: NavigationServer2D; map: RID): TypedArray[RID] =
+proc mapGetLinks*(self: NavigationServer2D; map: RID): Array[RID] =
   expandMethodBind(className NavigationServer2D, "map_get_links", 2684255073)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [getPtr map], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
-proc mapGetRegions*(self: NavigationServer2D; map: RID): TypedArray[RID] =
+proc mapGetRegions*(self: NavigationServer2D; map: RID): Array[RID] =
   expandMethodBind(className NavigationServer2D, "map_get_regions", 2684255073)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [getPtr map], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
-proc mapGetAgents*(self: NavigationServer2D; map: RID): TypedArray[RID] =
+proc mapGetAgents*(self: NavigationServer2D; map: RID): Array[RID] =
   expandMethodBind(className NavigationServer2D, "map_get_agents", 2684255073)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [getPtr map], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
-proc mapGetObstacles*(self: NavigationServer2D; map: RID): TypedArray[RID] =
+proc mapGetObstacles*(self: NavigationServer2D; map: RID): Array[RID] =
   expandMethodBind(className NavigationServer2D, "map_get_obstacles", 2684255073)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [getPtr map], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 proc mapForceUpdate*(self: NavigationServer2D; map: RID): void =
   expandMethodBind(className NavigationServer2D, "map_force_update", 2722037293)

--- a/src/gdext/classes/gdnavigationserver3d.nim
+++ b/src/gdext/classes/gdnavigationserver3d.nim
@@ -6,11 +6,11 @@ import gdobject; export gdobject
 
 expandOnClassImported(NavigationServer3D, Object)
 
-proc getMaps*(self: NavigationServer3D): TypedArray[RID] =
+proc getMaps*(self: NavigationServer3D): Array[RID] =
   expandMethodBind(className NavigationServer3D, "get_maps", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 proc mapCreate*(self: NavigationServer3D): RID =
   expandMethodBind(className NavigationServer3D, "map_create", 529393457)
@@ -128,29 +128,29 @@ proc mapGetClosestPointOwner*(self: NavigationServer3D; map: RID; toPoint: Vecto
   methodbind.ptrcall(self, [getPtr map, getPtr toPoint], addr ret)
   (addr ret).decode_result(RID)
 
-proc mapGetLinks*(self: NavigationServer3D; map: RID): TypedArray[RID] =
+proc mapGetLinks*(self: NavigationServer3D; map: RID): Array[RID] =
   expandMethodBind(className NavigationServer3D, "map_get_links", 2684255073)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [getPtr map], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
-proc mapGetRegions*(self: NavigationServer3D; map: RID): TypedArray[RID] =
+proc mapGetRegions*(self: NavigationServer3D; map: RID): Array[RID] =
   expandMethodBind(className NavigationServer3D, "map_get_regions", 2684255073)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [getPtr map], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
-proc mapGetAgents*(self: NavigationServer3D; map: RID): TypedArray[RID] =
+proc mapGetAgents*(self: NavigationServer3D; map: RID): Array[RID] =
   expandMethodBind(className NavigationServer3D, "map_get_agents", 2684255073)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [getPtr map], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
-proc mapGetObstacles*(self: NavigationServer3D; map: RID): TypedArray[RID] =
+proc mapGetObstacles*(self: NavigationServer3D; map: RID): Array[RID] =
   expandMethodBind(className NavigationServer3D, "map_get_obstacles", 2684255073)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [getPtr map], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 proc mapForceUpdate*(self: NavigationServer3D; map: RID): void =
   expandMethodBind(className NavigationServer3D, "map_force_update", 2722037293)

--- a/src/gdext/classes/gdnode.nim
+++ b/src/gdext/classes/gdnode.nim
@@ -117,11 +117,11 @@ proc printOrphanNodes*(_: typedesc[Node]): void =
   expandMethodBind(className Node, "print_orphan_nodes", 3218959716)
   methodbind.ptrcall([])
 
-proc getOrphanNodeIds*(_: typedesc[Node]): TypedArray[Int] =
+proc getOrphanNodeIds*(_: typedesc[Node]): Array[Int] =
   expandMethodBind(className Node, "get_orphan_node_ids", 2915620761)
-  var ret: encoded TypedArray[Int]
+  var ret: encoded Array[Int]
   methodbind.ptrcall([], addr ret)
-  (addr ret).decode_result(TypedArray[Int])
+  (addr ret).decode_result(Array[Int])
 
 proc addSibling*(self: Node; sibling: Node; forceReadableName: bool = false): void =
   expandMethodBind(className Node, "add_sibling", 2570952461)
@@ -155,11 +155,11 @@ proc getChildCount*(self: Node; includeInternal: bool = false): int32 =
   methodbind.ptrcall(self, [getPtr includeInternal], addr ret)
   (addr ret).decode_result(int32)
 
-proc getChildren*(self: Node; includeInternal: bool = false): TypedArray[Node] =
+proc getChildren*(self: Node; includeInternal: bool = false): Array[Node] =
   expandMethodBind(className Node, "get_children", 873284517)
-  var ret: encoded TypedArray[Node]
+  var ret: encoded Array[Node]
   methodbind.ptrcall(self, [getPtr includeInternal], addr ret)
-  (addr ret).decode_result(TypedArray[Node])
+  (addr ret).decode_result(Array[Node])
 
 proc getChild*(self: Node; idx: int32; includeInternal: bool = false): Node =
   expandMethodBind(className Node, "get_child", 541253412)
@@ -197,11 +197,11 @@ proc findChild*(self: Node; pattern: String; recursive: bool = true; owned: bool
   methodbind.ptrcall(self, [getPtr pattern, getPtr recursive, getPtr owned], addr ret)
   (addr ret).decode_result(Node)
 
-proc findChildren*(self: Node; pattern: String; `type`: String = newGdString(); recursive: bool = true; owned: bool = true): TypedArray[Node] =
+proc findChildren*(self: Node; pattern: String; `type`: String = newGdString(); recursive: bool = true; owned: bool = true): Array[Node] =
   expandMethodBind(className Node, "find_children", 2560337219)
-  var ret: encoded TypedArray[Node]
+  var ret: encoded Array[Node]
   methodbind.ptrcall(self, [getPtr pattern, getPtr `type`, getPtr recursive, getPtr owned], addr ret)
-  (addr ret).decode_result(TypedArray[Node])
+  (addr ret).decode_result(Array[Node])
 
 proc findParent*(self: Node; pattern: String): Node =
   expandMethodBind(className Node, "find_parent", 1140089439)
@@ -215,11 +215,11 @@ proc hasNodeAndResource*(self: Node; path: NodePath): bool =
   methodbind.ptrcall(self, [getPtr path], addr ret)
   (addr ret).decode_result(bool)
 
-proc getNodeAndResource*(self: Node; path: NodePath): Array =
+proc getNodeAndResource*(self: Node; path: NodePath): Array[Variant] =
   expandMethodBind(className Node, "get_node_and_resource", 502563882)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr path], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc isInsideTree*(self: Node): bool =
   expandMethodBind(className Node, "is_inside_tree", 36873697)
@@ -275,11 +275,11 @@ proc moveChild*(self: Node; childNode: Node; toIndex: int32): void =
   expandMethodBind(className Node, "move_child", 3315886247)
   methodbind.ptrcall(self, [getPtr childNode, getPtr toIndex])
 
-proc getGroups*(self: Node): TypedArray[StringName] =
+proc getGroups*(self: Node): Array[StringName] =
   expandMethodBind(className Node, "get_groups", 3995934104)
-  var ret: encoded TypedArray[StringName]
+  var ret: encoded Array[StringName]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[StringName])
+  (addr ret).decode_result(Array[StringName])
 
 proc setOwner*(self: Node; owner: Node): void =
   expandMethodBind(className Node, "set_owner", 1078189570)
@@ -331,7 +331,7 @@ proc propagateNotification*(self: Node; what: int32): void =
   expandMethodBind(className Node, "propagate_notification", 1286410249)
   methodbind.ptrcall(self, [getPtr what])
 
-proc propagateCall*(self: Node; `method`: StringName; args: Array = newArray(); parentFirst: bool = false): void =
+proc propagateCall*(self: Node; `method`: StringName; args: Array[Variant] = newArray[Variant](); parentFirst: bool = false): void =
   expandMethodBind(className Node, "propagate_call", 1871007965)
   nilCheck args
   methodbind.ptrcall(self, [getPtr `method`, getPtr args, getPtr parentFirst])

--- a/src/gdext/classes/gdnode3d.nim
+++ b/src/gdext/classes/gdnode3d.nim
@@ -216,11 +216,11 @@ proc addGizmo*(self: Node3D; gizmo: gdref Node3DGizmo): void =
   expandMethodBind(className Node3D, "add_gizmo", 1544533845)
   methodbind.ptrcall(self, [getPtr gizmo])
 
-proc getGizmos*(self: Node3D): TypedArray[gdref Node3DGizmo] =
+proc getGizmos*(self: Node3D): Array[gdref Node3DGizmo] =
   expandMethodBind(className Node3D, "get_gizmos", 3995934104)
-  var ret: encoded TypedArray[gdref Node3DGizmo]
+  var ret: encoded Array[gdref Node3DGizmo]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref Node3DGizmo])
+  (addr ret).decode_result(Array[gdref Node3DGizmo])
 
 proc clearGizmos*(self: Node3D): void =
   expandMethodBind(className Node3D, "clear_gizmos", 3218959716)

--- a/src/gdext/classes/gdnoise.nim
+++ b/src/gdext/classes/gdnoise.nim
@@ -48,14 +48,14 @@ proc getSeamlessImage*(self: Noise; width: int32; height: int32; invert: bool = 
   methodbind.ptrcall(self, [getPtr width, getPtr height, getPtr invert, getPtr in3DSpace, getPtr skirt, getPtr normalize], addr ret)
   (addr ret).decode_result(gdref Image)
 
-proc getImage3D*(self: Noise; width: int32; height: int32; depth: int32; invert: bool = false; normalize: bool = true): TypedArray[gdref Image] =
+proc getImage3D*(self: Noise; width: int32; height: int32; depth: int32; invert: bool = false; normalize: bool = true): Array[gdref Image] =
   expandMethodBind(className Noise, "get_image_3d", 3977814329)
-  var ret: encoded TypedArray[gdref Image]
+  var ret: encoded Array[gdref Image]
   methodbind.ptrcall(self, [getPtr width, getPtr height, getPtr depth, getPtr invert, getPtr normalize], addr ret)
-  (addr ret).decode_result(TypedArray[gdref Image])
+  (addr ret).decode_result(Array[gdref Image])
 
-proc getSeamlessImage3D*(self: Noise; width: int32; height: int32; depth: int32; invert: bool = false; skirt: Float = 0.1; normalize: bool = true): TypedArray[gdref Image] =
+proc getSeamlessImage3D*(self: Noise; width: int32; height: int32; depth: int32; invert: bool = false; skirt: Float = 0.1; normalize: bool = true): Array[gdref Image] =
   expandMethodBind(className Noise, "get_seamless_image_3d", 451006340)
-  var ret: encoded TypedArray[gdref Image]
+  var ret: encoded Array[gdref Image]
   methodbind.ptrcall(self, [getPtr width, getPtr height, getPtr depth, getPtr invert, getPtr skirt, getPtr normalize], addr ret)
-  (addr ret).decode_result(TypedArray[gdref Image])
+  (addr ret).decode_result(Array[gdref Image])

--- a/src/gdext/classes/gdobject.nim
+++ b/src/gdext/classes/gdobject.nim
@@ -40,17 +40,17 @@ proc getIndexed*(self: Object; propertyPath: NodePath): Variant =
   methodbind.ptrcall(self, [getPtr propertyPath], addr ret)
   (addr ret).decode_result(Variant)
 
-proc getPropertyList*(self: Object): TypedArray[Dictionary] =
+proc getPropertyList*(self: Object): Array[Dictionary] =
   expandMethodBind(className Object, "get_property_list", 3995934104)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
-proc getMethodList*(self: Object): TypedArray[Dictionary] =
+proc getMethodList*(self: Object): Array[Dictionary] =
   expandMethodBind(className Object, "get_method_list", 3995934104)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc propertyCanRevert*(self: Object; property: StringName): bool =
   expandMethodBind(className Object, "property_can_revert", 2619796661)
@@ -110,13 +110,13 @@ proc hasMeta*(self: Object; name: StringName): bool =
   methodbind.ptrcall(self, [getPtr name], addr ret)
   (addr ret).decode_result(bool)
 
-proc getMetaList*(self: Object): TypedArray[StringName] =
+proc getMetaList*(self: Object): Array[StringName] =
   expandMethodBind(className Object, "get_meta_list", 3995934104)
-  var ret: encoded TypedArray[StringName]
+  var ret: encoded Array[StringName]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[StringName])
+  (addr ret).decode_result(Array[StringName])
 
-proc addUserSignal*(self: Object; signal: String; arguments: Array = newArray()): void =
+proc addUserSignal*(self: Object; signal: String; arguments: Array[Variant] = newArray[Variant]()): void =
   expandMethodBind(className Object, "add_user_signal", 85656714)
   nilCheck arguments
   methodbind.ptrcall(self, [getPtr signal, getPtr arguments])
@@ -159,7 +159,7 @@ proc setDeferred*(self: Object; property: StringName; value: Variant): void =
   expandMethodBind(className Object, "set_deferred", 3776071444)
   methodbind.ptrcall(self, [getPtr property, getPtr value])
 
-proc callv*(self: Object; `method`: StringName; argArray: Array): Variant =
+proc callv*(self: Object; `method`: StringName; argArray: Array[Variant]): Variant =
   expandMethodBind(className Object, "callv", 1260104456)
   nilCheck argArray
   var ret: encoded Variant
@@ -184,23 +184,23 @@ proc hasSignal*(self: Object; signal: StringName): bool =
   methodbind.ptrcall(self, [getPtr signal], addr ret)
   (addr ret).decode_result(bool)
 
-proc getSignalList*(self: Object): TypedArray[Dictionary] =
+proc getSignalList*(self: Object): Array[Dictionary] =
   expandMethodBind(className Object, "get_signal_list", 3995934104)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
-proc getSignalConnectionList*(self: Object; signal: StringName): TypedArray[Dictionary] =
+proc getSignalConnectionList*(self: Object; signal: StringName): Array[Dictionary] =
   expandMethodBind(className Object, "get_signal_connection_list", 3147814860)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr signal], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
-proc getIncomingConnections*(self: Object): TypedArray[Dictionary] =
+proc getIncomingConnections*(self: Object): Array[Dictionary] =
   expandMethodBind(className Object, "get_incoming_connections", 3995934104)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc connect*(self: Object; signal: StringName; callable: Callable; flags: uint32 = 0'u32): Error =
   expandMethodBind(className Object, "connect", 1518946055)

--- a/src/gdext/classes/gdoggpacketsequence.nim
+++ b/src/gdext/classes/gdoggpacketsequence.nim
@@ -6,16 +6,16 @@ import gdresource; export gdresource
 
 expandOnClassImported(OggPacketSequence, Resource)
 
-proc setPacketData*(self: OggPacketSequence; packetData: TypedArray[Array]): void =
+proc setPacketData*(self: OggPacketSequence; packetData: Array[Array[Variant]]): void =
   expandMethodBind(className OggPacketSequence, "set_packet_data", 381264803)
   nilCheck packetData
   methodbind.ptrcall(self, [getPtr packetData])
 
-proc getPacketData*(self: OggPacketSequence): TypedArray[Array] =
+proc getPacketData*(self: OggPacketSequence): Array[Array[Variant]] =
   expandMethodBind(className OggPacketSequence, "get_packet_data", 3995934104)
-  var ret: encoded TypedArray[Array]
+  var ret: encoded Array[Array[Variant]]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Array])
+  (addr ret).decode_result(Array[Array[Variant]])
 
 proc setPacketGranulePositions*(self: OggPacketSequence; granulePositions: PackedInt64Array): void =
   expandMethodBind(className OggPacketSequence, "set_packet_granule_positions", 3709968205)

--- a/src/gdext/classes/gdopenxractionmap.nim
+++ b/src/gdext/classes/gdopenxractionmap.nim
@@ -6,16 +6,16 @@ import gdresource; export gdresource
 
 expandOnClassImported(OpenXRActionMap, Resource)
 
-proc setActionSets*(self: OpenXRActionMap; actionSets: Array): void =
+proc setActionSets*(self: OpenXRActionMap; actionSets: Array[Variant]): void =
   expandMethodBind(className OpenXRActionMap, "set_action_sets", 381264803)
   nilCheck actionSets
   methodbind.ptrcall(self, [getPtr actionSets])
 
-proc getActionSets*(self: OpenXRActionMap): Array =
+proc getActionSets*(self: OpenXRActionMap): Array[Variant] =
   expandMethodBind(className OpenXRActionMap, "get_action_sets", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc getActionSetCount*(self: OpenXRActionMap): int32 =
   expandMethodBind(className OpenXRActionMap, "get_action_set_count", 3905245786)
@@ -43,16 +43,16 @@ proc removeActionSet*(self: OpenXRActionMap; actionSet: gdref OpenXRActionSet): 
   expandMethodBind(className OpenXRActionMap, "remove_action_set", 2093310581)
   methodbind.ptrcall(self, [getPtr actionSet])
 
-proc setInteractionProfiles*(self: OpenXRActionMap; interactionProfiles: Array): void =
+proc setInteractionProfiles*(self: OpenXRActionMap; interactionProfiles: Array[Variant]): void =
   expandMethodBind(className OpenXRActionMap, "set_interaction_profiles", 381264803)
   nilCheck interactionProfiles
   methodbind.ptrcall(self, [getPtr interactionProfiles])
 
-proc getInteractionProfiles*(self: OpenXRActionMap): Array =
+proc getInteractionProfiles*(self: OpenXRActionMap): Array[Variant] =
   expandMethodBind(className OpenXRActionMap, "get_interaction_profiles", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc getInteractionProfileCount*(self: OpenXRActionMap): int32 =
   expandMethodBind(className OpenXRActionMap, "get_interaction_profile_count", 3905245786)

--- a/src/gdext/classes/gdopenxractionset.nim
+++ b/src/gdext/classes/gdopenxractionset.nim
@@ -32,16 +32,16 @@ proc getActionCount*(self: OpenXRActionSet): int32 =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(int32)
 
-proc setActions*(self: OpenXRActionSet; actions: Array): void =
+proc setActions*(self: OpenXRActionSet; actions: Array[Variant]): void =
   expandMethodBind(className OpenXRActionSet, "set_actions", 381264803)
   nilCheck actions
   methodbind.ptrcall(self, [getPtr actions])
 
-proc getActions*(self: OpenXRActionSet): Array =
+proc getActions*(self: OpenXRActionSet): Array[Variant] =
   expandMethodBind(className OpenXRActionSet, "get_actions", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc addAction*(self: OpenXRActionSet; action: gdref OpenXRAction): void =
   expandMethodBind(className OpenXRActionSet, "add_action", 349361333)

--- a/src/gdext/classes/gdopenxrapiextension.nim
+++ b/src/gdext/classes/gdopenxrapiextension.nim
@@ -30,7 +30,7 @@ proc transformFromPose*(self: OpenXRAPIExtension; pose: pointer): Transform3D =
   methodbind.ptrcall(self, [getPtr pose], addr ret)
   (addr ret).decode_result(Transform3D)
 
-proc xrResult*(self: OpenXRAPIExtension; retval: uint64; format: String; args: Array): bool =
+proc xrResult*(self: OpenXRAPIExtension; retval: uint64; format: String; args: Array[Variant]): bool =
   expandMethodBind(className OpenXRAPIExtension, "xr_result", 3886436197)
   nilCheck args
   var ret: encoded bool

--- a/src/gdext/classes/gdopenxrextensionwrapper.nim
+++ b/src/gdext/classes/gdopenxrextensionwrapper.nim
@@ -191,7 +191,7 @@ proc registerVirtual_setViewportCompositionLayerAndGetNextPointer*[T: OpenXRExte
   Self.vmethods[newStringName"_set_viewport_composition_layer_and_get_next_pointer"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[OpenXRExtensionWrapper](p_instance).setViewportCompositionLayerAndGetNextPointer(p_args[0].decode(pointer), p_args[1].decode(Dictionary), p_args[2].decode(pointer)).encode(r_ret)
 
-method getViewportCompositionLayerExtensionProperties*(self: OpenXRExtensionWrapper): TypedArray[Dictionary] {.base.} = (discard)
+method getViewportCompositionLayerExtensionProperties*(self: OpenXRExtensionWrapper): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_getViewportCompositionLayerExtensionProperties*[T: OpenXRExtensionWrapper](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_viewport_composition_layer_extension_properties"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[OpenXRExtensionWrapper](p_instance).getViewportCompositionLayerExtensionProperties().encode(r_ret)

--- a/src/gdext/classes/gdopenxrinteractionprofile.nim
+++ b/src/gdext/classes/gdopenxrinteractionprofile.nim
@@ -28,16 +28,16 @@ proc getBinding*(self: OpenXRInteractionProfile; index: int32): gdref OpenXRIPBi
   methodbind.ptrcall(self, [getPtr index], addr ret)
   (addr ret).decode_result(gdref OpenXRIPBinding)
 
-proc setBindings*(self: OpenXRInteractionProfile; bindings: Array): void =
+proc setBindings*(self: OpenXRInteractionProfile; bindings: Array[Variant]): void =
   expandMethodBind(className OpenXRInteractionProfile, "set_bindings", 381264803)
   nilCheck bindings
   methodbind.ptrcall(self, [getPtr bindings])
 
-proc getBindings*(self: OpenXRInteractionProfile): Array =
+proc getBindings*(self: OpenXRInteractionProfile): Array[Variant] =
   expandMethodBind(className OpenXRInteractionProfile, "get_bindings", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc getBindingModifierCount*(self: OpenXRInteractionProfile): int32 =
   expandMethodBind(className OpenXRInteractionProfile, "get_binding_modifier_count", 3905245786)
@@ -51,16 +51,16 @@ proc getBindingModifier*(self: OpenXRInteractionProfile; index: int32): gdref Op
   methodbind.ptrcall(self, [getPtr index], addr ret)
   (addr ret).decode_result(gdref OpenXRIPBindingModifier)
 
-proc setBindingModifiers*(self: OpenXRInteractionProfile; bindingModifiers: Array): void =
+proc setBindingModifiers*(self: OpenXRInteractionProfile; bindingModifiers: Array[Variant]): void =
   expandMethodBind(className OpenXRInteractionProfile, "set_binding_modifiers", 381264803)
   nilCheck bindingModifiers
   methodbind.ptrcall(self, [getPtr bindingModifiers])
 
-proc getBindingModifiers*(self: OpenXRInteractionProfile): Array =
+proc getBindingModifiers*(self: OpenXRInteractionProfile): Array[Variant] =
   expandMethodBind(className OpenXRInteractionProfile, "get_binding_modifiers", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 template interactionProfilePath*(self: OpenXRInteractionProfile): untyped = self.getInteractionProfilePath()
 template `interactionProfilePath=`*(self: OpenXRInteractionProfile; value) = self.setInteractionProfilePath(value)

--- a/src/gdext/classes/gdopenxrinterface.nim
+++ b/src/gdext/classes/gdopenxrinterface.nim
@@ -68,17 +68,17 @@ proc setActionSetActive*(self: OpenXRInterface; name: String; active: bool): voi
   expandMethodBind(className OpenXRInterface, "set_action_set_active", 2678287736)
   methodbind.ptrcall(self, [getPtr name, getPtr active])
 
-proc getActionSets*(self: OpenXRInterface): Array =
+proc getActionSets*(self: OpenXRInterface): Array[Variant] =
   expandMethodBind(className OpenXRInterface, "get_action_sets", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
-proc getAvailableDisplayRefreshRates*(self: OpenXRInterface): Array =
+proc getAvailableDisplayRefreshRates*(self: OpenXRInterface): Array[Variant] =
   expandMethodBind(className OpenXRInterface, "get_available_display_refresh_rates", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc setMotionRange*(self: OpenXRInterface; hand: OpenXRInterface_Hand; motionRange: OpenXRInterface_HandMotionRange): void =
   expandMethodBind(className OpenXRInterface, "set_motion_range", 855158159)

--- a/src/gdext/classes/gdopenxripbinding.nim
+++ b/src/gdext/classes/gdopenxripbinding.nim
@@ -38,16 +38,16 @@ proc getBindingModifier*(self: OpenXRIPBinding; index: int32): gdref OpenXRActio
   methodbind.ptrcall(self, [getPtr index], addr ret)
   (addr ret).decode_result(gdref OpenXRActionBindingModifier)
 
-proc setBindingModifiers*(self: OpenXRIPBinding; bindingModifiers: Array): void =
+proc setBindingModifiers*(self: OpenXRIPBinding; bindingModifiers: Array[Variant]): void =
   expandMethodBind(className OpenXRIPBinding, "set_binding_modifiers", 381264803)
   nilCheck bindingModifiers
   methodbind.ptrcall(self, [getPtr bindingModifiers])
 
-proc getBindingModifiers*(self: OpenXRIPBinding): Array =
+proc getBindingModifiers*(self: OpenXRIPBinding): Array[Variant] =
   expandMethodBind(className OpenXRIPBinding, "get_binding_modifiers", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc setPaths*(self: OpenXRIPBinding; paths: PackedStringArray): void =
   expandMethodBind(className OpenXRIPBinding, "set_paths", 4015028928)

--- a/src/gdext/classes/gdopenxrrendermodelextension.nim
+++ b/src/gdext/classes/gdopenxrrendermodelextension.nim
@@ -22,11 +22,11 @@ proc renderModelDestroy*(self: OpenXRRenderModelExtension; renderModel: RID): vo
   expandMethodBind(className OpenXRRenderModelExtension, "render_model_destroy", 2722037293)
   methodbind.ptrcall(self, [getPtr renderModel])
 
-proc renderModelGetAll*(self: OpenXRRenderModelExtension): TypedArray[RID] =
+proc renderModelGetAll*(self: OpenXRRenderModelExtension): Array[RID] =
   expandMethodBind(className OpenXRRenderModelExtension, "render_model_get_all", 2915620761)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 proc renderModelNewSceneInstance*(self: OpenXRRenderModelExtension; renderModel: RID): Node3D =
   expandMethodBind(className OpenXRRenderModelExtension, "render_model_new_scene_instance", 788010739)

--- a/src/gdext/classes/gdos.nim
+++ b/src/gdext/classes/gdos.nim
@@ -136,7 +136,7 @@ proc getStderrType*(self: OS): OS_StdHandleType =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(OS_StdHandleType)
 
-proc execute*(self: OS; path: String; arguments: PackedStringArray; output: Array = newArray(); readStderr: bool = false; openConsole: bool = false): int32 =
+proc execute*(self: OS; path: String; arguments: PackedStringArray; output: Array[Variant] = newArray[Variant](); readStderr: bool = false; openConsole: bool = false): int32 =
   expandMethodBind(className OS, "execute", 1488299882)
   nilCheck output
   var ret: encoded int32

--- a/src/gdext/classes/gdperformance.nim
+++ b/src/gdext/classes/gdperformance.nim
@@ -12,7 +12,7 @@ proc getMonitor*(self: Performance; monitor: Performance_Monitor): float64 =
   methodbind.ptrcall(self, [getPtr monitor], addr ret)
   (addr ret).decode_result(float64)
 
-proc addCustomMonitor*(self: Performance; id: StringName; callable: Callable; arguments: Array = newArray()): void =
+proc addCustomMonitor*(self: Performance; id: StringName; callable: Callable; arguments: Array[Variant] = newArray[Variant]()): void =
   expandMethodBind(className Performance, "add_custom_monitor", 4099036814)
   nilCheck arguments
   methodbind.ptrcall(self, [getPtr id, getPtr callable, getPtr arguments])
@@ -39,8 +39,8 @@ proc getMonitorModificationTime*(self: Performance): uint64 =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(uint64)
 
-proc getCustomMonitorNames*(self: Performance): TypedArray[StringName] =
+proc getCustomMonitorNames*(self: Performance): Array[StringName] =
   expandMethodBind(className Performance, "get_custom_monitor_names", 2915620761)
-  var ret: encoded TypedArray[StringName]
+  var ret: encoded Array[StringName]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[StringName])
+  (addr ret).decode_result(Array[StringName])

--- a/src/gdext/classes/gdphysicalbonesimulator3d.nim
+++ b/src/gdext/classes/gdphysicalbonesimulator3d.nim
@@ -16,7 +16,7 @@ proc physicalBonesStopSimulation*(self: PhysicalBoneSimulator3D): void =
   expandMethodBind(className PhysicalBoneSimulator3D, "physical_bones_stop_simulation", 3218959716)
   methodbind.ptrcall(self, [])
 
-proc physicalBonesStartSimulation*(self: PhysicalBoneSimulator3D; bones: TypedArray[StringName] = newTypedArray[StringName]()): void =
+proc physicalBonesStartSimulation*(self: PhysicalBoneSimulator3D; bones: Array[StringName] = newArray[StringName]()): void =
   expandMethodBind(className PhysicalBoneSimulator3D, "physical_bones_start_simulation", 2787316981)
   nilCheck bones
   methodbind.ptrcall(self, [getPtr bones])

--- a/src/gdext/classes/gdphysicsbody2d.nim
+++ b/src/gdext/classes/gdphysicsbody2d.nim
@@ -24,11 +24,11 @@ proc getGravity*(self: PhysicsBody2D): Vector2 =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Vector2)
 
-proc getCollisionExceptions*(self: PhysicsBody2D): TypedArray[PhysicsBody2D] =
+proc getCollisionExceptions*(self: PhysicsBody2D): Array[PhysicsBody2D] =
   expandMethodBind(className PhysicsBody2D, "get_collision_exceptions", 2915620761)
-  var ret: encoded TypedArray[PhysicsBody2D]
+  var ret: encoded Array[PhysicsBody2D]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[PhysicsBody2D])
+  (addr ret).decode_result(Array[PhysicsBody2D])
 
 proc addCollisionExceptionWith*(self: PhysicsBody2D; body: Node): void =
   expandMethodBind(className PhysicsBody2D, "add_collision_exception_with", 1078189570)

--- a/src/gdext/classes/gdphysicsbody3d.nim
+++ b/src/gdext/classes/gdphysicsbody3d.nim
@@ -34,11 +34,11 @@ proc getAxisLock*(self: PhysicsBody3D; axis: PhysicsServer3D_BodyAxis): bool =
   methodbind.ptrcall(self, [getPtr axis], addr ret)
   (addr ret).decode_result(bool)
 
-proc getCollisionExceptions*(self: PhysicsBody3D): TypedArray[PhysicsBody3D] =
+proc getCollisionExceptions*(self: PhysicsBody3D): Array[PhysicsBody3D] =
   expandMethodBind(className PhysicsBody3D, "get_collision_exceptions", 2915620761)
-  var ret: encoded TypedArray[PhysicsBody3D]
+  var ret: encoded Array[PhysicsBody3D]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[PhysicsBody3D])
+  (addr ret).decode_result(Array[PhysicsBody3D])
 
 proc addCollisionExceptionWith*(self: PhysicsBody3D; body: Node): void =
   expandMethodBind(className PhysicsBody3D, "add_collision_exception_with", 1078189570)

--- a/src/gdext/classes/gdphysicsdirectspacestate2d.nim
+++ b/src/gdext/classes/gdphysicsdirectspacestate2d.nim
@@ -6,11 +6,11 @@ import gdobject; export gdobject
 
 expandOnClassImported(PhysicsDirectSpaceState2D, Object)
 
-proc intersectPoint*(self: PhysicsDirectSpaceState2D; parameters: gdref PhysicsPointQueryParameters2D; maxRetvals: int32 = 32): TypedArray[Dictionary] =
+proc intersectPoint*(self: PhysicsDirectSpaceState2D; parameters: gdref PhysicsPointQueryParameters2D; maxRetvals: int32 = 32): Array[Dictionary] =
   expandMethodBind(className PhysicsDirectSpaceState2D, "intersect_point", 2118456068)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr parameters, getPtr maxRetvals], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc intersectRay*(self: PhysicsDirectSpaceState2D; parameters: gdref PhysicsRayQueryParameters2D): Dictionary =
   expandMethodBind(className PhysicsDirectSpaceState2D, "intersect_ray", 1590275562)
@@ -18,11 +18,11 @@ proc intersectRay*(self: PhysicsDirectSpaceState2D; parameters: gdref PhysicsRay
   methodbind.ptrcall(self, [getPtr parameters], addr ret)
   (addr ret).decode_result(Dictionary)
 
-proc intersectShape*(self: PhysicsDirectSpaceState2D; parameters: gdref PhysicsShapeQueryParameters2D; maxRetvals: int32 = 32): TypedArray[Dictionary] =
+proc intersectShape*(self: PhysicsDirectSpaceState2D; parameters: gdref PhysicsShapeQueryParameters2D; maxRetvals: int32 = 32): Array[Dictionary] =
   expandMethodBind(className PhysicsDirectSpaceState2D, "intersect_shape", 2488867228)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr parameters, getPtr maxRetvals], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc castMotion*(self: PhysicsDirectSpaceState2D; parameters: gdref PhysicsShapeQueryParameters2D): PackedFloat32Array =
   expandMethodBind(className PhysicsDirectSpaceState2D, "cast_motion", 711275086)
@@ -30,11 +30,11 @@ proc castMotion*(self: PhysicsDirectSpaceState2D; parameters: gdref PhysicsShape
   methodbind.ptrcall(self, [getPtr parameters], addr ret)
   (addr ret).decode_result(PackedFloat32Array)
 
-proc collideShape*(self: PhysicsDirectSpaceState2D; parameters: gdref PhysicsShapeQueryParameters2D; maxRetvals: int32 = 32): TypedArray[Vector2] =
+proc collideShape*(self: PhysicsDirectSpaceState2D; parameters: gdref PhysicsShapeQueryParameters2D; maxRetvals: int32 = 32): Array[Vector2] =
   expandMethodBind(className PhysicsDirectSpaceState2D, "collide_shape", 2488867228)
-  var ret: encoded TypedArray[Vector2]
+  var ret: encoded Array[Vector2]
   methodbind.ptrcall(self, [getPtr parameters, getPtr maxRetvals], addr ret)
-  (addr ret).decode_result(TypedArray[Vector2])
+  (addr ret).decode_result(Array[Vector2])
 
 proc getRestInfo*(self: PhysicsDirectSpaceState2D; parameters: gdref PhysicsShapeQueryParameters2D): Dictionary =
   expandMethodBind(className PhysicsDirectSpaceState2D, "get_rest_info", 2803666496)

--- a/src/gdext/classes/gdphysicsdirectspacestate3d.nim
+++ b/src/gdext/classes/gdphysicsdirectspacestate3d.nim
@@ -6,11 +6,11 @@ import gdobject; export gdobject
 
 expandOnClassImported(PhysicsDirectSpaceState3D, Object)
 
-proc intersectPoint*(self: PhysicsDirectSpaceState3D; parameters: gdref PhysicsPointQueryParameters3D; maxRetvals: int32 = 32): TypedArray[Dictionary] =
+proc intersectPoint*(self: PhysicsDirectSpaceState3D; parameters: gdref PhysicsPointQueryParameters3D; maxRetvals: int32 = 32): Array[Dictionary] =
   expandMethodBind(className PhysicsDirectSpaceState3D, "intersect_point", 975173756)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr parameters, getPtr maxRetvals], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc intersectRay*(self: PhysicsDirectSpaceState3D; parameters: gdref PhysicsRayQueryParameters3D): Dictionary =
   expandMethodBind(className PhysicsDirectSpaceState3D, "intersect_ray", 3957970750)
@@ -18,11 +18,11 @@ proc intersectRay*(self: PhysicsDirectSpaceState3D; parameters: gdref PhysicsRay
   methodbind.ptrcall(self, [getPtr parameters], addr ret)
   (addr ret).decode_result(Dictionary)
 
-proc intersectShape*(self: PhysicsDirectSpaceState3D; parameters: gdref PhysicsShapeQueryParameters3D; maxRetvals: int32 = 32): TypedArray[Dictionary] =
+proc intersectShape*(self: PhysicsDirectSpaceState3D; parameters: gdref PhysicsShapeQueryParameters3D; maxRetvals: int32 = 32): Array[Dictionary] =
   expandMethodBind(className PhysicsDirectSpaceState3D, "intersect_shape", 3762137681)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr parameters, getPtr maxRetvals], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc castMotion*(self: PhysicsDirectSpaceState3D; parameters: gdref PhysicsShapeQueryParameters3D): PackedFloat32Array =
   expandMethodBind(className PhysicsDirectSpaceState3D, "cast_motion", 1778757334)
@@ -30,11 +30,11 @@ proc castMotion*(self: PhysicsDirectSpaceState3D; parameters: gdref PhysicsShape
   methodbind.ptrcall(self, [getPtr parameters], addr ret)
   (addr ret).decode_result(PackedFloat32Array)
 
-proc collideShape*(self: PhysicsDirectSpaceState3D; parameters: gdref PhysicsShapeQueryParameters3D; maxRetvals: int32 = 32): TypedArray[Vector3] =
+proc collideShape*(self: PhysicsDirectSpaceState3D; parameters: gdref PhysicsShapeQueryParameters3D; maxRetvals: int32 = 32): Array[Vector3] =
   expandMethodBind(className PhysicsDirectSpaceState3D, "collide_shape", 3762137681)
-  var ret: encoded TypedArray[Vector3]
+  var ret: encoded Array[Vector3]
   methodbind.ptrcall(self, [getPtr parameters, getPtr maxRetvals], addr ret)
-  (addr ret).decode_result(TypedArray[Vector3])
+  (addr ret).decode_result(Array[Vector3])
 
 proc getRestInfo*(self: PhysicsDirectSpaceState3D; parameters: gdref PhysicsShapeQueryParameters3D): Dictionary =
   expandMethodBind(className PhysicsDirectSpaceState3D, "get_rest_info", 1376751592)

--- a/src/gdext/classes/gdphysicspointqueryparameters2d.nim
+++ b/src/gdext/classes/gdphysicspointqueryparameters2d.nim
@@ -36,16 +36,16 @@ proc getCollisionMask*(self: PhysicsPointQueryParameters2D): uint32 =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(uint32)
 
-proc setExclude*(self: PhysicsPointQueryParameters2D; exclude: TypedArray[RID]): void =
+proc setExclude*(self: PhysicsPointQueryParameters2D; exclude: Array[RID]): void =
   expandMethodBind(className PhysicsPointQueryParameters2D, "set_exclude", 381264803)
   nilCheck exclude
   methodbind.ptrcall(self, [getPtr exclude])
 
-proc getExclude*(self: PhysicsPointQueryParameters2D): TypedArray[RID] =
+proc getExclude*(self: PhysicsPointQueryParameters2D): Array[RID] =
   expandMethodBind(className PhysicsPointQueryParameters2D, "get_exclude", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 proc setCollideWithBodies*(self: PhysicsPointQueryParameters2D; enable: bool): void =
   expandMethodBind(className PhysicsPointQueryParameters2D, "set_collide_with_bodies", 2586408642)

--- a/src/gdext/classes/gdphysicspointqueryparameters3d.nim
+++ b/src/gdext/classes/gdphysicspointqueryparameters3d.nim
@@ -26,16 +26,16 @@ proc getCollisionMask*(self: PhysicsPointQueryParameters3D): uint32 =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(uint32)
 
-proc setExclude*(self: PhysicsPointQueryParameters3D; exclude: TypedArray[RID]): void =
+proc setExclude*(self: PhysicsPointQueryParameters3D; exclude: Array[RID]): void =
   expandMethodBind(className PhysicsPointQueryParameters3D, "set_exclude", 381264803)
   nilCheck exclude
   methodbind.ptrcall(self, [getPtr exclude])
 
-proc getExclude*(self: PhysicsPointQueryParameters3D): TypedArray[RID] =
+proc getExclude*(self: PhysicsPointQueryParameters3D): Array[RID] =
   expandMethodBind(className PhysicsPointQueryParameters3D, "get_exclude", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 proc setCollideWithBodies*(self: PhysicsPointQueryParameters3D; enable: bool): void =
   expandMethodBind(className PhysicsPointQueryParameters3D, "set_collide_with_bodies", 2586408642)

--- a/src/gdext/classes/gdphysicsrayqueryparameters2d.nim
+++ b/src/gdext/classes/gdphysicsrayqueryparameters2d.nim
@@ -6,7 +6,7 @@ import gdrefcounted; export gdrefcounted
 
 expandOnClassImported(PhysicsRayQueryParameters2D, RefCounted)
 
-proc create*(_: typedesc[PhysicsRayQueryParameters2D]; `from`: Vector2; to: Vector2; collisionMask: uint32 = 4294967295'u32; exclude: TypedArray[RID] = newTypedArray[RID]()): gdref PhysicsRayQueryParameters2D =
+proc create*(_: typedesc[PhysicsRayQueryParameters2D]; `from`: Vector2; to: Vector2; collisionMask: uint32 = 4294967295'u32; exclude: Array[RID] = newArray[RID]()): gdref PhysicsRayQueryParameters2D =
   expandMethodBind(className PhysicsRayQueryParameters2D, "create", 3196569324)
   nilCheck exclude
   var ret: encoded gdref PhysicsRayQueryParameters2D
@@ -43,16 +43,16 @@ proc getCollisionMask*(self: PhysicsRayQueryParameters2D): uint32 =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(uint32)
 
-proc setExclude*(self: PhysicsRayQueryParameters2D; exclude: TypedArray[RID]): void =
+proc setExclude*(self: PhysicsRayQueryParameters2D; exclude: Array[RID]): void =
   expandMethodBind(className PhysicsRayQueryParameters2D, "set_exclude", 381264803)
   nilCheck exclude
   methodbind.ptrcall(self, [getPtr exclude])
 
-proc getExclude*(self: PhysicsRayQueryParameters2D): TypedArray[RID] =
+proc getExclude*(self: PhysicsRayQueryParameters2D): Array[RID] =
   expandMethodBind(className PhysicsRayQueryParameters2D, "get_exclude", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 proc setCollideWithBodies*(self: PhysicsRayQueryParameters2D; enable: bool): void =
   expandMethodBind(className PhysicsRayQueryParameters2D, "set_collide_with_bodies", 2586408642)

--- a/src/gdext/classes/gdphysicsrayqueryparameters3d.nim
+++ b/src/gdext/classes/gdphysicsrayqueryparameters3d.nim
@@ -6,7 +6,7 @@ import gdrefcounted; export gdrefcounted
 
 expandOnClassImported(PhysicsRayQueryParameters3D, RefCounted)
 
-proc create*(_: typedesc[PhysicsRayQueryParameters3D]; `from`: Vector3; to: Vector3; collisionMask: uint32 = 4294967295'u32; exclude: TypedArray[RID] = newTypedArray[RID]()): gdref PhysicsRayQueryParameters3D =
+proc create*(_: typedesc[PhysicsRayQueryParameters3D]; `from`: Vector3; to: Vector3; collisionMask: uint32 = 4294967295'u32; exclude: Array[RID] = newArray[RID]()): gdref PhysicsRayQueryParameters3D =
   expandMethodBind(className PhysicsRayQueryParameters3D, "create", 3110599579)
   nilCheck exclude
   var ret: encoded gdref PhysicsRayQueryParameters3D
@@ -43,16 +43,16 @@ proc getCollisionMask*(self: PhysicsRayQueryParameters3D): uint32 =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(uint32)
 
-proc setExclude*(self: PhysicsRayQueryParameters3D; exclude: TypedArray[RID]): void =
+proc setExclude*(self: PhysicsRayQueryParameters3D; exclude: Array[RID]): void =
   expandMethodBind(className PhysicsRayQueryParameters3D, "set_exclude", 381264803)
   nilCheck exclude
   methodbind.ptrcall(self, [getPtr exclude])
 
-proc getExclude*(self: PhysicsRayQueryParameters3D): TypedArray[RID] =
+proc getExclude*(self: PhysicsRayQueryParameters3D): Array[RID] =
   expandMethodBind(className PhysicsRayQueryParameters3D, "get_exclude", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 proc setCollideWithBodies*(self: PhysicsRayQueryParameters3D; enable: bool): void =
   expandMethodBind(className PhysicsRayQueryParameters3D, "set_collide_with_bodies", 2586408642)

--- a/src/gdext/classes/gdphysicsserver2dextension.nim
+++ b/src/gdext/classes/gdphysicsserver2dextension.nim
@@ -501,7 +501,7 @@ proc registerVirtual_bodyRemoveCollisionException*[T: PhysicsServer2DExtension](
   Self.vmethods[newStringName"_body_remove_collision_exception"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[PhysicsServer2DExtension](p_instance).bodyRemoveCollisionException(p_args[0].decode(RID), p_args[1].decode(RID))
 
-method bodyGetCollisionExceptions*(self: PhysicsServer2DExtension; body: RID): TypedArray[RID] {.base.} = (discard)
+method bodyGetCollisionExceptions*(self: PhysicsServer2DExtension; body: RID): Array[RID] {.base.} = (discard)
 proc registerVirtual_bodyGetCollisionExceptions*[T: PhysicsServer2DExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_body_get_collision_exceptions"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[PhysicsServer2DExtension](p_instance).bodyGetCollisionExceptions(p_args[0].decode(RID)).encode(r_ret)

--- a/src/gdext/classes/gdphysicsserver3dextension.nim
+++ b/src/gdext/classes/gdphysicsserver3dextension.nim
@@ -511,7 +511,7 @@ proc registerVirtual_bodyRemoveCollisionException*[T: PhysicsServer3DExtension](
   Self.vmethods[newStringName"_body_remove_collision_exception"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[PhysicsServer3DExtension](p_instance).bodyRemoveCollisionException(p_args[0].decode(RID), p_args[1].decode(RID))
 
-method bodyGetCollisionExceptions*(self: PhysicsServer3DExtension; body: RID): TypedArray[RID] {.base.} = (discard)
+method bodyGetCollisionExceptions*(self: PhysicsServer3DExtension; body: RID): Array[RID] {.base.} = (discard)
 proc registerVirtual_bodyGetCollisionExceptions*[T: PhysicsServer3DExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_body_get_collision_exceptions"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[PhysicsServer3DExtension](p_instance).bodyGetCollisionExceptions(p_args[0].decode(RID)).encode(r_ret)
@@ -626,7 +626,7 @@ proc registerVirtual_softBodyRemoveCollisionException*[T: PhysicsServer3DExtensi
   Self.vmethods[newStringName"_soft_body_remove_collision_exception"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[PhysicsServer3DExtension](p_instance).softBodyRemoveCollisionException(p_args[0].decode(RID), p_args[1].decode(RID))
 
-method softBodyGetCollisionExceptions*(self: PhysicsServer3DExtension; body: RID): TypedArray[RID] {.base.} = (discard)
+method softBodyGetCollisionExceptions*(self: PhysicsServer3DExtension; body: RID): Array[RID] {.base.} = (discard)
 proc registerVirtual_softBodyGetCollisionExceptions*[T: PhysicsServer3DExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_soft_body_get_collision_exceptions"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[PhysicsServer3DExtension](p_instance).softBodyGetCollisionExceptions(p_args[0].decode(RID)).encode(r_ret)

--- a/src/gdext/classes/gdphysicsshapequeryparameters2d.nim
+++ b/src/gdext/classes/gdphysicsshapequeryparameters2d.nim
@@ -66,16 +66,16 @@ proc getCollisionMask*(self: PhysicsShapeQueryParameters2D): uint32 =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(uint32)
 
-proc setExclude*(self: PhysicsShapeQueryParameters2D; exclude: TypedArray[RID]): void =
+proc setExclude*(self: PhysicsShapeQueryParameters2D; exclude: Array[RID]): void =
   expandMethodBind(className PhysicsShapeQueryParameters2D, "set_exclude", 381264803)
   nilCheck exclude
   methodbind.ptrcall(self, [getPtr exclude])
 
-proc getExclude*(self: PhysicsShapeQueryParameters2D): TypedArray[RID] =
+proc getExclude*(self: PhysicsShapeQueryParameters2D): Array[RID] =
   expandMethodBind(className PhysicsShapeQueryParameters2D, "get_exclude", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 proc setCollideWithBodies*(self: PhysicsShapeQueryParameters2D; enable: bool): void =
   expandMethodBind(className PhysicsShapeQueryParameters2D, "set_collide_with_bodies", 2586408642)

--- a/src/gdext/classes/gdphysicsshapequeryparameters3d.nim
+++ b/src/gdext/classes/gdphysicsshapequeryparameters3d.nim
@@ -66,16 +66,16 @@ proc getCollisionMask*(self: PhysicsShapeQueryParameters3D): uint32 =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(uint32)
 
-proc setExclude*(self: PhysicsShapeQueryParameters3D; exclude: TypedArray[RID]): void =
+proc setExclude*(self: PhysicsShapeQueryParameters3D; exclude: Array[RID]): void =
   expandMethodBind(className PhysicsShapeQueryParameters3D, "set_exclude", 381264803)
   nilCheck exclude
   methodbind.ptrcall(self, [getPtr exclude])
 
-proc getExclude*(self: PhysicsShapeQueryParameters3D): TypedArray[RID] =
+proc getExclude*(self: PhysicsShapeQueryParameters3D): Array[RID] =
   expandMethodBind(className PhysicsShapeQueryParameters3D, "get_exclude", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 proc setCollideWithBodies*(self: PhysicsShapeQueryParameters3D; enable: bool): void =
   expandMethodBind(className PhysicsShapeQueryParameters3D, "set_collide_with_bodies", 2586408642)

--- a/src/gdext/classes/gdphysicstestmotionparameters2d.nim
+++ b/src/gdext/classes/gdphysicstestmotionparameters2d.nim
@@ -46,24 +46,24 @@ proc setCollideSeparationRayEnabled*(self: PhysicsTestMotionParameters2D; enable
   expandMethodBind(className PhysicsTestMotionParameters2D, "set_collide_separation_ray_enabled", 2586408642)
   methodbind.ptrcall(self, [getPtr enabled])
 
-proc getExcludeBodies*(self: PhysicsTestMotionParameters2D): TypedArray[RID] =
+proc getExcludeBodies*(self: PhysicsTestMotionParameters2D): Array[RID] =
   expandMethodBind(className PhysicsTestMotionParameters2D, "get_exclude_bodies", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
-proc setExcludeBodies*(self: PhysicsTestMotionParameters2D; excludeList: TypedArray[RID]): void =
+proc setExcludeBodies*(self: PhysicsTestMotionParameters2D; excludeList: Array[RID]): void =
   expandMethodBind(className PhysicsTestMotionParameters2D, "set_exclude_bodies", 381264803)
   nilCheck excludeList
   methodbind.ptrcall(self, [getPtr excludeList])
 
-proc getExcludeObjects*(self: PhysicsTestMotionParameters2D): TypedArray[Int] =
+proc getExcludeObjects*(self: PhysicsTestMotionParameters2D): Array[Int] =
   expandMethodBind(className PhysicsTestMotionParameters2D, "get_exclude_objects", 3995934104)
-  var ret: encoded TypedArray[Int]
+  var ret: encoded Array[Int]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Int])
+  (addr ret).decode_result(Array[Int])
 
-proc setExcludeObjects*(self: PhysicsTestMotionParameters2D; excludeList: TypedArray[Int]): void =
+proc setExcludeObjects*(self: PhysicsTestMotionParameters2D; excludeList: Array[Int]): void =
   expandMethodBind(className PhysicsTestMotionParameters2D, "set_exclude_objects", 381264803)
   nilCheck excludeList
   methodbind.ptrcall(self, [getPtr excludeList])

--- a/src/gdext/classes/gdphysicstestmotionparameters3d.nim
+++ b/src/gdext/classes/gdphysicstestmotionparameters3d.nim
@@ -56,24 +56,24 @@ proc setCollideSeparationRayEnabled*(self: PhysicsTestMotionParameters3D; enable
   expandMethodBind(className PhysicsTestMotionParameters3D, "set_collide_separation_ray_enabled", 2586408642)
   methodbind.ptrcall(self, [getPtr enabled])
 
-proc getExcludeBodies*(self: PhysicsTestMotionParameters3D): TypedArray[RID] =
+proc getExcludeBodies*(self: PhysicsTestMotionParameters3D): Array[RID] =
   expandMethodBind(className PhysicsTestMotionParameters3D, "get_exclude_bodies", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
-proc setExcludeBodies*(self: PhysicsTestMotionParameters3D; excludeList: TypedArray[RID]): void =
+proc setExcludeBodies*(self: PhysicsTestMotionParameters3D; excludeList: Array[RID]): void =
   expandMethodBind(className PhysicsTestMotionParameters3D, "set_exclude_bodies", 381264803)
   nilCheck excludeList
   methodbind.ptrcall(self, [getPtr excludeList])
 
-proc getExcludeObjects*(self: PhysicsTestMotionParameters3D): TypedArray[Int] =
+proc getExcludeObjects*(self: PhysicsTestMotionParameters3D): Array[Int] =
   expandMethodBind(className PhysicsTestMotionParameters3D, "get_exclude_objects", 3995934104)
-  var ret: encoded TypedArray[Int]
+  var ret: encoded Array[Int]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Int])
+  (addr ret).decode_result(Array[Int])
 
-proc setExcludeObjects*(self: PhysicsTestMotionParameters3D; excludeList: TypedArray[Int]): void =
+proc setExcludeObjects*(self: PhysicsTestMotionParameters3D; excludeList: Array[Int]): void =
   expandMethodBind(className PhysicsTestMotionParameters3D, "set_exclude_objects", 381264803)
   nilCheck excludeList
   methodbind.ptrcall(self, [getPtr excludeList])

--- a/src/gdext/classes/gdpolygon2d.nim
+++ b/src/gdext/classes/gdpolygon2d.nim
@@ -36,16 +36,16 @@ proc getColor*(self: Polygon2D): Color =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Color)
 
-proc setPolygons*(self: Polygon2D; polygons: Array): void =
+proc setPolygons*(self: Polygon2D; polygons: Array[Variant]): void =
   expandMethodBind(className Polygon2D, "set_polygons", 381264803)
   nilCheck polygons
   methodbind.ptrcall(self, [getPtr polygons])
 
-proc getPolygons*(self: Polygon2D): Array =
+proc getPolygons*(self: Polygon2D): Array[Variant] =
   expandMethodBind(className Polygon2D, "get_polygons", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc setVertexColors*(self: Polygon2D; vertexColors: PackedColorArray): void =
   expandMethodBind(className Polygon2D, "set_vertex_colors", 3546319833)

--- a/src/gdext/classes/gdprimitivemesh.nim
+++ b/src/gdext/classes/gdprimitivemesh.nim
@@ -6,7 +6,7 @@ import gdmesh; export gdmesh
 
 expandOnClassImported(PrimitiveMesh, Mesh)
 
-method createMeshArray*(self: PrimitiveMesh): Array {.base.} = (discard)
+method createMeshArray*(self: PrimitiveMesh): Array[Variant] {.base.} = (discard)
 proc registerVirtual_createMeshArray*[T: PrimitiveMesh](Self: typedesc[T]) =
   Self.vmethods[newStringName"_create_mesh_array"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[PrimitiveMesh](p_instance).createMeshArray().encode(r_ret)
@@ -21,11 +21,11 @@ proc getMaterial*(self: PrimitiveMesh): gdref Material =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(gdref Material)
 
-proc getMeshArrays*(self: PrimitiveMesh): Array =
+proc getMeshArrays*(self: PrimitiveMesh): Array[Variant] =
   expandMethodBind(className PrimitiveMesh, "get_mesh_arrays", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc setCustomAabb*(self: PrimitiveMesh; aabb: AABB): void =
   expandMethodBind(className PrimitiveMesh, "set_custom_aabb", 259215842)

--- a/src/gdext/classes/gdprojectsettings.nim
+++ b/src/gdext/classes/gdprojectsettings.nim
@@ -28,11 +28,11 @@ proc getSettingWithOverride*(self: ProjectSettings; name: StringName): Variant =
   methodbind.ptrcall(self, [getPtr name], addr ret)
   (addr ret).decode_result(Variant)
 
-proc getGlobalClassList*(self: ProjectSettings): TypedArray[Dictionary] =
+proc getGlobalClassList*(self: ProjectSettings): Array[Dictionary] =
   expandMethodBind(className ProjectSettings, "get_global_class_list", 2915620761)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc getSettingWithOverrideAndCustomFeatures*(self: ProjectSettings; name: StringName; features: PackedStringArray): Variant =
   expandMethodBind(className ProjectSettings, "get_setting_with_override_and_custom_features", 2434817427)

--- a/src/gdext/classes/gdrdpipelinecolorblendstate.nim
+++ b/src/gdext/classes/gdrdpipelinecolorblendstate.nim
@@ -36,16 +36,16 @@ proc getBlendConstant*(self: RDPipelineColorBlendState): Color =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Color)
 
-proc setAttachments*(self: RDPipelineColorBlendState; attachments: TypedArray[gdref RDPipelineColorBlendStateAttachment]): void =
+proc setAttachments*(self: RDPipelineColorBlendState; attachments: Array[gdref RDPipelineColorBlendStateAttachment]): void =
   expandMethodBind(className RDPipelineColorBlendState, "set_attachments", 381264803)
   nilCheck attachments
   methodbind.ptrcall(self, [getPtr attachments])
 
-proc getAttachments*(self: RDPipelineColorBlendState): TypedArray[gdref RDPipelineColorBlendStateAttachment] =
+proc getAttachments*(self: RDPipelineColorBlendState): Array[gdref RDPipelineColorBlendStateAttachment] =
   expandMethodBind(className RDPipelineColorBlendState, "get_attachments", 3995934104)
-  var ret: encoded TypedArray[gdref RDPipelineColorBlendStateAttachment]
+  var ret: encoded Array[gdref RDPipelineColorBlendStateAttachment]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref RDPipelineColorBlendStateAttachment])
+  (addr ret).decode_result(Array[gdref RDPipelineColorBlendStateAttachment])
 
 template enableLogicOp*(self: RDPipelineColorBlendState): untyped = self.getEnableLogicOp()
 template `enableLogicOp=`*(self: RDPipelineColorBlendState; value) = self.setEnableLogicOp(value)

--- a/src/gdext/classes/gdrdpipelinemultisamplestate.nim
+++ b/src/gdext/classes/gdrdpipelinemultisamplestate.nim
@@ -56,16 +56,16 @@ proc getEnableAlphaToOne*(self: RDPipelineMultisampleState): bool =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
 
-proc setSampleMasks*(self: RDPipelineMultisampleState; masks: TypedArray[Int]): void =
+proc setSampleMasks*(self: RDPipelineMultisampleState; masks: Array[Int]): void =
   expandMethodBind(className RDPipelineMultisampleState, "set_sample_masks", 381264803)
   nilCheck masks
   methodbind.ptrcall(self, [getPtr masks])
 
-proc getSampleMasks*(self: RDPipelineMultisampleState): TypedArray[Int] =
+proc getSampleMasks*(self: RDPipelineMultisampleState): Array[Int] =
   expandMethodBind(className RDPipelineMultisampleState, "get_sample_masks", 3995934104)
-  var ret: encoded TypedArray[Int]
+  var ret: encoded Array[Int]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Int])
+  (addr ret).decode_result(Array[Int])
 
 template sampleCount*(self: RDPipelineMultisampleState): untyped = self.getSampleCount()
 template `sampleCount=`*(self: RDPipelineMultisampleState; value) = self.setSampleCount(value)

--- a/src/gdext/classes/gdrdshaderfile.nim
+++ b/src/gdext/classes/gdrdshaderfile.nim
@@ -16,11 +16,11 @@ proc getSpirv*(self: RDShaderFile; version: StringName = default(StringName)): g
   methodbind.ptrcall(self, [getPtr version], addr ret)
   (addr ret).decode_result(gdref RDShaderSPIRV)
 
-proc getVersionList*(self: RDShaderFile): TypedArray[StringName] =
+proc getVersionList*(self: RDShaderFile): Array[StringName] =
   expandMethodBind(className RDShaderFile, "get_version_list", 3995934104)
-  var ret: encoded TypedArray[StringName]
+  var ret: encoded Array[StringName]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[StringName])
+  (addr ret).decode_result(Array[StringName])
 
 proc setBaseError*(self: RDShaderFile; error: String): void =
   expandMethodBind(className RDShaderFile, "set_base_error", 83702148)

--- a/src/gdext/classes/gdrduniform.nim
+++ b/src/gdext/classes/gdrduniform.nim
@@ -34,11 +34,11 @@ proc clearIds*(self: RDUniform): void =
   expandMethodBind(className RDUniform, "clear_ids", 3218959716)
   methodbind.ptrcall(self, [])
 
-proc getIds*(self: RDUniform): TypedArray[RID] =
+proc getIds*(self: RDUniform): Array[RID] =
   expandMethodBind(className RDUniform, "get_ids", 3995934104)
-  var ret: encoded TypedArray[RID]
+  var ret: encoded Array[RID]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[RID])
+  (addr ret).decode_result(Array[RID])
 
 template uniformType*(self: RDUniform): untyped = self.getUniformType()
 template `uniformType=`*(self: RDUniform; value) = self.setUniformType(value)

--- a/src/gdext/classes/gdregex.nim
+++ b/src/gdext/classes/gdregex.nim
@@ -28,11 +28,11 @@ proc search*(self: RegEx; subject: String; offset: int32 = 0; `end`: int32 = -1)
   methodbind.ptrcall(self, [getPtr subject, getPtr offset, getPtr `end`], addr ret)
   (addr ret).decode_result(gdref RegExMatch)
 
-proc searchAll*(self: RegEx; subject: String; offset: int32 = 0; `end`: int32 = -1): TypedArray[gdref RegExMatch] =
+proc searchAll*(self: RegEx; subject: String; offset: int32 = 0; `end`: int32 = -1): Array[gdref RegExMatch] =
   expandMethodBind(className RegEx, "search_all", 849021363)
-  var ret: encoded TypedArray[gdref RegExMatch]
+  var ret: encoded Array[gdref RegExMatch]
   methodbind.ptrcall(self, [getPtr subject, getPtr offset, getPtr `end`], addr ret)
-  (addr ret).decode_result(TypedArray[gdref RegExMatch])
+  (addr ret).decode_result(Array[gdref RegExMatch])
 
 proc sub*(self: RegEx; subject: String; replacement: String; all: bool = false; offset: int32 = 0; `end`: int32 = -1): String =
   expandMethodBind(className RegEx, "sub", 54019702)

--- a/src/gdext/classes/gdrenderingdevice.nim
+++ b/src/gdext/classes/gdrenderingdevice.nim
@@ -9,7 +9,7 @@ expandOnClassImported(RenderingDevice, Object)
 const InvalidId* = -1
 const InvalidFormatId* = -1
 
-proc textureCreate*(self: RenderingDevice; format: gdref RDTextureFormat; view: gdref RDTextureView; data: TypedArray[PackedByteArray] = newTypedArray[PackedByteArray]()): RID =
+proc textureCreate*(self: RenderingDevice; format: gdref RDTextureFormat; view: gdref RDTextureView; data: Array[PackedByteArray] = newArray[PackedByteArray]()): RID =
   expandMethodBind(className RenderingDevice, "texture_create", 3709173589)
   nilCheck data
   var ret: encoded RID
@@ -110,14 +110,14 @@ proc textureGetNativeHandle*(self: RenderingDevice; texture: RID): uint64 =
   methodbind.ptrcall(self, [getPtr texture], addr ret)
   (addr ret).decode_result(uint64)
 
-proc framebufferFormatCreate*(self: RenderingDevice; attachments: TypedArray[gdref RDAttachmentFormat]; viewCount: uint32 = 1'u32): int64 =
+proc framebufferFormatCreate*(self: RenderingDevice; attachments: Array[gdref RDAttachmentFormat]; viewCount: uint32 = 1'u32): int64 =
   expandMethodBind(className RenderingDevice, "framebuffer_format_create", 697032759)
   nilCheck attachments
   var ret: encoded int64
   methodbind.ptrcall(self, [getPtr attachments, getPtr viewCount], addr ret)
   (addr ret).decode_result(int64)
 
-proc framebufferFormatCreateMultipass*(self: RenderingDevice; attachments: TypedArray[gdref RDAttachmentFormat]; passes: TypedArray[gdref RDFramebufferPass]; viewCount: uint32 = 1'u32): int64 =
+proc framebufferFormatCreateMultipass*(self: RenderingDevice; attachments: Array[gdref RDAttachmentFormat]; passes: Array[gdref RDFramebufferPass]; viewCount: uint32 = 1'u32): int64 =
   expandMethodBind(className RenderingDevice, "framebuffer_format_create_multipass", 2647479094)
   nilCheck attachments
   nilCheck passes
@@ -137,14 +137,14 @@ proc framebufferFormatGetTextureSamples*(self: RenderingDevice; format: int64; r
   methodbind.ptrcall(self, [getPtr format, getPtr renderPass], addr ret)
   (addr ret).decode_result(RenderingDevice_TextureSamples)
 
-proc framebufferCreate*(self: RenderingDevice; textures: TypedArray[RID]; validateWithFormat: int64 = -1; viewCount: uint32 = 1'u32): RID =
+proc framebufferCreate*(self: RenderingDevice; textures: Array[RID]; validateWithFormat: int64 = -1; viewCount: uint32 = 1'u32): RID =
   expandMethodBind(className RenderingDevice, "framebuffer_create", 3284231055)
   nilCheck textures
   var ret: encoded RID
   methodbind.ptrcall(self, [getPtr textures, getPtr validateWithFormat, getPtr viewCount], addr ret)
   (addr ret).decode_result(RID)
 
-proc framebufferCreateMultipass*(self: RenderingDevice; textures: TypedArray[RID]; passes: TypedArray[gdref RDFramebufferPass]; validateWithFormat: int64 = -1; viewCount: uint32 = 1'u32): RID =
+proc framebufferCreateMultipass*(self: RenderingDevice; textures: Array[RID]; passes: Array[gdref RDFramebufferPass]; validateWithFormat: int64 = -1; viewCount: uint32 = 1'u32): RID =
   expandMethodBind(className RenderingDevice, "framebuffer_create_multipass", 1750306695)
   nilCheck textures
   nilCheck passes
@@ -188,14 +188,14 @@ proc vertexBufferCreate*(self: RenderingDevice; sizeBytes: uint32; data: PackedB
   methodbind.ptrcall(self, [getPtr sizeBytes, getPtr data, getPtr creationBits], addr ret)
   (addr ret).decode_result(RID)
 
-proc vertexFormatCreate*(self: RenderingDevice; vertexDescriptions: TypedArray[gdref RDVertexAttribute]): int64 =
+proc vertexFormatCreate*(self: RenderingDevice; vertexDescriptions: Array[gdref RDVertexAttribute]): int64 =
   expandMethodBind(className RenderingDevice, "vertex_format_create", 1242678479)
   nilCheck vertexDescriptions
   var ret: encoded int64
   methodbind.ptrcall(self, [getPtr vertexDescriptions], addr ret)
   (addr ret).decode_result(int64)
 
-proc vertexArrayCreate*(self: RenderingDevice; vertexCount: uint32; vertexFormat: int64; srcBuffers: TypedArray[RID]; offsets: PackedInt64Array = PackedInt64Array()): RID =
+proc vertexArrayCreate*(self: RenderingDevice; vertexCount: uint32; vertexFormat: int64; srcBuffers: Array[RID]; offsets: PackedInt64Array = PackedInt64Array()): RID =
   expandMethodBind(className RenderingDevice, "vertex_array_create", 3799816279)
   nilCheck srcBuffers
   var ret: encoded RID
@@ -268,7 +268,7 @@ proc textureBufferCreate*(self: RenderingDevice; sizeBytes: uint32; format: Rend
   methodbind.ptrcall(self, [getPtr sizeBytes, getPtr format, getPtr data], addr ret)
   (addr ret).decode_result(RID)
 
-proc uniformSetCreate*(self: RenderingDevice; uniforms: TypedArray[gdref RDUniform]; shader: RID; shaderSet: uint32): RID =
+proc uniformSetCreate*(self: RenderingDevice; uniforms: Array[gdref RDUniform]; shader: RID; shaderSet: uint32): RID =
   expandMethodBind(className RenderingDevice, "uniform_set_create", 2280795797)
   nilCheck uniforms
   var ret: encoded RID
@@ -317,7 +317,7 @@ proc bufferGetDeviceAddress*(self: RenderingDevice; buffer: RID): uint64 =
   methodbind.ptrcall(self, [getPtr buffer], addr ret)
   (addr ret).decode_result(uint64)
 
-proc renderPipelineCreate*(self: RenderingDevice; shader: RID; framebufferFormat: int64; vertexFormat: int64; primitive: RenderingDevice_RenderPrimitive; rasterizationState: gdref RDPipelineRasterizationState; multisampleState: gdref RDPipelineMultisampleState; stencilState: gdref RDPipelineDepthStencilState; colorBlendState: gdref RDPipelineColorBlendState; dynamicStateFlags: set[RenderingDevice_PipelineDynamicStateFlags] = {}; forRenderPass: uint32 = 0'u32; specializationConstants: TypedArray[gdref RDPipelineSpecializationConstant] = newTypedArray[gdref RDPipelineSpecializationConstant]()): RID =
+proc renderPipelineCreate*(self: RenderingDevice; shader: RID; framebufferFormat: int64; vertexFormat: int64; primitive: RenderingDevice_RenderPrimitive; rasterizationState: gdref RDPipelineRasterizationState; multisampleState: gdref RDPipelineMultisampleState; stencilState: gdref RDPipelineDepthStencilState; colorBlendState: gdref RDPipelineColorBlendState; dynamicStateFlags: set[RenderingDevice_PipelineDynamicStateFlags] = {}; forRenderPass: uint32 = 0'u32; specializationConstants: Array[gdref RDPipelineSpecializationConstant] = newArray[gdref RDPipelineSpecializationConstant]()): RID =
   expandMethodBind(className RenderingDevice, "render_pipeline_create", 2385451958)
   nilCheck specializationConstants
   var ret: encoded RID
@@ -330,7 +330,7 @@ proc renderPipelineIsValid*(self: RenderingDevice; renderPipeline: RID): bool =
   methodbind.ptrcall(self, [getPtr renderPipeline], addr ret)
   (addr ret).decode_result(bool)
 
-proc computePipelineCreate*(self: RenderingDevice; shader: RID; specializationConstants: TypedArray[gdref RDPipelineSpecializationConstant] = newTypedArray[gdref RDPipelineSpecializationConstant]()): RID =
+proc computePipelineCreate*(self: RenderingDevice; shader: RID; specializationConstants: Array[gdref RDPipelineSpecializationConstant] = newArray[gdref RDPipelineSpecializationConstant]()): RID =
   expandMethodBind(className RenderingDevice, "compute_pipeline_create", 1448838280)
   nilCheck specializationConstants
   var ret: encoded RID
@@ -373,7 +373,7 @@ proc drawListBegin*(self: RenderingDevice; framebuffer: RID; drawFlags: set[Rend
   methodbind.ptrcall(self, [getPtr framebuffer, getPtr drawFlags, getPtr clearColorValues, getPtr clearDepthValue, getPtr clearStencilValue, getPtr region, getPtr breadcrumb], addr ret)
   (addr ret).decode_result(int64)
 
-proc drawListBeginSplit*(self: RenderingDevice; framebuffer: RID; splits: uint32; initialColorAction: RenderingDevice_InitialAction; finalColorAction: RenderingDevice_FinalAction; initialDepthAction: RenderingDevice_InitialAction; finalDepthAction: RenderingDevice_FinalAction; clearColorValues: PackedColorArray = PackedColorArray(); clearDepth: Float = 1.0; clearStencil: uint32 = 0'u32; region: Rect2 = rect2(0, 0, 0, 0); storageTextures: TypedArray[RID] = newTypedArray[RID]()): PackedInt64Array =
+proc drawListBeginSplit*(self: RenderingDevice; framebuffer: RID; splits: uint32; initialColorAction: RenderingDevice_InitialAction; finalColorAction: RenderingDevice_FinalAction; initialDepthAction: RenderingDevice_InitialAction; finalDepthAction: RenderingDevice_FinalAction; clearColorValues: PackedColorArray = PackedColorArray(); clearDepth: Float = 1.0; clearStencil: uint32 = 0'u32; region: Rect2 = rect2(0, 0, 0, 0); storageTextures: Array[RID] = newArray[RID]()): PackedInt64Array =
   expandMethodBind(className RenderingDevice, "draw_list_begin_split", 2406300660)
   nilCheck storageTextures
   var ret: encoded PackedInt64Array

--- a/src/gdext/classes/gdrenderingserver.nim
+++ b/src/gdext/classes/gdrenderingserver.nim
@@ -31,14 +31,14 @@ proc texture2DCreate*(self: RenderingServer; image: gdref Image): RID =
   methodbind.ptrcall(self, [getPtr image], addr ret)
   (addr ret).decode_result(RID)
 
-proc texture2DLayeredCreate*(self: RenderingServer; layers: TypedArray[gdref Image]; layeredType: RenderingServer_TextureLayeredType): RID =
+proc texture2DLayeredCreate*(self: RenderingServer; layers: Array[gdref Image]; layeredType: RenderingServer_TextureLayeredType): RID =
   expandMethodBind(className RenderingServer, "texture_2d_layered_create", 913689023)
   nilCheck layers
   var ret: encoded RID
   methodbind.ptrcall(self, [getPtr layers, getPtr layeredType], addr ret)
   (addr ret).decode_result(RID)
 
-proc texture3DCreate*(self: RenderingServer; format: Image_Format; width: int32; height: int32; depth: int32; mipmaps: bool; data: TypedArray[gdref Image]): RID =
+proc texture3DCreate*(self: RenderingServer; format: Image_Format; width: int32; height: int32; depth: int32; mipmaps: bool; data: Array[gdref Image]): RID =
   expandMethodBind(className RenderingServer, "texture_3d_create", 4036838706)
   nilCheck data
   var ret: encoded RID
@@ -61,7 +61,7 @@ proc texture2DUpdate*(self: RenderingServer; texture: RID; image: gdref Image; l
   expandMethodBind(className RenderingServer, "texture_2d_update", 999539803)
   methodbind.ptrcall(self, [getPtr texture, getPtr image, getPtr layer])
 
-proc texture3DUpdate*(self: RenderingServer; texture: RID; data: TypedArray[gdref Image]): void =
+proc texture3DUpdate*(self: RenderingServer; texture: RID; data: Array[gdref Image]): void =
   expandMethodBind(className RenderingServer, "texture_3d_update", 684822712)
   nilCheck data
   methodbind.ptrcall(self, [getPtr texture, getPtr data])
@@ -100,11 +100,11 @@ proc texture2DLayerGet*(self: RenderingServer; texture: RID; layer: int32): gdre
   methodbind.ptrcall(self, [getPtr texture, getPtr layer], addr ret)
   (addr ret).decode_result(gdref Image)
 
-proc texture3DGet*(self: RenderingServer; texture: RID): TypedArray[gdref Image] =
+proc texture3DGet*(self: RenderingServer; texture: RID): Array[gdref Image] =
   expandMethodBind(className RenderingServer, "texture_3d_get", 2684255073)
-  var ret: encoded TypedArray[gdref Image]
+  var ret: encoded Array[gdref Image]
   methodbind.ptrcall(self, [getPtr texture], addr ret)
-  (addr ret).decode_result(TypedArray[gdref Image])
+  (addr ret).decode_result(Array[gdref Image])
 
 proc textureReplace*(self: RenderingServer; texture: RID; byTexture: RID): void =
   expandMethodBind(className RenderingServer, "texture_replace", 395945892)
@@ -172,11 +172,11 @@ proc shaderGetCode*(self: RenderingServer; shader: RID): String =
   methodbind.ptrcall(self, [getPtr shader], addr ret)
   (addr ret).decode_result(String)
 
-proc getShaderParameterList*(self: RenderingServer; shader: RID): TypedArray[Dictionary] =
+proc getShaderParameterList*(self: RenderingServer; shader: RID): Array[Dictionary] =
   expandMethodBind(className RenderingServer, "get_shader_parameter_list", 2684255073)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr shader], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc shaderGetParameterDefault*(self: RenderingServer; shader: RID; name: StringName): Variant =
   expandMethodBind(className RenderingServer, "shader_get_parameter_default", 2621281810)
@@ -222,7 +222,7 @@ proc materialSetNextPass*(self: RenderingServer; material: RID; nextMaterial: RI
   expandMethodBind(className RenderingServer, "material_set_next_pass", 395945892)
   methodbind.ptrcall(self, [getPtr material, getPtr nextMaterial])
 
-proc meshCreateFromSurfaces*(self: RenderingServer; surfaces: TypedArray[Dictionary]; blendShapeCount: int32 = 0): RID =
+proc meshCreateFromSurfaces*(self: RenderingServer; surfaces: Array[Dictionary]; blendShapeCount: int32 = 0): RID =
   expandMethodBind(className RenderingServer, "mesh_create_from_surfaces", 4291747531)
   nilCheck surfaces
   var ret: encoded RID
@@ -276,7 +276,7 @@ proc meshAddSurface*(self: RenderingServer; mesh: RID; surface: Dictionary): voi
   nilCheck surface
   methodbind.ptrcall(self, [getPtr mesh, getPtr surface])
 
-proc meshAddSurfaceFromArrays*(self: RenderingServer; mesh: RID; primitive: RenderingServer_PrimitiveType; arrays: Array; blendShapes: Array = newArray(); lods: Dictionary = newDictionary(); compressFormat: set[RenderingServer_ArrayFormat] = {}): void =
+proc meshAddSurfaceFromArrays*(self: RenderingServer; mesh: RID; primitive: RenderingServer_PrimitiveType; arrays: Array[Variant]; blendShapes: Array[Variant] = newArray[Variant](); lods: Dictionary = newDictionary(); compressFormat: set[RenderingServer_ArrayFormat] = {}): void =
   expandMethodBind(className RenderingServer, "mesh_add_surface_from_arrays", 2342446560)
   nilCheck arrays
   nilCheck blendShapes
@@ -315,17 +315,17 @@ proc meshGetSurface*(self: RenderingServer; mesh: RID; surface: int32): Dictiona
   methodbind.ptrcall(self, [getPtr mesh, getPtr surface], addr ret)
   (addr ret).decode_result(Dictionary)
 
-proc meshSurfaceGetArrays*(self: RenderingServer; mesh: RID; surface: int32): Array =
+proc meshSurfaceGetArrays*(self: RenderingServer; mesh: RID; surface: int32): Array[Variant] =
   expandMethodBind(className RenderingServer, "mesh_surface_get_arrays", 1778388067)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr mesh, getPtr surface], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
-proc meshSurfaceGetBlendShapeArrays*(self: RenderingServer; mesh: RID; surface: int32): TypedArray[Array] =
+proc meshSurfaceGetBlendShapeArrays*(self: RenderingServer; mesh: RID; surface: int32): Array[Array[Variant]] =
   expandMethodBind(className RenderingServer, "mesh_surface_get_blend_shape_arrays", 1778388067)
-  var ret: encoded TypedArray[Array]
+  var ret: encoded Array[Array[Variant]]
   methodbind.ptrcall(self, [getPtr mesh, getPtr surface], addr ret)
-  (addr ret).decode_result(TypedArray[Array])
+  (addr ret).decode_result(Array[Array[Variant]])
 
 proc meshGetSurfaceCount*(self: RenderingServer; mesh: RID): int32 =
   expandMethodBind(className RenderingServer, "mesh_get_surface_count", 2198884583)
@@ -995,7 +995,7 @@ proc particlesSetTrails*(self: RenderingServer; particles: RID; enable: bool; le
   expandMethodBind(className RenderingServer, "particles_set_trails", 2010054925)
   methodbind.ptrcall(self, [getPtr particles, getPtr enable, getPtr lengthSec])
 
-proc particlesSetTrailBindPoses*(self: RenderingServer; particles: RID; bindPoses: TypedArray[Transform3D]): void =
+proc particlesSetTrailBindPoses*(self: RenderingServer; particles: RID; bindPoses: Array[Transform3D]): void =
   expandMethodBind(className RenderingServer, "particles_set_trail_bind_poses", 684822712)
   nilCheck bindPoses
   methodbind.ptrcall(self, [getPtr particles, getPtr bindPoses])
@@ -1452,7 +1452,7 @@ proc compositorCreate*(self: RenderingServer): RID =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(RID)
 
-proc compositorSetCompositorEffects*(self: RenderingServer; compositor: RID; effects: TypedArray[RID]): void =
+proc compositorSetCompositorEffects*(self: RenderingServer; compositor: RID; effects: Array[RID]): void =
   expandMethodBind(className RenderingServer, "compositor_set_compositor_effects", 684822712)
   nilCheck effects
   methodbind.ptrcall(self, [getPtr compositor, getPtr effects])
@@ -1757,11 +1757,11 @@ proc instanceGeometryGetShaderParameterDefaultValue*(self: RenderingServer; inst
   methodbind.ptrcall(self, [getPtr instance, getPtr parameter], addr ret)
   (addr ret).decode_result(Variant)
 
-proc instanceGeometryGetShaderParameterList*(self: RenderingServer; instance: RID): TypedArray[Dictionary] =
+proc instanceGeometryGetShaderParameterList*(self: RenderingServer; instance: RID): Array[Dictionary] =
   expandMethodBind(className RenderingServer, "instance_geometry_get_shader_parameter_list", 2684255073)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr instance], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc instancesCullAabb*(self: RenderingServer; aabb: AABB; scenario: RID = RID()): PackedInt64Array =
   expandMethodBind(className RenderingServer, "instances_cull_aabb", 2570105777)
@@ -1775,19 +1775,19 @@ proc instancesCullRay*(self: RenderingServer; `from`: Vector3; to: Vector3; scen
   methodbind.ptrcall(self, [getPtr `from`, getPtr to, getPtr scenario], addr ret)
   (addr ret).decode_result(PackedInt64Array)
 
-proc instancesCullConvex*(self: RenderingServer; convex: TypedArray[Plane]; scenario: RID = RID()): PackedInt64Array =
+proc instancesCullConvex*(self: RenderingServer; convex: Array[Plane]; scenario: RID = RID()): PackedInt64Array =
   expandMethodBind(className RenderingServer, "instances_cull_convex", 2488539944)
   nilCheck convex
   var ret: encoded PackedInt64Array
   methodbind.ptrcall(self, [getPtr convex, getPtr scenario], addr ret)
   (addr ret).decode_result(PackedInt64Array)
 
-proc bakeRenderUv2*(self: RenderingServer; base: RID; materialOverrides: TypedArray[RID]; imageSize: Vector2i): TypedArray[gdref Image] =
+proc bakeRenderUv2*(self: RenderingServer; base: RID; materialOverrides: Array[RID]; imageSize: Vector2i): Array[gdref Image] =
   expandMethodBind(className RenderingServer, "bake_render_uv2", 1904608558)
   nilCheck materialOverrides
-  var ret: encoded TypedArray[gdref Image]
+  var ret: encoded Array[gdref Image]
   methodbind.ptrcall(self, [getPtr base, getPtr materialOverrides, getPtr imageSize], addr ret)
-  (addr ret).decode_result(TypedArray[gdref Image])
+  (addr ret).decode_result(Array[gdref Image])
 
 proc canvasCreate*(self: RenderingServer): RID =
   expandMethodBind(className RenderingServer, "canvas_create", 529393457)
@@ -2031,11 +2031,11 @@ proc canvasItemGetInstanceShaderParameterDefaultValue*(self: RenderingServer; in
   methodbind.ptrcall(self, [getPtr instance, getPtr parameter], addr ret)
   (addr ret).decode_result(Variant)
 
-proc canvasItemGetInstanceShaderParameterList*(self: RenderingServer; instance: RID): TypedArray[Dictionary] =
+proc canvasItemGetInstanceShaderParameterList*(self: RenderingServer; instance: RID): Array[Dictionary] =
   expandMethodBind(className RenderingServer, "canvas_item_get_instance_shader_parameter_list", 2684255073)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr instance], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc canvasItemSetVisibilityNotifier*(self: RenderingServer; item: RID; enable: bool; area: Rect2; enterCallable: Callable; exitCallable: Callable): void =
   expandMethodBind(className RenderingServer, "canvas_item_set_visibility_notifier", 3568945579)
@@ -2213,11 +2213,11 @@ proc globalShaderParameterRemove*(self: RenderingServer; name: StringName): void
   expandMethodBind(className RenderingServer, "global_shader_parameter_remove", 3304788590)
   methodbind.ptrcall(self, [getPtr name])
 
-proc globalShaderParameterGetList*(self: RenderingServer): TypedArray[StringName] =
+proc globalShaderParameterGetList*(self: RenderingServer): Array[StringName] =
   expandMethodBind(className RenderingServer, "global_shader_parameter_get_list", 3995934104)
-  var ret: encoded TypedArray[StringName]
+  var ret: encoded Array[StringName]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[StringName])
+  (addr ret).decode_result(Array[StringName])
 
 proc globalShaderParameterSet*(self: RenderingServer; name: StringName; value: Variant): void =
   expandMethodBind(className RenderingServer, "global_shader_parameter_set", 3776071444)

--- a/src/gdext/classes/gdresourceloader.nim
+++ b/src/gdext/classes/gdresourceloader.nim
@@ -12,7 +12,7 @@ proc loadThreadedRequest*(self: ResourceLoader; path: String; typeHint: String =
   methodbind.ptrcall(self, [getPtr path, getPtr typeHint, getPtr useSubThreads, getPtr cacheMode], addr ret)
   (addr ret).decode_result(Error)
 
-proc loadThreadedGetStatus*(self: ResourceLoader; path: String; progress: Array = newArray()): ResourceLoader_ThreadLoadStatus =
+proc loadThreadedGetStatus*(self: ResourceLoader; path: String; progress: Array[Variant] = newArray[Variant]()): ResourceLoader_ThreadLoadStatus =
   expandMethodBind(className ResourceLoader, "load_threaded_get_status", 4137685479)
   nilCheck progress
   var ret: encoded ResourceLoader_ThreadLoadStatus

--- a/src/gdext/classes/gdrichtextlabel.nim
+++ b/src/gdext/classes/gdrichtextlabel.nim
@@ -199,16 +199,16 @@ proc getStructuredTextBidiOverride*(self: RichTextLabel): TextServer_StructuredT
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(TextServer_StructuredTextParser)
 
-proc setStructuredTextBidiOverrideOptions*(self: RichTextLabel; args: Array): void =
+proc setStructuredTextBidiOverrideOptions*(self: RichTextLabel; args: Array[Variant]): void =
   expandMethodBind(className RichTextLabel, "set_structured_text_bidi_override_options", 381264803)
   nilCheck args
   methodbind.ptrcall(self, [getPtr args])
 
-proc getStructuredTextBidiOverrideOptions*(self: RichTextLabel): Array =
+proc getStructuredTextBidiOverrideOptions*(self: RichTextLabel): Array[Variant] =
   expandMethodBind(className RichTextLabel, "get_structured_text_bidi_override_options", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc setTextDirection*(self: RichTextLabel; direction: Control_TextDirection): void =
   expandMethodBind(className RichTextLabel, "set_text_direction", 119160795)
@@ -642,16 +642,16 @@ proc parseExpressionsForValues*(self: RichTextLabel; expressions: PackedStringAr
   methodbind.ptrcall(self, [getPtr expressions], addr ret)
   (addr ret).decode_result(Dictionary)
 
-proc setEffects*(self: RichTextLabel; effects: Array): void =
+proc setEffects*(self: RichTextLabel; effects: Array[Variant]): void =
   expandMethodBind(className RichTextLabel, "set_effects", 381264803)
   nilCheck effects
   methodbind.ptrcall(self, [getPtr effects])
 
-proc getEffects*(self: RichTextLabel): Array =
+proc getEffects*(self: RichTextLabel): Array[Variant] =
   expandMethodBind(className RichTextLabel, "get_effects", 2915620761)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc installEffect*(self: RichTextLabel; effect: Variant): void =
   expandMethodBind(className RichTextLabel, "install_effect", 1114965689)

--- a/src/gdext/classes/gdrigidbody2d.nim
+++ b/src/gdext/classes/gdrigidbody2d.nim
@@ -287,11 +287,11 @@ proc getFreezeMode*(self: RigidBody2D): RigidBody2D_FreezeMode =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(RigidBody2D_FreezeMode)
 
-proc getCollidingBodies*(self: RigidBody2D): TypedArray[Node2D] =
+proc getCollidingBodies*(self: RigidBody2D): Array[Node2D] =
   expandMethodBind(className RigidBody2D, "get_colliding_bodies", 3995934104)
-  var ret: encoded TypedArray[Node2D]
+  var ret: encoded Array[Node2D]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Node2D])
+  (addr ret).decode_result(Array[Node2D])
 
 template mass*(self: RigidBody2D): untyped = self.getMass()
 template `mass=`*(self: RigidBody2D; value) = self.setMass(value)

--- a/src/gdext/classes/gdrigidbody3d.nim
+++ b/src/gdext/classes/gdrigidbody3d.nim
@@ -293,11 +293,11 @@ proc getFreezeMode*(self: RigidBody3D): RigidBody3D_FreezeMode =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(RigidBody3D_FreezeMode)
 
-proc getCollidingBodies*(self: RigidBody3D): TypedArray[Node3D] =
+proc getCollidingBodies*(self: RigidBody3D): Array[Node3D] =
   expandMethodBind(className RigidBody3D, "get_colliding_bodies", 3995934104)
-  var ret: encoded TypedArray[Node3D]
+  var ret: encoded Array[Node3D]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Node3D])
+  (addr ret).decode_result(Array[Node3D])
 
 template mass*(self: RigidBody3D): untyped = self.getMass()
 template `mass=`*(self: RigidBody3D; value) = self.setMass(value)

--- a/src/gdext/classes/gdscenereplicationconfig.nim
+++ b/src/gdext/classes/gdscenereplicationconfig.nim
@@ -6,11 +6,11 @@ import gdresource; export gdresource
 
 expandOnClassImported(SceneReplicationConfig, Resource)
 
-proc getProperties*(self: SceneReplicationConfig): TypedArray[NodePath] =
+proc getProperties*(self: SceneReplicationConfig): Array[NodePath] =
   expandMethodBind(className SceneReplicationConfig, "get_properties", 3995934104)
-  var ret: encoded TypedArray[NodePath]
+  var ret: encoded Array[NodePath]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[NodePath])
+  (addr ret).decode_result(Array[NodePath])
 
 proc addProperty*(self: SceneReplicationConfig; path: NodePath; index: int32 = -1): void =
   expandMethodBind(className SceneReplicationConfig, "add_property", 4094619021)

--- a/src/gdext/classes/gdscenestate.nim
+++ b/src/gdext/classes/gdscenestate.nim
@@ -132,11 +132,11 @@ proc getConnectionFlags*(self: SceneState; idx: int32): int32 =
   methodbind.ptrcall(self, [getPtr idx], addr ret)
   (addr ret).decode_result(int32)
 
-proc getConnectionBinds*(self: SceneState; idx: int32): Array =
+proc getConnectionBinds*(self: SceneState; idx: int32): Array[Variant] =
   expandMethodBind(className SceneState, "get_connection_binds", 663333327)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr idx], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc getConnectionUnbinds*(self: SceneState; idx: int32): int32 =
   expandMethodBind(className SceneState, "get_connection_unbinds", 923996154)

--- a/src/gdext/classes/gdscenetree.nim
+++ b/src/gdext/classes/gdscenetree.nim
@@ -112,11 +112,11 @@ proc createTween*(self: SceneTree): gdref Tween =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(gdref Tween)
 
-proc getProcessedTweens*(self: SceneTree): TypedArray[gdref Tween] =
+proc getProcessedTweens*(self: SceneTree): Array[gdref Tween] =
   expandMethodBind(className SceneTree, "get_processed_tweens", 2915620761)
-  var ret: encoded TypedArray[gdref Tween]
+  var ret: encoded Array[gdref Tween]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref Tween])
+  (addr ret).decode_result(Array[gdref Tween])
 
 proc getNodeCount*(self: SceneTree): int32 =
   expandMethodBind(className SceneTree, "get_node_count", 3905245786)
@@ -180,11 +180,11 @@ proc setGroup*(self: SceneTree; group: StringName; property: String; value: Vari
   expandMethodBind(className SceneTree, "set_group", 1279312029)
   methodbind.ptrcall(self, [getPtr group, getPtr property, getPtr value])
 
-proc getNodesInGroup*(self: SceneTree; group: StringName): TypedArray[Node] =
+proc getNodesInGroup*(self: SceneTree; group: StringName): Array[Node] =
   expandMethodBind(className SceneTree, "get_nodes_in_group", 689397652)
-  var ret: encoded TypedArray[Node]
+  var ret: encoded Array[Node]
   methodbind.ptrcall(self, [getPtr group], addr ret)
-  (addr ret).decode_result(TypedArray[Node])
+  (addr ret).decode_result(Array[Node])
 
 proc getFirstNodeInGroup*(self: SceneTree; group: StringName): Node =
   expandMethodBind(className SceneTree, "get_first_node_in_group", 4071044623)

--- a/src/gdext/classes/gdscript.nim
+++ b/src/gdext/classes/gdscript.nim
@@ -64,23 +64,23 @@ proc hasScriptSignal*(self: Script; signalName: StringName): bool =
   methodbind.ptrcall(self, [getPtr signalName], addr ret)
   (addr ret).decode_result(bool)
 
-proc getScriptPropertyList*(self: Script): TypedArray[Dictionary] =
+proc getScriptPropertyList*(self: Script): Array[Dictionary] =
   expandMethodBind(className Script, "get_script_property_list", 2915620761)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
-proc getScriptMethodList*(self: Script): TypedArray[Dictionary] =
+proc getScriptMethodList*(self: Script): Array[Dictionary] =
   expandMethodBind(className Script, "get_script_method_list", 2915620761)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
-proc getScriptSignalList*(self: Script): TypedArray[Dictionary] =
+proc getScriptSignalList*(self: Script): Array[Dictionary] =
   expandMethodBind(className Script, "get_script_signal_list", 2915620761)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc getScriptConstantMap*(self: Script): Dictionary =
   expandMethodBind(className Script, "get_script_constant_map", 2382534195)

--- a/src/gdext/classes/gdscripteditor.nim
+++ b/src/gdext/classes/gdscripteditor.nim
@@ -12,11 +12,11 @@ proc getCurrentEditor*(self: ScriptEditor): ScriptEditorBase =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(ScriptEditorBase)
 
-proc getOpenScriptEditors*(self: ScriptEditor): TypedArray[ScriptEditorBase] =
+proc getOpenScriptEditors*(self: ScriptEditor): Array[ScriptEditorBase] =
   expandMethodBind(className ScriptEditor, "get_open_script_editors", 3995934104)
-  var ret: encoded TypedArray[ScriptEditorBase]
+  var ret: encoded Array[ScriptEditorBase]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[ScriptEditorBase])
+  (addr ret).decode_result(Array[ScriptEditorBase])
 
 proc getBreakpoints*(self: ScriptEditor): PackedStringArray =
   expandMethodBind(className ScriptEditor, "get_breakpoints", 2981934095)
@@ -42,11 +42,11 @@ proc getCurrentScript*(self: ScriptEditor): gdref Script =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(gdref Script)
 
-proc getOpenScripts*(self: ScriptEditor): TypedArray[gdref Script] =
+proc getOpenScripts*(self: ScriptEditor): Array[gdref Script] =
   expandMethodBind(className ScriptEditor, "get_open_scripts", 3995934104)
-  var ret: encoded TypedArray[gdref Script]
+  var ret: encoded Array[gdref Script]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref Script])
+  (addr ret).decode_result(Array[gdref Script])
 
 proc openScriptCreateDialog*(self: ScriptEditor; baseName: String; basePath: String): void =
   expandMethodBind(className ScriptEditor, "open_script_create_dialog", 3186203200)

--- a/src/gdext/classes/gdscriptextension.nim
+++ b/src/gdext/classes/gdscriptextension.nim
@@ -81,7 +81,7 @@ proc registerVirtual_getDocClassName*[T: ScriptExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_doc_class_name"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptExtension](p_instance).getDocClassName().encode(r_ret)
 
-method getDocumentation*(self: ScriptExtension): TypedArray[Dictionary] {.base.} = (discard)
+method getDocumentation*(self: ScriptExtension): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_getDocumentation*[T: ScriptExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_documentation"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptExtension](p_instance).getDocumentation().encode(r_ret)
@@ -136,7 +136,7 @@ proc registerVirtual_hasScriptSignal*[T: ScriptExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_has_script_signal"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptExtension](p_instance).hasScriptSignal(p_args[0].decode(StringName)).encode(r_ret)
 
-method getScriptSignalList*(self: ScriptExtension): TypedArray[Dictionary] {.base.} = (discard)
+method getScriptSignalList*(self: ScriptExtension): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_getScriptSignalList*[T: ScriptExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_script_signal_list"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptExtension](p_instance).getScriptSignalList().encode(r_ret)
@@ -156,12 +156,12 @@ proc registerVirtual_updateExports*[T: ScriptExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_update_exports"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptExtension](p_instance).updateExports()
 
-method getScriptMethodList*(self: ScriptExtension): TypedArray[Dictionary] {.base.} = (discard)
+method getScriptMethodList*(self: ScriptExtension): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_getScriptMethodList*[T: ScriptExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_script_method_list"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptExtension](p_instance).getScriptMethodList().encode(r_ret)
 
-method getScriptPropertyList*(self: ScriptExtension): TypedArray[Dictionary] {.base.} = (discard)
+method getScriptPropertyList*(self: ScriptExtension): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_getScriptPropertyList*[T: ScriptExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_script_property_list"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptExtension](p_instance).getScriptPropertyList().encode(r_ret)
@@ -176,7 +176,7 @@ proc registerVirtual_getConstants*[T: ScriptExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_constants"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptExtension](p_instance).getConstants().encode(r_ret)
 
-method getMembers*(self: ScriptExtension): TypedArray[StringName] {.base.} = (discard)
+method getMembers*(self: ScriptExtension): Array[StringName] {.base.} = (discard)
 proc registerVirtual_getMembers*[T: ScriptExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_members"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptExtension](p_instance).getMembers().encode(r_ret)

--- a/src/gdext/classes/gdscriptlanguageextension.nim
+++ b/src/gdext/classes/gdscriptlanguageextension.nim
@@ -61,7 +61,7 @@ proc registerVirtual_makeTemplate*[T: ScriptLanguageExtension](Self: typedesc[T]
   Self.vmethods[newStringName"_make_template"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptLanguageExtension](p_instance).makeTemplate(p_args[0].decode(String), p_args[1].decode(String), p_args[2].decode(String)).encode(r_ret)
 
-method getBuiltInTemplates*(self: ScriptLanguageExtension; `object`: StringName): TypedArray[Dictionary] {.base.} = (discard)
+method getBuiltInTemplates*(self: ScriptLanguageExtension; `object`: StringName): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_getBuiltInTemplates*[T: ScriptLanguageExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_built_in_templates"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptLanguageExtension](p_instance).getBuiltInTemplates(p_args[0].decode(StringName)).encode(r_ret)
@@ -226,7 +226,7 @@ proc registerVirtual_debugParseStackLevelExpression*[T: ScriptLanguageExtension]
   Self.vmethods[newStringName"_debug_parse_stack_level_expression"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptLanguageExtension](p_instance).debugParseStackLevelExpression(p_args[0].decode(int32), p_args[1].decode(String), p_args[2].decode(int32), p_args[3].decode(int32)).encode(r_ret)
 
-method debugGetCurrentStackInfo*(self: ScriptLanguageExtension): TypedArray[Dictionary] {.base.} = (discard)
+method debugGetCurrentStackInfo*(self: ScriptLanguageExtension): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_debugGetCurrentStackInfo*[T: ScriptLanguageExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_debug_get_current_stack_info"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptLanguageExtension](p_instance).debugGetCurrentStackInfo().encode(r_ret)
@@ -236,10 +236,10 @@ proc registerVirtual_reloadAllScripts*[T: ScriptLanguageExtension](Self: typedes
   Self.vmethods[newStringName"_reload_all_scripts"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptLanguageExtension](p_instance).reloadAllScripts()
 
-method reloadScripts*(self: ScriptLanguageExtension; scripts: Array; softReload: bool): void {.base.} = (discard)
+method reloadScripts*(self: ScriptLanguageExtension; scripts: Array[Variant]; softReload: bool): void {.base.} = (discard)
 proc registerVirtual_reloadScripts*[T: ScriptLanguageExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_reload_scripts"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[ScriptLanguageExtension](p_instance).reloadScripts(p_args[0].decode(Array), p_args[1].decode(bool))
+    errproof: cast[ScriptLanguageExtension](p_instance).reloadScripts(p_args[0].decode(Array[Variant]), p_args[1].decode(bool))
 
 method reloadToolScript*(self: ScriptLanguageExtension; script: gdref Script; softReload: bool): void {.base.} = (discard)
 proc registerVirtual_reloadToolScript*[T: ScriptLanguageExtension](Self: typedesc[T]) =
@@ -251,7 +251,7 @@ proc registerVirtual_getRecognizedExtensions*[T: ScriptLanguageExtension](Self: 
   Self.vmethods[newStringName"_get_recognized_extensions"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptLanguageExtension](p_instance).getRecognizedExtensions().encode(r_ret)
 
-method getPublicFunctions*(self: ScriptLanguageExtension): TypedArray[Dictionary] {.base.} = (discard)
+method getPublicFunctions*(self: ScriptLanguageExtension): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_getPublicFunctions*[T: ScriptLanguageExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_public_functions"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptLanguageExtension](p_instance).getPublicFunctions().encode(r_ret)
@@ -261,7 +261,7 @@ proc registerVirtual_getPublicConstants*[T: ScriptLanguageExtension](Self: typed
   Self.vmethods[newStringName"_get_public_constants"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptLanguageExtension](p_instance).getPublicConstants().encode(r_ret)
 
-method getPublicAnnotations*(self: ScriptLanguageExtension): TypedArray[Dictionary] {.base.} = (discard)
+method getPublicAnnotations*(self: ScriptLanguageExtension): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_getPublicAnnotations*[T: ScriptLanguageExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_public_annotations"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[ScriptLanguageExtension](p_instance).getPublicAnnotations().encode(r_ret)

--- a/src/gdext/classes/gdshader.nim
+++ b/src/gdext/classes/gdshader.nim
@@ -32,11 +32,11 @@ proc getDefaultTextureParameter*(self: Shader; name: StringName; index: int32 = 
   methodbind.ptrcall(self, [getPtr name, getPtr index], addr ret)
   (addr ret).decode_result(gdref Texture)
 
-proc getShaderUniformList*(self: Shader; getGroups: bool = false): Array =
+proc getShaderUniformList*(self: Shader; getGroups: bool = false): Array[Variant] =
   expandMethodBind(className Shader, "get_shader_uniform_list", 1230511656)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr getGroups], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc inspectNativeShaderCode*(self: Shader): void =
   expandMethodBind(className Shader, "inspect_native_shader_code", 3218959716)

--- a/src/gdext/classes/gdshapecast2d.nim
+++ b/src/gdext/classes/gdshapecast2d.nim
@@ -184,11 +184,11 @@ proc isCollideWithBodiesEnabled*(self: ShapeCast2D): bool =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
 
-proc getCollisionResult*(self: ShapeCast2D): Array =
+proc getCollisionResult*(self: ShapeCast2D): Array[Variant] =
   expandMethodBind(className ShapeCast2D, "get_collision_result", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 template enabled*(self: ShapeCast2D): untyped = self.isEnabled()
 template `enabled=`*(self: ShapeCast2D; value) = self.setEnabled(value)

--- a/src/gdext/classes/gdshapecast3d.nim
+++ b/src/gdext/classes/gdshapecast3d.nim
@@ -188,11 +188,11 @@ proc isCollideWithBodiesEnabled*(self: ShapeCast3D): bool =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
 
-proc getCollisionResult*(self: ShapeCast3D): Array =
+proc getCollisionResult*(self: ShapeCast3D): Array[Variant] =
   expandMethodBind(className ShapeCast3D, "get_collision_result", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc setDebugShapeCustomColor*(self: ShapeCast3D; debugShapeCustomColor: Color): void =
   expandMethodBind(className ShapeCast3D, "set_debug_shape_custom_color", 2920490490)

--- a/src/gdext/classes/gdshortcut.nim
+++ b/src/gdext/classes/gdshortcut.nim
@@ -6,16 +6,16 @@ import gdresource; export gdresource
 
 expandOnClassImported(Shortcut, Resource)
 
-proc setEvents*(self: Shortcut; events: Array): void =
+proc setEvents*(self: Shortcut; events: Array[Variant]): void =
   expandMethodBind(className Shortcut, "set_events", 381264803)
   nilCheck events
   methodbind.ptrcall(self, [getPtr events])
 
-proc getEvents*(self: Shortcut): Array =
+proc getEvents*(self: Shortcut): Array[Variant] =
   expandMethodBind(className Shortcut, "get_events", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc hasValidEvent*(self: Shortcut): bool =
   expandMethodBind(className Shortcut, "has_valid_event", 36873697)

--- a/src/gdext/classes/gdskeleton3d.nim
+++ b/src/gdext/classes/gdskeleton3d.nim
@@ -36,11 +36,11 @@ proc getBoneMeta*(self: Skeleton3D; boneIdx: int32; key: StringName): Variant =
   methodbind.ptrcall(self, [getPtr boneIdx, getPtr key], addr ret)
   (addr ret).decode_result(Variant)
 
-proc getBoneMetaList*(self: Skeleton3D; boneIdx: int32): TypedArray[StringName] =
+proc getBoneMetaList*(self: Skeleton3D; boneIdx: int32): Array[StringName] =
   expandMethodBind(className Skeleton3D, "get_bone_meta_list", 663333327)
-  var ret: encoded TypedArray[StringName]
+  var ret: encoded Array[StringName]
   methodbind.ptrcall(self, [getPtr boneIdx], addr ret)
-  (addr ret).decode_result(TypedArray[StringName])
+  (addr ret).decode_result(Array[StringName])
 
 proc hasBoneMeta*(self: Skeleton3D; boneIdx: int32; key: StringName): bool =
   expandMethodBind(className Skeleton3D, "has_bone_meta", 921227809)
@@ -276,7 +276,7 @@ proc physicalBonesStopSimulation*(self: Skeleton3D): void =
   expandMethodBind(className Skeleton3D, "physical_bones_stop_simulation", 3218959716)
   methodbind.ptrcall(self, [])
 
-proc physicalBonesStartSimulation*(self: Skeleton3D; bones: TypedArray[StringName] = newTypedArray[StringName]()): void =
+proc physicalBonesStartSimulation*(self: Skeleton3D; bones: Array[StringName] = newArray[StringName]()): void =
   expandMethodBind(className Skeleton3D, "physical_bones_start_simulation", 2787316981)
   nilCheck bones
   methodbind.ptrcall(self, [getPtr bones])

--- a/src/gdext/classes/gdskeletonmodification2dphysicalbones.nim
+++ b/src/gdext/classes/gdskeletonmodification2dphysicalbones.nim
@@ -30,12 +30,12 @@ proc fetchPhysicalBones*(self: SkeletonModification2DPhysicalBones): void =
   expandMethodBind(className SkeletonModification2DPhysicalBones, "fetch_physical_bones", 3218959716)
   methodbind.ptrcall(self, [])
 
-proc startSimulation*(self: SkeletonModification2DPhysicalBones; bones: TypedArray[StringName] = newTypedArray[StringName]()): void =
+proc startSimulation*(self: SkeletonModification2DPhysicalBones; bones: Array[StringName] = newArray[StringName]()): void =
   expandMethodBind(className SkeletonModification2DPhysicalBones, "start_simulation", 2787316981)
   nilCheck bones
   methodbind.ptrcall(self, [getPtr bones])
 
-proc stopSimulation*(self: SkeletonModification2DPhysicalBones; bones: TypedArray[StringName] = newTypedArray[StringName]()): void =
+proc stopSimulation*(self: SkeletonModification2DPhysicalBones; bones: Array[StringName] = newArray[StringName]()): void =
   expandMethodBind(className SkeletonModification2DPhysicalBones, "stop_simulation", 2787316981)
   nilCheck bones
   methodbind.ptrcall(self, [getPtr bones])

--- a/src/gdext/classes/gdsoftbody3d.nim
+++ b/src/gdext/classes/gdsoftbody3d.nim
@@ -72,11 +72,11 @@ proc getDisableMode*(self: SoftBody3D): SoftBody3D_DisableMode =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(SoftBody3D_DisableMode)
 
-proc getCollisionExceptions*(self: SoftBody3D): TypedArray[PhysicsBody3D] =
+proc getCollisionExceptions*(self: SoftBody3D): Array[PhysicsBody3D] =
   expandMethodBind(className SoftBody3D, "get_collision_exceptions", 2915620761)
-  var ret: encoded TypedArray[PhysicsBody3D]
+  var ret: encoded Array[PhysicsBody3D]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[PhysicsBody3D])
+  (addr ret).decode_result(Array[PhysicsBody3D])
 
 proc addCollisionExceptionWith*(self: SoftBody3D; body: Node): void =
   expandMethodBind(className SoftBody3D, "add_collision_exception_with", 1078189570)

--- a/src/gdext/classes/gdstreampeer.nim
+++ b/src/gdext/classes/gdstreampeer.nim
@@ -12,23 +12,23 @@ proc putData*(self: StreamPeer; data: PackedByteArray): Error =
   methodbind.ptrcall(self, [getPtr data], addr ret)
   (addr ret).decode_result(Error)
 
-proc putPartialData*(self: StreamPeer; data: PackedByteArray): Array =
+proc putPartialData*(self: StreamPeer; data: PackedByteArray): Array[Variant] =
   expandMethodBind(className StreamPeer, "put_partial_data", 2934048347)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr data], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
-proc getData*(self: StreamPeer; bytes: int32): Array =
+proc getData*(self: StreamPeer; bytes: int32): Array[Variant] =
   expandMethodBind(className StreamPeer, "get_data", 1171824711)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr bytes], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
-proc getPartialData*(self: StreamPeer; bytes: int32): Array =
+proc getPartialData*(self: StreamPeer; bytes: int32): Array[Variant] =
   expandMethodBind(className StreamPeer, "get_partial_data", 1171824711)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr bytes], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc getAvailableBytes*(self: StreamPeer): int32 =
   expandMethodBind(className StreamPeer, "get_available_bytes", 3905245786)

--- a/src/gdext/classes/gdsurfacetool.nim
+++ b/src/gdext/classes/gdsurfacetool.nim
@@ -70,7 +70,7 @@ proc setSmoothGroup*(self: SurfaceTool; index: uint32): void =
   expandMethodBind(className SurfaceTool, "set_smooth_group", 1286410249)
   methodbind.ptrcall(self, [getPtr index])
 
-proc addTriangleFan*(self: SurfaceTool; vertices: PackedVector3Array; uvs: PackedVector2Array = PackedVector2Array(); colors: PackedColorArray = PackedColorArray(); uv2s: PackedVector2Array = PackedVector2Array(); normals: PackedVector3Array = PackedVector3Array(); tangents: TypedArray[Plane] = newTypedArray[Plane]()): void =
+proc addTriangleFan*(self: SurfaceTool; vertices: PackedVector3Array; uvs: PackedVector2Array = PackedVector2Array(); colors: PackedColorArray = PackedColorArray(); uv2s: PackedVector2Array = PackedVector2Array(); normals: PackedVector3Array = PackedVector3Array(); tangents: Array[Plane] = newArray[Plane]()): void =
   expandMethodBind(className SurfaceTool, "add_triangle_fan", 2235017613)
   nilCheck tangents
   methodbind.ptrcall(self, [getPtr vertices, getPtr uvs, getPtr colors, getPtr uv2s, getPtr normals, getPtr tangents])
@@ -129,7 +129,7 @@ proc createFrom*(self: SurfaceTool; existing: gdref Mesh; surface: int32): void 
   expandMethodBind(className SurfaceTool, "create_from", 1767024570)
   methodbind.ptrcall(self, [getPtr existing, getPtr surface])
 
-proc createFromArrays*(self: SurfaceTool; arrays: Array; primitiveType: Mesh_PrimitiveType = primitiveTriangles): void =
+proc createFromArrays*(self: SurfaceTool; arrays: Array[Variant]; primitiveType: Mesh_PrimitiveType = primitiveTriangles): void =
   expandMethodBind(className SurfaceTool, "create_from_arrays", 1894639680)
   nilCheck arrays
   methodbind.ptrcall(self, [getPtr arrays, getPtr primitiveType])
@@ -148,8 +148,8 @@ proc commit*(self: SurfaceTool; existing: gdref ArrayMesh = default gdref ArrayM
   methodbind.ptrcall(self, [getPtr existing, getPtr flags], addr ret)
   (addr ret).decode_result(gdref ArrayMesh)
 
-proc commitToArrays*(self: SurfaceTool): Array =
+proc commitToArrays*(self: SurfaceTool): Array[Variant] =
   expandMethodBind(className SurfaceTool, "commit_to_arrays", 2915620761)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])

--- a/src/gdext/classes/gdtextedit.nim
+++ b/src/gdext/classes/gdtextedit.nim
@@ -100,16 +100,16 @@ proc getStructuredTextBidiOverride*(self: TextEdit): TextServer_StructuredTextPa
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(TextServer_StructuredTextParser)
 
-proc setStructuredTextBidiOverrideOptions*(self: TextEdit; args: Array): void =
+proc setStructuredTextBidiOverrideOptions*(self: TextEdit; args: Array[Variant]): void =
   expandMethodBind(className TextEdit, "set_structured_text_bidi_override_options", 381264803)
   nilCheck args
   methodbind.ptrcall(self, [getPtr args])
 
-proc getStructuredTextBidiOverrideOptions*(self: TextEdit): Array =
+proc getStructuredTextBidiOverrideOptions*(self: TextEdit): Array[Variant] =
   expandMethodBind(className TextEdit, "get_structured_text_bidi_override_options", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc setTabSize*(self: TextEdit; size: int32): void =
   expandMethodBind(className TextEdit, "set_tab_size", 1286410249)
@@ -757,11 +757,11 @@ proc getSelectionAtLineColumn*(self: TextEdit; line: int32; column: int32; inclu
   methodbind.ptrcall(self, [getPtr line, getPtr column, getPtr includeEdges, getPtr onlySelections], addr ret)
   (addr ret).decode_result(int32)
 
-proc getLineRangesFromCarets*(self: TextEdit; onlySelections: bool = false; mergeAdjacent: bool = true): TypedArray[Vector2i] =
+proc getLineRangesFromCarets*(self: TextEdit; onlySelections: bool = false; mergeAdjacent: bool = true): Array[Vector2i] =
   expandMethodBind(className TextEdit, "get_line_ranges_from_carets", 2393089247)
-  var ret: encoded TypedArray[Vector2i]
+  var ret: encoded Array[Vector2i]
   methodbind.ptrcall(self, [getPtr onlySelections, getPtr mergeAdjacent], addr ret)
-  (addr ret).decode_result(TypedArray[Vector2i])
+  (addr ret).decode_result(Array[Vector2i])
 
 proc getSelectionOriginLine*(self: TextEdit; caretIndex: int32 = 0): int32 =
   expandMethodBind(className TextEdit, "get_selection_origin_line", 1591665591)

--- a/src/gdext/classes/gdtextline.nim
+++ b/src/gdext/classes/gdtextline.nim
@@ -56,7 +56,7 @@ proc getPreserveControl*(self: TextLine): bool =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
 
-proc setBidiOverride*(self: TextLine; override: Array): void =
+proc setBidiOverride*(self: TextLine; override: Array[Variant]): void =
   expandMethodBind(className TextLine, "set_bidi_override", 381264803)
   nilCheck override
   methodbind.ptrcall(self, [getPtr override])
@@ -133,11 +133,11 @@ proc getEllipsisChar*(self: TextLine): String =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(String)
 
-proc getObjects*(self: TextLine): Array =
+proc getObjects*(self: TextLine): Array[Variant] =
   expandMethodBind(className TextLine, "get_objects", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc getObjectRect*(self: TextLine; key: Variant): Rect2 =
   expandMethodBind(className TextLine, "get_object_rect", 1742700391)

--- a/src/gdext/classes/gdtextmesh.nim
+++ b/src/gdext/classes/gdtextmesh.nim
@@ -166,16 +166,16 @@ proc getStructuredTextBidiOverride*(self: TextMesh): TextServer_StructuredTextPa
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(TextServer_StructuredTextParser)
 
-proc setStructuredTextBidiOverrideOptions*(self: TextMesh; args: Array): void =
+proc setStructuredTextBidiOverrideOptions*(self: TextMesh; args: Array[Variant]): void =
   expandMethodBind(className TextMesh, "set_structured_text_bidi_override_options", 381264803)
   nilCheck args
   methodbind.ptrcall(self, [getPtr args])
 
-proc getStructuredTextBidiOverrideOptions*(self: TextMesh): Array =
+proc getStructuredTextBidiOverrideOptions*(self: TextMesh): Array[Variant] =
   expandMethodBind(className TextMesh, "get_structured_text_bidi_override_options", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc setUppercase*(self: TextMesh; enable: bool): void =
   expandMethodBind(className TextMesh, "set_uppercase", 2586408642)

--- a/src/gdext/classes/gdtextparagraph.nim
+++ b/src/gdext/classes/gdtextparagraph.nim
@@ -66,7 +66,7 @@ proc getPreserveControl*(self: TextParagraph): bool =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
 
-proc setBidiOverride*(self: TextParagraph; override: Array): void =
+proc setBidiOverride*(self: TextParagraph; override: Array[Variant]): void =
   expandMethodBind(className TextParagraph, "set_bidi_override", 381264803)
   nilCheck override
   methodbind.ptrcall(self, [getPtr override])
@@ -225,11 +225,11 @@ proc getLineSpacing*(self: TextParagraph): Float =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Float)
 
-proc getLineObjects*(self: TextParagraph; line: int32): Array =
+proc getLineObjects*(self: TextParagraph; line: int32): Array[Variant] =
   expandMethodBind(className TextParagraph, "get_line_objects", 663333327)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr line], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc getLineObjectRect*(self: TextParagraph; line: int32; key: Variant): Rect2 =
   expandMethodBind(className TextParagraph, "get_line_object_rect", 204315017)

--- a/src/gdext/classes/gdtextserver.nim
+++ b/src/gdext/classes/gdtextserver.nim
@@ -375,11 +375,11 @@ proc fontGetOversampling*(self: TextServer; fontRid: RID): float64 =
   methodbind.ptrcall(self, [getPtr fontRid], addr ret)
   (addr ret).decode_result(float64)
 
-proc fontGetSizeCacheList*(self: TextServer; fontRid: RID): TypedArray[Vector2i] =
+proc fontGetSizeCacheList*(self: TextServer; fontRid: RID): Array[Vector2i] =
   expandMethodBind(className TextServer, "font_get_size_cache_list", 2684255073)
-  var ret: encoded TypedArray[Vector2i]
+  var ret: encoded Array[Vector2i]
   methodbind.ptrcall(self, [getPtr fontRid], addr ret)
-  (addr ret).decode_result(TypedArray[Vector2i])
+  (addr ret).decode_result(Array[Vector2i])
 
 proc fontClearSizeCache*(self: TextServer; fontRid: RID): void =
   expandMethodBind(className TextServer, "font_clear_size_cache", 2722037293)
@@ -389,11 +389,11 @@ proc fontRemoveSizeCache*(self: TextServer; fontRid: RID; size: Vector2i): void 
   expandMethodBind(className TextServer, "font_remove_size_cache", 2450610377)
   methodbind.ptrcall(self, [getPtr fontRid, getPtr size])
 
-proc fontGetSizeCacheInfo*(self: TextServer; fontRid: RID): TypedArray[Dictionary] =
+proc fontGetSizeCacheInfo*(self: TextServer; fontRid: RID): Array[Dictionary] =
   expandMethodBind(className TextServer, "font_get_size_cache_info", 2684255073)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr fontRid], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc fontSetAscent*(self: TextServer; fontRid: RID; size: int64; ascent: float64): void =
   expandMethodBind(className TextServer, "font_set_ascent", 1892459533)
@@ -561,11 +561,11 @@ proc fontGetGlyphContours*(self: TextServer; font: RID; size: int64; index: int6
   methodbind.ptrcall(self, [getPtr font, getPtr size, getPtr index], addr ret)
   (addr ret).decode_result(Dictionary)
 
-proc fontGetKerningList*(self: TextServer; fontRid: RID; size: int64): TypedArray[Vector2i] =
+proc fontGetKerningList*(self: TextServer; fontRid: RID; size: int64): Array[Vector2i] =
   expandMethodBind(className TextServer, "font_get_kerning_list", 1778388067)
-  var ret: encoded TypedArray[Vector2i]
+  var ret: encoded Array[Vector2i]
   methodbind.ptrcall(self, [getPtr fontRid, getPtr size], addr ret)
-  (addr ret).decode_result(TypedArray[Vector2i])
+  (addr ret).decode_result(Array[Vector2i])
 
 proc fontClearKerningMap*(self: TextServer; fontRid: RID; size: int64): void =
   expandMethodBind(className TextServer, "font_clear_kerning_map", 3411492887)
@@ -752,7 +752,7 @@ proc shapedTextGetInferredDirection*(self: TextServer; shaped: RID): TextServer_
   methodbind.ptrcall(self, [getPtr shaped], addr ret)
   (addr ret).decode_result(TextServer_Direction)
 
-proc shapedTextSetBidiOverride*(self: TextServer; shaped: RID; override: Array): void =
+proc shapedTextSetBidiOverride*(self: TextServer; shaped: RID; override: Array[Variant]): void =
   expandMethodBind(className TextServer, "shaped_text_set_bidi_override", 684822712)
   nilCheck override
   methodbind.ptrcall(self, [getPtr shaped, getPtr override])
@@ -817,7 +817,7 @@ proc shapedTextGetSpacing*(self: TextServer; shaped: RID; spacing: TextServer_Sp
   methodbind.ptrcall(self, [getPtr shaped, getPtr spacing], addr ret)
   (addr ret).decode_result(int64)
 
-proc shapedTextAddString*(self: TextServer; shaped: RID; text: String; fonts: TypedArray[RID]; size: int64; opentypeFeatures: Dictionary = newDictionary(); language: String = newGdString(); meta: Variant = default(Variant)): bool =
+proc shapedTextAddString*(self: TextServer; shaped: RID; text: String; fonts: Array[RID]; size: int64; opentypeFeatures: Dictionary = newDictionary(); language: String = newGdString(); meta: Variant = default(Variant)): bool =
   expandMethodBind(className TextServer, "shaped_text_add_string", 623473029)
   nilCheck fonts
   nilCheck opentypeFeatures
@@ -873,7 +873,7 @@ proc shapedGetSpanObject*(self: TextServer; shaped: RID; index: int64): Variant 
   methodbind.ptrcall(self, [getPtr shaped, getPtr index], addr ret)
   (addr ret).decode_result(Variant)
 
-proc shapedSetSpanUpdateFont*(self: TextServer; shaped: RID; index: int64; fonts: TypedArray[RID]; size: int64; opentypeFeatures: Dictionary = newDictionary()): void =
+proc shapedSetSpanUpdateFont*(self: TextServer; shaped: RID; index: int64; fonts: Array[RID]; size: int64; opentypeFeatures: Dictionary = newDictionary()): void =
   expandMethodBind(className TextServer, "shaped_set_span_update_font", 2022725822)
   nilCheck fonts
   nilCheck opentypeFeatures
@@ -969,17 +969,17 @@ proc shapedTextHasVisibleChars*(self: TextServer; shaped: RID): bool =
   methodbind.ptrcall(self, [getPtr shaped], addr ret)
   (addr ret).decode_result(bool)
 
-proc shapedTextGetGlyphs*(self: TextServer; shaped: RID): TypedArray[Dictionary] =
+proc shapedTextGetGlyphs*(self: TextServer; shaped: RID): Array[Dictionary] =
   expandMethodBind(className TextServer, "shaped_text_get_glyphs", 2684255073)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr shaped], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
-proc shapedTextSortLogical*(self: TextServer; shaped: RID): TypedArray[Dictionary] =
+proc shapedTextSortLogical*(self: TextServer; shaped: RID): Array[Dictionary] =
   expandMethodBind(className TextServer, "shaped_text_sort_logical", 2670461153)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr shaped], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc shapedTextGetGlyphCount*(self: TextServer; shaped: RID): int64 =
   expandMethodBind(className TextServer, "shaped_text_get_glyph_count", 2198884583)
@@ -1023,11 +1023,11 @@ proc shapedTextGetEllipsisPos*(self: TextServer; shaped: RID): int64 =
   methodbind.ptrcall(self, [getPtr shaped], addr ret)
   (addr ret).decode_result(int64)
 
-proc shapedTextGetEllipsisGlyphs*(self: TextServer; shaped: RID): TypedArray[Dictionary] =
+proc shapedTextGetEllipsisGlyphs*(self: TextServer; shaped: RID): Array[Dictionary] =
   expandMethodBind(className TextServer, "shaped_text_get_ellipsis_glyphs", 2684255073)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr shaped], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc shapedTextGetEllipsisGlyphCount*(self: TextServer; shaped: RID): int64 =
   expandMethodBind(className TextServer, "shaped_text_get_ellipsis_glyph_count", 2198884583)
@@ -1039,11 +1039,11 @@ proc shapedTextOverrunTrimToWidth*(self: TextServer; shaped: RID; width: float64
   expandMethodBind(className TextServer, "shaped_text_overrun_trim_to_width", 2723146520)
   methodbind.ptrcall(self, [getPtr shaped, getPtr width, getPtr overrunTrimFlags])
 
-proc shapedTextGetObjects*(self: TextServer; shaped: RID): Array =
+proc shapedTextGetObjects*(self: TextServer; shaped: RID): Array[Variant] =
   expandMethodBind(className TextServer, "shaped_text_get_objects", 2684255073)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr shaped], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc shapedTextGetObjectRect*(self: TextServer; shaped: RID; key: Variant): Rect2 =
   expandMethodBind(className TextServer, "shaped_text_get_object_rect", 447978354)
@@ -1257,9 +1257,9 @@ proc stringToTitle*(self: TextServer; string: String; language: String = newGdSt
   methodbind.ptrcall(self, [getPtr string, getPtr language], addr ret)
   (addr ret).decode_result(String)
 
-proc parseStructuredText*(self: TextServer; parserType: TextServer_StructuredTextParser; args: Array; text: String): TypedArray[Vector3i] =
+proc parseStructuredText*(self: TextServer; parserType: TextServer_StructuredTextParser; args: Array[Variant]; text: String): Array[Vector3i] =
   expandMethodBind(className TextServer, "parse_structured_text", 3310685015)
   nilCheck args
-  var ret: encoded TypedArray[Vector3i]
+  var ret: encoded Array[Vector3i]
   methodbind.ptrcall(self, [getPtr parserType, getPtr args, getPtr text], addr ret)
-  (addr ret).decode_result(TypedArray[Vector3i])
+  (addr ret).decode_result(Array[Vector3i])

--- a/src/gdext/classes/gdtextserverextension.nim
+++ b/src/gdext/classes/gdtextserverextension.nim
@@ -366,7 +366,7 @@ proc registerVirtual_fontGetOversampling*[T: TextServerExtension](Self: typedesc
   Self.vmethods[newStringName"_font_get_oversampling"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextServerExtension](p_instance).fontGetOversampling(p_args[0].decode(RID)).encode(r_ret)
 
-method fontGetSizeCacheList*(self: TextServerExtension; fontRid: RID): TypedArray[Vector2i] {.base.} = (discard)
+method fontGetSizeCacheList*(self: TextServerExtension; fontRid: RID): Array[Vector2i] {.base.} = (discard)
 proc registerVirtual_fontGetSizeCacheList*[T: TextServerExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_font_get_size_cache_list"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextServerExtension](p_instance).fontGetSizeCacheList(p_args[0].decode(RID)).encode(r_ret)
@@ -381,7 +381,7 @@ proc registerVirtual_fontRemoveSizeCache*[T: TextServerExtension](Self: typedesc
   Self.vmethods[newStringName"_font_remove_size_cache"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextServerExtension](p_instance).fontRemoveSizeCache(p_args[0].decode(RID), p_args[1].decode(Vector2i))
 
-method fontGetSizeCacheInfo*(self: TextServerExtension; fontRid: RID): TypedArray[Dictionary] {.base.} = (discard)
+method fontGetSizeCacheInfo*(self: TextServerExtension; fontRid: RID): Array[Dictionary] {.base.} = (discard)
 proc registerVirtual_fontGetSizeCacheInfo*[T: TextServerExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_font_get_size_cache_info"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextServerExtension](p_instance).fontGetSizeCacheInfo(p_args[0].decode(RID)).encode(r_ret)
@@ -551,7 +551,7 @@ proc registerVirtual_fontGetGlyphContours*[T: TextServerExtension](Self: typedes
   Self.vmethods[newStringName"_font_get_glyph_contours"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextServerExtension](p_instance).fontGetGlyphContours(p_args[0].decode(RID), p_args[1].decode(int64), p_args[2].decode(int64)).encode(r_ret)
 
-method fontGetKerningList*(self: TextServerExtension; fontRid: RID; size: int64): TypedArray[Vector2i] {.base.} = (discard)
+method fontGetKerningList*(self: TextServerExtension; fontRid: RID; size: int64): Array[Vector2i] {.base.} = (discard)
 proc registerVirtual_fontGetKerningList*[T: TextServerExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_font_get_kerning_list"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextServerExtension](p_instance).fontGetKerningList(p_args[0].decode(RID), p_args[1].decode(int64)).encode(r_ret)
@@ -746,10 +746,10 @@ proc registerVirtual_shapedTextGetInferredDirection*[T: TextServerExtension](Sel
   Self.vmethods[newStringName"_shaped_text_get_inferred_direction"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextServerExtension](p_instance).shapedTextGetInferredDirection(p_args[0].decode(RID)).encode(r_ret)
 
-method shapedTextSetBidiOverride*(self: TextServerExtension; shaped: RID; override: Array): void {.base.} = (discard)
+method shapedTextSetBidiOverride*(self: TextServerExtension; shaped: RID; override: Array[Variant]): void {.base.} = (discard)
 proc registerVirtual_shapedTextSetBidiOverride*[T: TextServerExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_shaped_text_set_bidi_override"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[TextServerExtension](p_instance).shapedTextSetBidiOverride(p_args[0].decode(RID), p_args[1].decode(Array))
+    errproof: cast[TextServerExtension](p_instance).shapedTextSetBidiOverride(p_args[0].decode(RID), p_args[1].decode(Array[Variant]))
 
 method shapedTextSetCustomPunctuation*(self: TextServerExtension; shaped: RID; punct: String): void {.base.} = (discard)
 proc registerVirtual_shapedTextSetCustomPunctuation*[T: TextServerExtension](Self: typedesc[T]) =
@@ -811,10 +811,10 @@ proc registerVirtual_shapedTextGetSpacing*[T: TextServerExtension](Self: typedes
   Self.vmethods[newStringName"_shaped_text_get_spacing"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextServerExtension](p_instance).shapedTextGetSpacing(p_args[0].decode(RID), p_args[1].decode(TextServer_SpacingType)).encode(r_ret)
 
-method shapedTextAddString*(self: TextServerExtension; shaped: RID; text: String; fonts: TypedArray[RID]; size: int64; opentypeFeatures: Dictionary; language: String; meta: Variant): bool {.base.} = (discard)
+method shapedTextAddString*(self: TextServerExtension; shaped: RID; text: String; fonts: Array[RID]; size: int64; opentypeFeatures: Dictionary; language: String; meta: Variant): bool {.base.} = (discard)
 proc registerVirtual_shapedTextAddString*[T: TextServerExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_shaped_text_add_string"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[TextServerExtension](p_instance).shapedTextAddString(p_args[0].decode(RID), p_args[1].decode(String), p_args[2].decode(TypedArray[RID]), p_args[3].decode(int64), p_args[4].decode(Dictionary), p_args[5].decode(String), p_args[6].decode(Variant)).encode(r_ret)
+    errproof: cast[TextServerExtension](p_instance).shapedTextAddString(p_args[0].decode(RID), p_args[1].decode(String), p_args[2].decode(Array[RID]), p_args[3].decode(int64), p_args[4].decode(Dictionary), p_args[5].decode(String), p_args[6].decode(Variant)).encode(r_ret)
 
 method shapedTextAddObject*(self: TextServerExtension; shaped: RID; key: Variant; size: Vector2; inlineAlign: InlineAlignment; length: int64; baseline: float64): bool {.base.} = (discard)
 proc registerVirtual_shapedTextAddObject*[T: TextServerExtension](Self: typedesc[T]) =
@@ -856,10 +856,10 @@ proc registerVirtual_shapedGetSpanObject*[T: TextServerExtension](Self: typedesc
   Self.vmethods[newStringName"_shaped_get_span_object"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextServerExtension](p_instance).shapedGetSpanObject(p_args[0].decode(RID), p_args[1].decode(int64)).encode(r_ret)
 
-method shapedSetSpanUpdateFont*(self: TextServerExtension; shaped: RID; index: int64; fonts: TypedArray[RID]; size: int64; opentypeFeatures: Dictionary): void {.base.} = (discard)
+method shapedSetSpanUpdateFont*(self: TextServerExtension; shaped: RID; index: int64; fonts: Array[RID]; size: int64; opentypeFeatures: Dictionary): void {.base.} = (discard)
 proc registerVirtual_shapedSetSpanUpdateFont*[T: TextServerExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_shaped_set_span_update_font"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[TextServerExtension](p_instance).shapedSetSpanUpdateFont(p_args[0].decode(RID), p_args[1].decode(int64), p_args[2].decode(TypedArray[RID]), p_args[3].decode(int64), p_args[4].decode(Dictionary))
+    errproof: cast[TextServerExtension](p_instance).shapedSetSpanUpdateFont(p_args[0].decode(RID), p_args[1].decode(int64), p_args[2].decode(Array[RID]), p_args[3].decode(int64), p_args[4].decode(Dictionary))
 
 method shapedGetRunCount*(self: TextServerExtension; shaped: RID): int64 {.base.} = (discard)
 proc registerVirtual_shapedGetRunCount*[T: TextServerExtension](Self: typedesc[T]) =
@@ -1001,7 +1001,7 @@ proc registerVirtual_shapedTextOverrunTrimToWidth*[T: TextServerExtension](Self:
   Self.vmethods[newStringName"_shaped_text_overrun_trim_to_width"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextServerExtension](p_instance).shapedTextOverrunTrimToWidth(p_args[0].decode(RID), p_args[1].decode(float64), p_args[2].decode(set[TextServer_TextOverrunFlag]))
 
-method shapedTextGetObjects*(self: TextServerExtension; shaped: RID): Array {.base.} = (discard)
+method shapedTextGetObjects*(self: TextServerExtension; shaped: RID): Array[Variant] {.base.} = (discard)
 proc registerVirtual_shapedTextGetObjects*[T: TextServerExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_shaped_text_get_objects"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextServerExtension](p_instance).shapedTextGetObjects(p_args[0].decode(RID)).encode(r_ret)
@@ -1186,10 +1186,10 @@ proc registerVirtual_stringToTitle*[T: TextServerExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_string_to_title"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TextServerExtension](p_instance).stringToTitle(p_args[0].decode(String), p_args[1].decode(String)).encode(r_ret)
 
-method parseStructuredText*(self: TextServerExtension; parserType: TextServer_StructuredTextParser; args: Array; text: String): TypedArray[Vector3i] {.base.} = (discard)
+method parseStructuredText*(self: TextServerExtension; parserType: TextServer_StructuredTextParser; args: Array[Variant]; text: String): Array[Vector3i] {.base.} = (discard)
 proc registerVirtual_parseStructuredText*[T: TextServerExtension](Self: typedesc[T]) =
   Self.vmethods[newStringName"_parse_structured_text"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[TextServerExtension](p_instance).parseStructuredText(p_args[0].decode(TextServer_StructuredTextParser), p_args[1].decode(Array), p_args[2].decode(String)).encode(r_ret)
+    errproof: cast[TextServerExtension](p_instance).parseStructuredText(p_args[0].decode(TextServer_StructuredTextParser), p_args[1].decode(Array[Variant]), p_args[2].decode(String)).encode(r_ret)
 
 method cleanup*(self: TextServerExtension): void {.base.} = (discard)
 proc registerVirtual_cleanup*[T: TextServerExtension](Self: typedesc[T]) =

--- a/src/gdext/classes/gdtextservermanager.nim
+++ b/src/gdext/classes/gdtextservermanager.nim
@@ -26,11 +26,11 @@ proc getInterface*(self: TextServerManager; idx: int32): gdref TextServer =
   methodbind.ptrcall(self, [getPtr idx], addr ret)
   (addr ret).decode_result(gdref TextServer)
 
-proc getInterfaces*(self: TextServerManager): TypedArray[Dictionary] =
+proc getInterfaces*(self: TextServerManager): Array[Dictionary] =
   expandMethodBind(className TextServerManager, "get_interfaces", 3995934104)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc findInterface*(self: TextServerManager; name: String): gdref TextServer =
   expandMethodBind(className TextServerManager, "find_interface", 2240905781)

--- a/src/gdext/classes/gdtexture3d.nim
+++ b/src/gdext/classes/gdtexture3d.nim
@@ -51,11 +51,11 @@ proc registerVirtual_hasMipmaps*[T: Texture3D](Self: typedesc[T]) =
   Self.vmethods[newStringName"_has_mipmaps"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Texture3D](p_instance).hasMipmaps().encode(r_ret)
 
-method getData*(self: Texture3D): TypedArray[gdref Image] {.base.} =
+method getData*(self: Texture3D): Array[gdref Image] {.base.} =
   expandMethodBind(className Texture3D, "get_data", 3995934104)
-  var ret: encoded TypedArray[gdref Image]
+  var ret: encoded Array[gdref Image]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[gdref Image])
+  (addr ret).decode_result(Array[gdref Image])
 proc registerVirtual_getData*[T: Texture3D](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_data"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[Texture3D](p_instance).getData().encode(r_ret)

--- a/src/gdext/classes/gdtilemap.nim
+++ b/src/gdext/classes/gdtilemap.nim
@@ -240,7 +240,7 @@ proc getLayerForBodyRid*(self: TileMap; body: RID): int32 =
   methodbind.ptrcall(self, [getPtr body], addr ret)
   (addr ret).decode_result(int32)
 
-proc getPattern*(self: TileMap; layer: int32; coordsArray: TypedArray[Vector2i]): gdref TileMapPattern =
+proc getPattern*(self: TileMap; layer: int32; coordsArray: Array[Vector2i]): gdref TileMapPattern =
   expandMethodBind(className TileMap, "get_pattern", 2833570986)
   nilCheck coordsArray
   var ret: encoded gdref TileMapPattern
@@ -257,12 +257,12 @@ proc setPattern*(self: TileMap; layer: int32; position: Vector2i; pattern: gdref
   expandMethodBind(className TileMap, "set_pattern", 1195853946)
   methodbind.ptrcall(self, [getPtr layer, getPtr position, getPtr pattern])
 
-proc setCellsTerrainConnect*(self: TileMap; layer: int32; cells: TypedArray[Vector2i]; terrainSet: int32; terrain: int32; ignoreEmptyTerrains: bool = true): void =
+proc setCellsTerrainConnect*(self: TileMap; layer: int32; cells: Array[Vector2i]; terrainSet: int32; terrain: int32; ignoreEmptyTerrains: bool = true): void =
   expandMethodBind(className TileMap, "set_cells_terrain_connect", 3578627656)
   nilCheck cells
   methodbind.ptrcall(self, [getPtr layer, getPtr cells, getPtr terrainSet, getPtr terrain, getPtr ignoreEmptyTerrains])
 
-proc setCellsTerrainPath*(self: TileMap; layer: int32; path: TypedArray[Vector2i]; terrainSet: int32; terrain: int32; ignoreEmptyTerrains: bool = true): void =
+proc setCellsTerrainPath*(self: TileMap; layer: int32; path: Array[Vector2i]; terrainSet: int32; terrain: int32; ignoreEmptyTerrains: bool = true): void =
   expandMethodBind(className TileMap, "set_cells_terrain_path", 3578627656)
   nilCheck path
   methodbind.ptrcall(self, [getPtr layer, getPtr path, getPtr terrainSet, getPtr terrain, getPtr ignoreEmptyTerrains])
@@ -287,23 +287,23 @@ proc notifyRuntimeTileDataUpdate*(self: TileMap; layer: int32 = -1): void =
   expandMethodBind(className TileMap, "notify_runtime_tile_data_update", 1025054187)
   methodbind.ptrcall(self, [getPtr layer])
 
-proc getSurroundingCells*(self: TileMap; coords: Vector2i): TypedArray[Vector2i] =
+proc getSurroundingCells*(self: TileMap; coords: Vector2i): Array[Vector2i] =
   expandMethodBind(className TileMap, "get_surrounding_cells", 2673526557)
-  var ret: encoded TypedArray[Vector2i]
+  var ret: encoded Array[Vector2i]
   methodbind.ptrcall(self, [getPtr coords], addr ret)
-  (addr ret).decode_result(TypedArray[Vector2i])
+  (addr ret).decode_result(Array[Vector2i])
 
-proc getUsedCells*(self: TileMap; layer: int32): TypedArray[Vector2i] =
+proc getUsedCells*(self: TileMap; layer: int32): Array[Vector2i] =
   expandMethodBind(className TileMap, "get_used_cells", 663333327)
-  var ret: encoded TypedArray[Vector2i]
+  var ret: encoded Array[Vector2i]
   methodbind.ptrcall(self, [getPtr layer], addr ret)
-  (addr ret).decode_result(TypedArray[Vector2i])
+  (addr ret).decode_result(Array[Vector2i])
 
-proc getUsedCellsById*(self: TileMap; layer: int32; sourceId: int32 = -1; atlasCoords: Vector2i = vector2i(-1, -1); alternativeTile: int32 = -1): TypedArray[Vector2i] =
+proc getUsedCellsById*(self: TileMap; layer: int32; sourceId: int32 = -1; atlasCoords: Vector2i = vector2i(-1, -1); alternativeTile: int32 = -1): Array[Vector2i] =
   expandMethodBind(className TileMap, "get_used_cells_by_id", 2931012785)
-  var ret: encoded TypedArray[Vector2i]
+  var ret: encoded Array[Vector2i]
   methodbind.ptrcall(self, [getPtr layer, getPtr sourceId, getPtr atlasCoords, getPtr alternativeTile], addr ret)
-  (addr ret).decode_result(TypedArray[Vector2i])
+  (addr ret).decode_result(Array[Vector2i])
 
 proc getUsedRect*(self: TileMap): Rect2i =
   expandMethodBind(className TileMap, "get_used_rect", 410525958)

--- a/src/gdext/classes/gdtilemaplayer.nim
+++ b/src/gdext/classes/gdtilemaplayer.nim
@@ -16,10 +16,10 @@ proc registerVirtual_tileDataRuntimeUpdate*[T: TileMapLayer](Self: typedesc[T]) 
   Self.vmethods[newStringName"_tile_data_runtime_update"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[TileMapLayer](p_instance).tileDataRuntimeUpdate(p_args[0].decode(Vector2i), p_args[1].decode(TileData))
 
-method updateCells*(self: TileMapLayer; coords: TypedArray[Vector2i]; forcedCleanup: bool): void {.base.} = (discard)
+method updateCells*(self: TileMapLayer; coords: Array[Vector2i]; forcedCleanup: bool): void {.base.} = (discard)
 proc registerVirtual_updateCells*[T: TileMapLayer](Self: typedesc[T]) =
   Self.vmethods[newStringName"_update_cells"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[TileMapLayer](p_instance).updateCells(p_args[0].decode(TypedArray[Vector2i]), p_args[1].decode(bool))
+    errproof: cast[TileMapLayer](p_instance).updateCells(p_args[0].decode(Array[Vector2i]), p_args[1].decode(bool))
 
 proc setCell*(self: TileMapLayer; coords: Vector2i; sourceId: int32 = -1; atlasCoords: Vector2i = vector2i(-1, -1); alternativeTile: int32 = 0): void =
   expandMethodBind(className TileMapLayer, "set_cell", 2428518503)
@@ -79,17 +79,17 @@ proc isCellTransposed*(self: TileMapLayer; coords: Vector2i): bool =
   methodbind.ptrcall(self, [getPtr coords], addr ret)
   (addr ret).decode_result(bool)
 
-proc getUsedCells*(self: TileMapLayer): TypedArray[Vector2i] =
+proc getUsedCells*(self: TileMapLayer): Array[Vector2i] =
   expandMethodBind(className TileMapLayer, "get_used_cells", 3995934104)
-  var ret: encoded TypedArray[Vector2i]
+  var ret: encoded Array[Vector2i]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Vector2i])
+  (addr ret).decode_result(Array[Vector2i])
 
-proc getUsedCellsById*(self: TileMapLayer; sourceId: int32 = -1; atlasCoords: Vector2i = vector2i(-1, -1); alternativeTile: int32 = -1): TypedArray[Vector2i] =
+proc getUsedCellsById*(self: TileMapLayer; sourceId: int32 = -1; atlasCoords: Vector2i = vector2i(-1, -1); alternativeTile: int32 = -1): Array[Vector2i] =
   expandMethodBind(className TileMapLayer, "get_used_cells_by_id", 4175304538)
-  var ret: encoded TypedArray[Vector2i]
+  var ret: encoded Array[Vector2i]
   methodbind.ptrcall(self, [getPtr sourceId, getPtr atlasCoords, getPtr alternativeTile], addr ret)
-  (addr ret).decode_result(TypedArray[Vector2i])
+  (addr ret).decode_result(Array[Vector2i])
 
 proc getUsedRect*(self: TileMapLayer): Rect2i =
   expandMethodBind(className TileMapLayer, "get_used_rect", 410525958)
@@ -97,7 +97,7 @@ proc getUsedRect*(self: TileMapLayer): Rect2i =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(Rect2i)
 
-proc getPattern*(self: TileMapLayer; coordsArray: TypedArray[Vector2i]): gdref TileMapPattern =
+proc getPattern*(self: TileMapLayer; coordsArray: Array[Vector2i]): gdref TileMapPattern =
   expandMethodBind(className TileMapLayer, "get_pattern", 3820813253)
   nilCheck coordsArray
   var ret: encoded gdref TileMapPattern
@@ -108,12 +108,12 @@ proc setPattern*(self: TileMapLayer; position: Vector2i; pattern: gdref TileMapP
   expandMethodBind(className TileMapLayer, "set_pattern", 1491151770)
   methodbind.ptrcall(self, [getPtr position, getPtr pattern])
 
-proc setCellsTerrainConnect*(self: TileMapLayer; cells: TypedArray[Vector2i]; terrainSet: int32; terrain: int32; ignoreEmptyTerrains: bool = true): void =
+proc setCellsTerrainConnect*(self: TileMapLayer; cells: Array[Vector2i]; terrainSet: int32; terrain: int32; ignoreEmptyTerrains: bool = true): void =
   expandMethodBind(className TileMapLayer, "set_cells_terrain_connect", 748968311)
   nilCheck cells
   methodbind.ptrcall(self, [getPtr cells, getPtr terrainSet, getPtr terrain, getPtr ignoreEmptyTerrains])
 
-proc setCellsTerrainPath*(self: TileMapLayer; path: TypedArray[Vector2i]; terrainSet: int32; terrain: int32; ignoreEmptyTerrains: bool = true): void =
+proc setCellsTerrainPath*(self: TileMapLayer; path: Array[Vector2i]; terrainSet: int32; terrain: int32; ignoreEmptyTerrains: bool = true): void =
   expandMethodBind(className TileMapLayer, "set_cells_terrain_path", 748968311)
   nilCheck path
   methodbind.ptrcall(self, [getPtr path, getPtr terrainSet, getPtr terrain, getPtr ignoreEmptyTerrains])
@@ -144,11 +144,11 @@ proc mapPattern*(self: TileMapLayer; positionInTilemap: Vector2i; coordsInPatter
   methodbind.ptrcall(self, [getPtr positionInTilemap, getPtr coordsInPattern, getPtr pattern], addr ret)
   (addr ret).decode_result(Vector2i)
 
-proc getSurroundingCells*(self: TileMapLayer; coords: Vector2i): TypedArray[Vector2i] =
+proc getSurroundingCells*(self: TileMapLayer; coords: Vector2i): Array[Vector2i] =
   expandMethodBind(className TileMapLayer, "get_surrounding_cells", 2673526557)
-  var ret: encoded TypedArray[Vector2i]
+  var ret: encoded Array[Vector2i]
   methodbind.ptrcall(self, [getPtr coords], addr ret)
-  (addr ret).decode_result(TypedArray[Vector2i])
+  (addr ret).decode_result(Array[Vector2i])
 
 proc getNeighborCell*(self: TileMapLayer; coords: Vector2i; neighbor: TileSet_CellNeighbor): Vector2i =
   expandMethodBind(className TileMapLayer, "get_neighbor_cell", 986575103)

--- a/src/gdext/classes/gdtilemappattern.nim
+++ b/src/gdext/classes/gdtilemappattern.nim
@@ -38,11 +38,11 @@ proc getCellAlternativeTile*(self: TileMapPattern; coords: Vector2i): int32 =
   methodbind.ptrcall(self, [getPtr coords], addr ret)
   (addr ret).decode_result(int32)
 
-proc getUsedCells*(self: TileMapPattern): TypedArray[Vector2i] =
+proc getUsedCells*(self: TileMapPattern): Array[Vector2i] =
   expandMethodBind(className TileMapPattern, "get_used_cells", 3995934104)
-  var ret: encoded TypedArray[Vector2i]
+  var ret: encoded Array[Vector2i]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Vector2i])
+  (addr ret).decode_result(Array[Vector2i])
 
 proc getSize*(self: TileMapPattern): Vector2i =
   expandMethodBind(className TileMapPattern, "get_size", 3690982128)

--- a/src/gdext/classes/gdtileset.nim
+++ b/src/gdext/classes/gdtileset.nim
@@ -374,11 +374,11 @@ proc setCoordsLevelTileProxy*(self: TileSet; pSourceFrom: int32; coordsFrom: Vec
   expandMethodBind(className TileSet, "set_coords_level_tile_proxy", 1769939278)
   methodbind.ptrcall(self, [getPtr pSourceFrom, getPtr coordsFrom, getPtr sourceTo, getPtr coordsTo])
 
-proc getCoordsLevelTileProxy*(self: TileSet; sourceFrom: int32; coordsFrom: Vector2i): Array =
+proc getCoordsLevelTileProxy*(self: TileSet; sourceFrom: int32; coordsFrom: Vector2i): Array[Variant] =
   expandMethodBind(className TileSet, "get_coords_level_tile_proxy", 2856536371)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr sourceFrom, getPtr coordsFrom], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc hasCoordsLevelTileProxy*(self: TileSet; sourceFrom: int32; coordsFrom: Vector2i): bool =
   expandMethodBind(className TileSet, "has_coords_level_tile_proxy", 3957903770)
@@ -394,11 +394,11 @@ proc setAlternativeLevelTileProxy*(self: TileSet; sourceFrom: int32; coordsFrom:
   expandMethodBind(className TileSet, "set_alternative_level_tile_proxy", 3862385460)
   methodbind.ptrcall(self, [getPtr sourceFrom, getPtr coordsFrom, getPtr alternativeFrom, getPtr sourceTo, getPtr coordsTo, getPtr alternativeTo])
 
-proc getAlternativeLevelTileProxy*(self: TileSet; sourceFrom: int32; coordsFrom: Vector2i; alternativeFrom: int32): Array =
+proc getAlternativeLevelTileProxy*(self: TileSet; sourceFrom: int32; coordsFrom: Vector2i; alternativeFrom: int32): Array[Variant] =
   expandMethodBind(className TileSet, "get_alternative_level_tile_proxy", 2303761075)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr sourceFrom, getPtr coordsFrom, getPtr alternativeFrom], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc hasAlternativeLevelTileProxy*(self: TileSet; sourceFrom: int32; coordsFrom: Vector2i; alternativeFrom: int32): bool =
   expandMethodBind(className TileSet, "has_alternative_level_tile_proxy", 180086755)
@@ -410,11 +410,11 @@ proc removeAlternativeLevelTileProxy*(self: TileSet; sourceFrom: int32; coordsFr
   expandMethodBind(className TileSet, "remove_alternative_level_tile_proxy", 2328951467)
   methodbind.ptrcall(self, [getPtr sourceFrom, getPtr coordsFrom, getPtr alternativeFrom])
 
-proc mapTileProxy*(self: TileSet; sourceFrom: int32; coordsFrom: Vector2i; alternativeFrom: int32): Array =
+proc mapTileProxy*(self: TileSet; sourceFrom: int32; coordsFrom: Vector2i; alternativeFrom: int32): Array[Variant] =
   expandMethodBind(className TileSet, "map_tile_proxy", 4267935328)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr sourceFrom, getPtr coordsFrom, getPtr alternativeFrom], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc cleanupInvalidTileProxies*(self: TileSet): void =
   expandMethodBind(className TileSet, "cleanup_invalid_tile_proxies", 3218959716)

--- a/src/gdext/classes/gdtreeitem.nim
+++ b/src/gdext/classes/gdtreeitem.nim
@@ -120,16 +120,16 @@ proc getStructuredTextBidiOverride*(self: TreeItem; column: int32): TextServer_S
   methodbind.ptrcall(self, [getPtr column], addr ret)
   (addr ret).decode_result(TextServer_StructuredTextParser)
 
-proc setStructuredTextBidiOverrideOptions*(self: TreeItem; column: int32; args: Array): void =
+proc setStructuredTextBidiOverrideOptions*(self: TreeItem; column: int32; args: Array[Variant]): void =
   expandMethodBind(className TreeItem, "set_structured_text_bidi_override_options", 537221740)
   nilCheck args
   methodbind.ptrcall(self, [getPtr column, getPtr args])
 
-proc getStructuredTextBidiOverrideOptions*(self: TreeItem; column: int32): Array =
+proc getStructuredTextBidiOverrideOptions*(self: TreeItem; column: int32): Array[Variant] =
   expandMethodBind(className TreeItem, "get_structured_text_bidi_override_options", 663333327)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [getPtr column], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc setLanguage*(self: TreeItem; column: int32; language: String): void =
   expandMethodBind(className TreeItem, "set_language", 501894301)
@@ -581,11 +581,11 @@ proc getChildCount*(self: TreeItem): int32 =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(int32)
 
-proc getChildren*(self: TreeItem): TypedArray[TreeItem] =
+proc getChildren*(self: TreeItem): Array[TreeItem] =
   expandMethodBind(className TreeItem, "get_children", 2915620761)
-  var ret: encoded TypedArray[TreeItem]
+  var ret: encoded Array[TreeItem]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[TreeItem])
+  (addr ret).decode_result(Array[TreeItem])
 
 proc getIndex*(self: TreeItem): int32 =
   expandMethodBind(className TreeItem, "get_index", 2455072627)

--- a/src/gdext/classes/gduniformsetcacherd.nim
+++ b/src/gdext/classes/gduniformsetcacherd.nim
@@ -6,7 +6,7 @@ import gdobject; export gdobject
 
 expandOnClassImported(UniformSetCacheRD, Object)
 
-proc getCache*(_: typedesc[UniformSetCacheRD]; shader: RID; set: uint32; uniforms: TypedArray[gdref RDUniform]): RID =
+proc getCache*(_: typedesc[UniformSetCacheRD]; shader: RID; set: uint32; uniforms: Array[gdref RDUniform]): RID =
   expandMethodBind(className UniformSetCacheRD, "get_cache", 658571723)
   nilCheck uniforms
   var ret: encoded RID

--- a/src/gdext/classes/gdviewport.nim
+++ b/src/gdext/classes/gdviewport.nim
@@ -422,11 +422,11 @@ proc isEmbeddingSubwindows*(self: Viewport): bool =
   methodbind.ptrcall(self, [], addr ret)
   (addr ret).decode_result(bool)
 
-proc getEmbeddedSubwindows*(self: Viewport): TypedArray[Window] =
+proc getEmbeddedSubwindows*(self: Viewport): Array[Window] =
   expandMethodBind(className Viewport, "get_embedded_subwindows", 3995934104)
-  var ret: encoded TypedArray[Window]
+  var ret: encoded Array[Window]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Window])
+  (addr ret).decode_result(Array[Window])
 
 proc setCanvasCullMask*(self: Viewport; mask: uint32): void =
   expandMethodBind(className Viewport, "set_canvas_cull_mask", 1286410249)

--- a/src/gdext/classes/gdvisualshader.nim
+++ b/src/gdext/classes/gdvisualshader.nim
@@ -79,11 +79,11 @@ proc connectNodesForced*(self: VisualShader; `type`: VisualShader_Type; fromNode
   expandMethodBind(className VisualShader, "connect_nodes_forced", 2268060358)
   methodbind.ptrcall(self, [getPtr `type`, getPtr fromNode, getPtr fromPort, getPtr toNode, getPtr toPort])
 
-proc getNodeConnections*(self: VisualShader; `type`: VisualShader_Type): TypedArray[Dictionary] =
+proc getNodeConnections*(self: VisualShader; `type`: VisualShader_Type): Array[Dictionary] =
   expandMethodBind(className VisualShader, "get_node_connections", 1441964831)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [getPtr `type`], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc attachNodeToFrame*(self: VisualShader; `type`: VisualShader_Type; id: int32; frame: int32): void =
   expandMethodBind(className VisualShader, "attach_node_to_frame", 2479945279)

--- a/src/gdext/classes/gdvisualshadernode.nim
+++ b/src/gdext/classes/gdvisualshadernode.nim
@@ -40,16 +40,16 @@ proc clearDefaultInputValues*(self: VisualShaderNode): void =
   expandMethodBind(className VisualShaderNode, "clear_default_input_values", 3218959716)
   methodbind.ptrcall(self, [])
 
-proc setDefaultInputValues*(self: VisualShaderNode; values: Array): void =
+proc setDefaultInputValues*(self: VisualShaderNode; values: Array[Variant]): void =
   expandMethodBind(className VisualShaderNode, "set_default_input_values", 381264803)
   nilCheck values
   methodbind.ptrcall(self, [getPtr values])
 
-proc getDefaultInputValues*(self: VisualShaderNode): Array =
+proc getDefaultInputValues*(self: VisualShaderNode): Array[Variant] =
   expandMethodBind(className VisualShaderNode, "get_default_input_values", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc setFrame*(self: VisualShaderNode; frame: int32): void =
   expandMethodBind(className VisualShaderNode, "set_frame", 1286410249)

--- a/src/gdext/classes/gdvisualshadernodecustom.nim
+++ b/src/gdext/classes/gdvisualshadernodecustom.nim
@@ -86,10 +86,10 @@ proc registerVirtual_getPropertyOptions*[T: VisualShaderNodeCustom](Self: typede
   Self.vmethods[newStringName"_get_property_options"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
     errproof: cast[VisualShaderNodeCustom](p_instance).getPropertyOptions(p_args[0].decode(int32)).encode(r_ret)
 
-method getCode*(self: VisualShaderNodeCustom; inputVars: TypedArray[String]; outputVars: TypedArray[String]; mode: Shader_Mode; `type`: VisualShader_Type): String {.base.} = (discard)
+method getCode*(self: VisualShaderNodeCustom; inputVars: Array[String]; outputVars: Array[String]; mode: Shader_Mode; `type`: VisualShader_Type): String {.base.} = (discard)
 proc registerVirtual_getCode*[T: VisualShaderNodeCustom](Self: typedesc[T]) =
   Self.vmethods[newStringName"_get_code"] = proc (p_instance: ClassInstancePtr; p_args: ptr UncheckedArray[ConstTypePtr]; r_ret: TypePtr) {.gdcall.} =
-    errproof: cast[VisualShaderNodeCustom](p_instance).getCode(p_args[0].decode(TypedArray[String]), p_args[1].decode(TypedArray[String]), p_args[2].decode(Shader_Mode), p_args[3].decode(VisualShader_Type)).encode(r_ret)
+    errproof: cast[VisualShaderNodeCustom](p_instance).getCode(p_args[0].decode(Array[String]), p_args[1].decode(Array[String]), p_args[2].decode(Shader_Mode), p_args[3].decode(VisualShader_Type)).encode(r_ret)
 
 method getFuncCode*(self: VisualShaderNodeCustom; mode: Shader_Mode; `type`: VisualShader_Type): String {.base.} = (discard)
 proc registerVirtual_getFuncCode*[T: VisualShaderNodeCustom](Self: typedesc[T]) =

--- a/src/gdext/classes/gdwebrtcmultiplayerpeer.nim
+++ b/src/gdext/classes/gdwebrtcmultiplayerpeer.nim
@@ -6,21 +6,21 @@ import gdmultiplayerpeer; export gdmultiplayerpeer
 
 expandOnClassImported(WebRTCMultiplayerPeer, MultiplayerPeer)
 
-proc createServer*(self: WebRTCMultiplayerPeer; channelsConfig: Array = newArray()): Error =
+proc createServer*(self: WebRTCMultiplayerPeer; channelsConfig: Array[Variant] = newArray[Variant]()): Error =
   expandMethodBind(className WebRTCMultiplayerPeer, "create_server", 2865356025)
   nilCheck channelsConfig
   var ret: encoded Error
   methodbind.ptrcall(self, [getPtr channelsConfig], addr ret)
   (addr ret).decode_result(Error)
 
-proc createClient*(self: WebRTCMultiplayerPeer; peerId: int32; channelsConfig: Array = newArray()): Error =
+proc createClient*(self: WebRTCMultiplayerPeer; peerId: int32; channelsConfig: Array[Variant] = newArray[Variant]()): Error =
   expandMethodBind(className WebRTCMultiplayerPeer, "create_client", 2641732907)
   nilCheck channelsConfig
   var ret: encoded Error
   methodbind.ptrcall(self, [getPtr peerId, getPtr channelsConfig], addr ret)
   (addr ret).decode_result(Error)
 
-proc createMesh*(self: WebRTCMultiplayerPeer; peerId: int32; channelsConfig: Array = newArray()): Error =
+proc createMesh*(self: WebRTCMultiplayerPeer; peerId: int32; channelsConfig: Array[Variant] = newArray[Variant]()): Error =
   expandMethodBind(className WebRTCMultiplayerPeer, "create_mesh", 2641732907)
   nilCheck channelsConfig
   var ret: encoded Error

--- a/src/gdext/classes/gdwebxrinterface.nim
+++ b/src/gdext/classes/gdwebxrinterface.nim
@@ -96,11 +96,11 @@ proc setDisplayRefreshRate*(self: WebXRInterface; refreshRate: Float): void =
   expandMethodBind(className WebXRInterface, "set_display_refresh_rate", 373806689)
   methodbind.ptrcall(self, [getPtr refreshRate])
 
-proc getAvailableDisplayRefreshRates*(self: WebXRInterface): Array =
+proc getAvailableDisplayRefreshRates*(self: WebXRInterface): Array[Variant] =
   expandMethodBind(className WebXRInterface, "get_available_display_refresh_rates", 3995934104)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 template sessionMode*(self: WebXRInterface): untyped = self.getSessionMode()
 template `sessionMode=`*(self: WebXRInterface; value) = self.setSessionMode(value)

--- a/src/gdext/classes/gdxrinterface.nim
+++ b/src/gdext/classes/gdxrinterface.nim
@@ -146,11 +146,11 @@ proc getProjectionForView*(self: XRInterface; view: uint32; aspect: float64; nea
   methodbind.ptrcall(self, [getPtr view, getPtr aspect, getPtr near, getPtr far], addr ret)
   (addr ret).decode_result(Projection)
 
-proc getSupportedEnvironmentBlendModes*(self: XRInterface): Array =
+proc getSupportedEnvironmentBlendModes*(self: XRInterface): Array[Variant] =
   expandMethodBind(className XRInterface, "get_supported_environment_blend_modes", 2915620761)
-  var ret: encoded Array
+  var ret: encoded Array[Variant]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(Array)
+  (addr ret).decode_result(Array[Variant])
 
 proc setEnvironmentBlendMode*(self: XRInterface; mode: XRInterface_EnvironmentBlendMode): bool =
   expandMethodBind(className XRInterface, "set_environment_blend_mode", 551152418)

--- a/src/gdext/classes/gdxrserver.nim
+++ b/src/gdext/classes/gdxrserver.nim
@@ -76,11 +76,11 @@ proc getInterface*(self: XRServer; idx: int32): gdref XRInterface =
   methodbind.ptrcall(self, [getPtr idx], addr ret)
   (addr ret).decode_result(gdref XRInterface)
 
-proc getInterfaces*(self: XRServer): TypedArray[Dictionary] =
+proc getInterfaces*(self: XRServer): Array[Dictionary] =
   expandMethodBind(className XRServer, "get_interfaces", 3995934104)
-  var ret: encoded TypedArray[Dictionary]
+  var ret: encoded Array[Dictionary]
   methodbind.ptrcall(self, [], addr ret)
-  (addr ret).decode_result(TypedArray[Dictionary])
+  (addr ret).decode_result(Array[Dictionary])
 
 proc findInterface*(self: XRServer; name: String): gdref XRInterface =
   expandMethodBind(className XRServer, "find_interface", 1395192955)

--- a/src/gdext/dicttools.nim
+++ b/src/gdext/dicttools.nim
@@ -4,7 +4,6 @@ import gdext/private/typeshift
 import gdext/private/macros
 import gdext/private/nilchecks
 import gdext/builtinindex
-import gdext/varianttools
 
 import std/[hashes, tables]
 
@@ -34,23 +33,28 @@ proc newDictionary*[A, B](pairs: openArray[(A, B)]): Dictionary =
     result[variant key] = variant value
 
 iterator keys*(self: Dictionary): Variant =
-  for key in self.variant.keys:
-    yield key
+  var iter: Variant
+  var valid: bool
+  var variant = variant self
+  if interfaceVariantIterInit(addr variant, addr iter, addr valid) and valid:
+    while true:
+      yield iter
+      if not(interfaceVariantIterNext(addr variant, addr iter, addr valid) and valid): break
 
 iterator values*(self: Dictionary): Variant =
-  for key in self.variant.keys:
+  for key in self.keys:
     yield self[key]
 
 iterator pairs*(self: Dictionary): tuple[key, item: Variant] =
-  for key in self.variant.keys:
+  for key in self.keys:
     yield (key, self[key])
 
 iterator mvalues*(self: var Dictionary): var Variant =
-  for key in self.variant.keys:
+  for key in self.keys:
     yield self[key]
 
 iterator mpairs*(self: var Dictionary): tuple[key: Variant; item: var Variant] =
-  for key in self.variant.keys:
+  for key in self.keys:
     yield (key, self[key])
 
 proc contains*[T: SomeProperty](dict: Dictionary; value: T): bool = dict.has(variant value)

--- a/src/gdext/dollars.nim
+++ b/src/gdext/dollars.nim
@@ -114,8 +114,6 @@ proc `$`*(v: Array): string =
   var variant: Variant
   variantFromType[VariantType_Array](addr variant, addr v)
   $variant
-proc `$`*(v: TypedArray): string =
-  $(v.Array)
 
 proc `$`*[T](v: PackedArray[T]): string =
   var variant: Variant

--- a/src/gdext/gen/gdaabbconstr.nim
+++ b/src/gdext/gen/gdaabbconstr.nim
@@ -1,6 +1,6 @@
 var AABB_constr: array[3, PtrConstructor]
 proc load_AABB_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {2}:
+  for i in 0..2:
     AABB_constr[i] = interface_Variant_getPtrConstructor(VariantType_AABB, int32 i)
 
 # proc aABB*(): AABB =

--- a/src/gdext/gen/gdarray.nim
+++ b/src/gdext/gen/gdarray.nim
@@ -10,22 +10,22 @@ var `<=(Array Array)`: PtrOperatorEvaluator
 # `>=(Array Array)`
 var `+(Array Array)`: PtrOperatorEvaluator
 # `in(Array Array)`
-func `not`*(left: Array): bool = {.noSideEffect.}:
+func `not`*(left: Array[Variant]): bool = {.noSideEffect.}:
   nilCheck left
   `not(Array)`(getPtr left, nil, addr result)
-func `==`*(left: Array; right: Array): bool = {.noSideEffect.}:
+func `==`*(left: Array[Variant]; right: Array[Variant]): bool = {.noSideEffect.}:
   nilCheck left
   nilCheck right
   `==(Array Array)`(getPtr left, getPtr right, addr result)
-func `<`*(left: Array; right: Array): bool = {.noSideEffect.}:
+func `<`*(left: Array[Variant]; right: Array[Variant]): bool = {.noSideEffect.}:
   nilCheck left
   nilCheck right
   `<(Array Array)`(getPtr left, getPtr right, addr result)
-func `<=`*(left: Array; right: Array): bool = {.noSideEffect.}:
+func `<=`*(left: Array[Variant]; right: Array[Variant]): bool = {.noSideEffect.}:
   nilCheck left
   nilCheck right
   `<=(Array Array)`(getPtr left, getPtr right, addr result)
-func `+`*(left: Array; right: Array): Array = {.noSideEffect.}:
+func `+`*(left: Array[Variant]; right: Array[Variant]): Array[Variant] = {.noSideEffect.}:
   nilCheck left
   nilCheck right
   `+(Array Array)`(getPtr left, getPtr right, addr result)
@@ -88,160 +88,160 @@ var `getTypedScript(Array)`: PtrBuiltinMethod
 var `makeReadOnly(Array)`: PtrBuiltinMethod
 var `isReadOnly(Array)`: PtrBuiltinMethod
 
-proc size*(self: Array): Int =
+proc size*(self: Array[Variant]): Int =
   nilCheck self
   `size(Array)`.call(addr self, [], addr result)
-proc isEmpty*(self: Array): bool =
+proc isEmpty*(self: Array[Variant]): bool =
   nilCheck self
   `isEmpty(Array)`.call(addr self, [], addr result)
-proc clear*(self: var Array): void =
+proc clear*(self: var Array[Variant]): void =
   nilCheck self
   `clear(Array)`.call(addr self, [])
-proc hash*(self: Array): Hash =
+proc hash*(self: Array[Variant]): Hash =
   nilCheck self
   `hash(Array)`.call(addr self, [], addr result)
-proc assign*(self: var Array; array: Array): void =
+proc assign*(self: var Array[Variant]; array: Array[Variant]): void =
   nilCheck self
   nilCheck array
   `assign(Array Array)`.call(addr self, [getPtr array])
-proc get*(self: Array; index: Int): Variant =
+proc get*(self: Array[Variant]; index: Int): Variant =
   nilCheck self
   `get(Array Int)`.call(addr self, [getPtr index], addr result)
-proc set*(self: var Array; index: Int; value: Variant): void =
+proc set*(self: var Array[Variant]; index: Int; value: Variant): void =
   nilCheck self
   `set(Array Int Variant)`.call(addr self, [getPtr index, getPtr value])
-proc pushBack*(self: var Array; value: Variant): void =
+proc pushBack*(self: var Array[Variant]; value: Variant): void =
   nilCheck self
   `pushBack(Array Variant)`.call(addr self, [getPtr value])
-proc pushFront*(self: var Array; value: Variant): void =
+proc pushFront*(self: var Array[Variant]; value: Variant): void =
   nilCheck self
   `pushFront(Array Variant)`.call(addr self, [getPtr value])
-proc append*(self: var Array; value: Variant): void =
+proc append*(self: var Array[Variant]; value: Variant): void =
   nilCheck self
   `append(Array Variant)`.call(addr self, [getPtr value])
-proc appendArray*(self: var Array; array: Array): void =
+proc appendArray*(self: var Array[Variant]; array: Array[Variant]): void =
   nilCheck self
   nilCheck array
   `appendArray(Array Array)`.call(addr self, [getPtr array])
-proc resize*(self: var Array; size: Int): Int =
+proc resize*(self: var Array[Variant]; size: Int): Int =
   nilCheck self
   `resize(Array Int)`.call(addr self, [getPtr size], addr result)
-proc insert*(self: var Array; position: Int; value: Variant): Int =
+proc insert*(self: var Array[Variant]; position: Int; value: Variant): Int =
   nilCheck self
   `insert(Array Int Variant)`.call(addr self, [getPtr position, getPtr value], addr result)
-proc removeAt*(self: var Array; position: Int): void =
+proc removeAt*(self: var Array[Variant]; position: Int): void =
   nilCheck self
   `removeAt(Array Int)`.call(addr self, [getPtr position])
-proc fill*(self: var Array; value: Variant): void =
+proc fill*(self: var Array[Variant]; value: Variant): void =
   nilCheck self
   `fill(Array Variant)`.call(addr self, [getPtr value])
-proc erase*(self: var Array; value: Variant): void =
+proc erase*(self: var Array[Variant]; value: Variant): void =
   nilCheck self
   `erase(Array Variant)`.call(addr self, [getPtr value])
-proc front*(self: Array): Variant =
+proc front*(self: Array[Variant]): Variant =
   nilCheck self
   `front(Array)`.call(addr self, [], addr result)
-proc back*(self: Array): Variant =
+proc back*(self: Array[Variant]): Variant =
   nilCheck self
   `back(Array)`.call(addr self, [], addr result)
-proc pickRandom*(self: Array): Variant =
+proc pickRandom*(self: Array[Variant]): Variant =
   nilCheck self
   `pickRandom(Array)`.call(addr self, [], addr result)
-proc find*(self: Array; what: Variant; `from`: Int = 0): Int =
+proc find*(self: Array[Variant]; what: Variant; `from`: Int = 0): Int =
   nilCheck self
   `find(Array Variant Int)`.call(addr self, [getPtr what, getPtr `from`], addr result)
-proc findCustom*(self: Array; `method`: Callable; `from`: Int = 0): Int =
+proc findCustom*(self: Array[Variant]; `method`: Callable; `from`: Int = 0): Int =
   nilCheck self
   `findCustom(Array Callable Int)`.call(addr self, [getPtr `method`, getPtr `from`], addr result)
-proc rfind*(self: Array; what: Variant; `from`: Int = -1): Int =
+proc rfind*(self: Array[Variant]; what: Variant; `from`: Int = -1): Int =
   nilCheck self
   `rfind(Array Variant Int)`.call(addr self, [getPtr what, getPtr `from`], addr result)
-proc rfindCustom*(self: Array; `method`: Callable; `from`: Int = -1): Int =
+proc rfindCustom*(self: Array[Variant]; `method`: Callable; `from`: Int = -1): Int =
   nilCheck self
   `rfindCustom(Array Callable Int)`.call(addr self, [getPtr `method`, getPtr `from`], addr result)
-proc count*(self: Array; value: Variant): Int =
+proc count*(self: Array[Variant]; value: Variant): Int =
   nilCheck self
   `count(Array Variant)`.call(addr self, [getPtr value], addr result)
-proc has*(self: Array; value: Variant): bool =
+proc has*(self: Array[Variant]; value: Variant): bool =
   nilCheck self
   `has(Array Variant)`.call(addr self, [getPtr value], addr result)
-proc popBack*(self: var Array): Variant =
+proc popBack*(self: var Array[Variant]): Variant =
   nilCheck self
   `popBack(Array)`.call(addr self, [], addr result)
-proc popFront*(self: var Array): Variant =
+proc popFront*(self: var Array[Variant]): Variant =
   nilCheck self
   `popFront(Array)`.call(addr self, [], addr result)
-proc popAt*(self: var Array; position: Int): Variant =
+proc popAt*(self: var Array[Variant]; position: Int): Variant =
   nilCheck self
   `popAt(Array Int)`.call(addr self, [getPtr position], addr result)
-proc sort*(self: var Array): void =
+proc sort*(self: var Array[Variant]): void =
   nilCheck self
   `sort(Array)`.call(addr self, [])
-proc sortCustom*(self: var Array; `func`: Callable): void =
+proc sortCustom*(self: var Array[Variant]; `func`: Callable): void =
   nilCheck self
   `sortCustom(Array Callable)`.call(addr self, [getPtr `func`])
-proc shuffle*(self: var Array): void =
+proc shuffle*(self: var Array[Variant]): void =
   nilCheck self
   `shuffle(Array)`.call(addr self, [])
-proc bsearch*(self: Array; value: Variant; before: bool = true): Int =
+proc bsearch*(self: Array[Variant]; value: Variant; before: bool = true): Int =
   nilCheck self
   `bsearch(Array Variant bool)`.call(addr self, [getPtr value, getPtr before], addr result)
-proc bsearchCustom*(self: Array; value: Variant; `func`: Callable; before: bool = true): Int =
+proc bsearchCustom*(self: Array[Variant]; value: Variant; `func`: Callable; before: bool = true): Int =
   nilCheck self
   `bsearchCustom(Array Variant Callable bool)`.call(addr self, [getPtr value, getPtr `func`, getPtr before], addr result)
-proc reverse*(self: var Array): void =
+proc reverse*(self: var Array[Variant]): void =
   nilCheck self
   `reverse(Array)`.call(addr self, [])
-proc duplicate*(self: Array; deep: bool = false): Array =
+proc duplicate*(self: Array[Variant]; deep: bool = false): Array[Variant] =
   nilCheck self
   `duplicate(Array bool)`.call(addr self, [getPtr deep], addr result)
-proc duplicateDeep*(self: Array; deepSubresourcesMode: Int = 1): Array =
+proc duplicateDeep*(self: Array[Variant]; deepSubresourcesMode: Int = 1): Array[Variant] =
   nilCheck self
   `duplicateDeep(Array Int)`.call(addr self, [getPtr deepSubresourcesMode], addr result)
-proc slice*(self: Array; begin: Int; `end`: Int = 2147483647; step: Int = 1; deep: bool = false): Array =
+proc slice*(self: Array[Variant]; begin: Int; `end`: Int = 2147483647; step: Int = 1; deep: bool = false): Array[Variant] =
   nilCheck self
   `slice(Array Int Int Int bool)`.call(addr self, [getPtr begin, getPtr `end`, getPtr step, getPtr deep], addr result)
-proc filter*(self: Array; `method`: Callable): Array =
+proc filter*(self: Array[Variant]; `method`: Callable): Array[Variant] =
   nilCheck self
   `filter(Array Callable)`.call(addr self, [getPtr `method`], addr result)
-proc map*(self: Array; `method`: Callable): Array =
+proc map*(self: Array[Variant]; `method`: Callable): Array[Variant] =
   nilCheck self
   `map(Array Callable)`.call(addr self, [getPtr `method`], addr result)
-proc reduce*(self: Array; `method`: Callable; accum: Variant = default(Variant)): Variant =
+proc reduce*(self: Array[Variant]; `method`: Callable; accum: Variant = default(Variant)): Variant =
   nilCheck self
   `reduce(Array Callable Variant)`.call(addr self, [getPtr `method`, getPtr accum], addr result)
-proc any*(self: Array; `method`: Callable): bool =
+proc any*(self: Array[Variant]; `method`: Callable): bool =
   nilCheck self
   `any(Array Callable)`.call(addr self, [getPtr `method`], addr result)
-proc all*(self: Array; `method`: Callable): bool =
+proc all*(self: Array[Variant]; `method`: Callable): bool =
   nilCheck self
   `all(Array Callable)`.call(addr self, [getPtr `method`], addr result)
-proc max*(self: Array): Variant =
+proc max*(self: Array[Variant]): Variant =
   nilCheck self
   `max(Array)`.call(addr self, [], addr result)
-proc min*(self: Array): Variant =
+proc min*(self: Array[Variant]): Variant =
   nilCheck self
   `min(Array)`.call(addr self, [], addr result)
-proc isTyped*(self: Array): bool =
+proc isTyped*(self: Array[Variant]): bool =
   nilCheck self
   `isTyped(Array)`.call(addr self, [], addr result)
-proc isSameTyped*(self: Array; array: Array): bool =
+proc isSameTyped*(self: Array[Variant]; array: Array[Variant]): bool =
   nilCheck self
   nilCheck array
   `isSameTyped(Array Array)`.call(addr self, [getPtr array], addr result)
-proc getTypedBuiltin*(self: Array): Int =
+proc getTypedBuiltin*(self: Array[Variant]): Int =
   nilCheck self
   `getTypedBuiltin(Array)`.call(addr self, [], addr result)
-proc getTypedClassName*(self: Array): StringName =
+proc getTypedClassName*(self: Array[Variant]): StringName =
   nilCheck self
   `getTypedClassName(Array)`.call(addr self, [], addr result)
-proc getTypedScript*(self: Array): Variant =
+proc getTypedScript*(self: Array[Variant]): Variant =
   nilCheck self
   `getTypedScript(Array)`.call(addr self, [], addr result)
-proc makeReadOnly*(self: var Array): void =
+proc makeReadOnly*(self: var Array[Variant]): void =
   nilCheck self
   `makeReadOnly(Array)`.call(addr self, [])
-proc isReadOnly*(self: Array): bool =
+proc isReadOnly*(self: Array[Variant]): bool =
   nilCheck self
   `isReadOnly(Array)`.call(addr self, [], addr result)
 

--- a/src/gdext/gen/gdarrayconstr.nim
+++ b/src/gdext/gen/gdarrayconstr.nim
@@ -1,43 +1,40 @@
 var Array_constr: array[13, PtrConstructor]
 proc load_Array_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}:
+  for i in 0..12:
     Array_constr[i] = interface_Variant_getPtrConstructor(VariantType_Array, int32 i)
 
-proc newArray*(): Array =
-  Array_constr[0](addr result, nil)
-proc newArray*(`from`: Array): Array =
-  let argArr = [getPtr `from`]
-  Array_constr[1](addr result, addr argArr[0])
-proc newArray*(base: Array; `type`: Int; className: StringName; script: Variant): Array =
+# proc newArray*(): Array[Variant] =
+# proc newArray*(`from`: Array[Variant]): Array[Variant] =
+proc newArray*(base: Array[Variant]; `type`: Int; className: StringName; script: Variant): Array[Variant] =
   let argArr = [getPtr base, getPtr `type`, getPtr className, getPtr script]
   Array_constr[2](addr result, addr argArr[0])
-proc newArray*(`from`: PackedByteArray): Array =
+proc newArray*(`from`: PackedByteArray): Array[Variant] =
   let argArr = [getPtr `from`]
   Array_constr[3](addr result, addr argArr[0])
-proc newArray*(`from`: PackedInt32Array): Array =
+proc newArray*(`from`: PackedInt32Array): Array[Variant] =
   let argArr = [getPtr `from`]
   Array_constr[4](addr result, addr argArr[0])
-proc newArray*(`from`: PackedInt64Array): Array =
+proc newArray*(`from`: PackedInt64Array): Array[Variant] =
   let argArr = [getPtr `from`]
   Array_constr[5](addr result, addr argArr[0])
-proc newArray*(`from`: PackedFloat32Array): Array =
+proc newArray*(`from`: PackedFloat32Array): Array[Variant] =
   let argArr = [getPtr `from`]
   Array_constr[6](addr result, addr argArr[0])
-proc newArray*(`from`: PackedFloat64Array): Array =
+proc newArray*(`from`: PackedFloat64Array): Array[Variant] =
   let argArr = [getPtr `from`]
   Array_constr[7](addr result, addr argArr[0])
-proc newArray*(`from`: PackedStringArray): Array =
+proc newArray*(`from`: PackedStringArray): Array[Variant] =
   let argArr = [getPtr `from`]
   Array_constr[8](addr result, addr argArr[0])
-proc newArray*(`from`: PackedVector2Array): Array =
+proc newArray*(`from`: PackedVector2Array): Array[Variant] =
   let argArr = [getPtr `from`]
   Array_constr[9](addr result, addr argArr[0])
-proc newArray*(`from`: PackedVector3Array): Array =
+proc newArray*(`from`: PackedVector3Array): Array[Variant] =
   let argArr = [getPtr `from`]
   Array_constr[10](addr result, addr argArr[0])
-proc newArray*(`from`: PackedColorArray): Array =
+proc newArray*(`from`: PackedColorArray): Array[Variant] =
   let argArr = [getPtr `from`]
   Array_constr[11](addr result, addr argArr[0])
-proc newArray*(`from`: PackedVector4Array): Array =
+proc newArray*(`from`: PackedVector4Array): Array[Variant] =
   let argArr = [getPtr `from`]
   Array_constr[12](addr result, addr argArr[0])

--- a/src/gdext/gen/gdbasisconstr.nim
+++ b/src/gdext/gen/gdbasisconstr.nim
@@ -1,6 +1,6 @@
 var Basis_constr: array[5, PtrConstructor]
 proc load_Basis_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {2, 3}:
+  for i in 0..4:
     Basis_constr[i] = interface_Variant_getPtrConstructor(VariantType_Basis, int32 i)
 
 # proc basis*(): Basis =

--- a/src/gdext/gen/gdcallable.nim
+++ b/src/gdext/gen/gdcallable.nim
@@ -35,7 +35,7 @@ var `bind(Callable Variant)`: PtrBuiltinMethod
 
 proc create*(_: typedesc[Callable]; variant: Variant; `method`: StringName): Callable =
   `create(Callable Variant StringName)`.call([getPtr variant, getPtr `method`], addr result)
-proc callv*(self: Callable; arguments: Array): Variant =
+proc callv*(self: Callable; arguments: Array[Variant]): Variant =
   nilCheck arguments
   `callv(Callable Array)`.call(addr self, [getPtr arguments], addr result)
 proc isNull*(self: Callable): bool =
@@ -56,13 +56,13 @@ proc getArgumentCount*(self: Callable): Int =
   `getArgumentCount(Callable)`.call(addr self, [], addr result)
 proc getBoundArgumentsCount*(self: Callable): Int =
   `getBoundArgumentsCount(Callable)`.call(addr self, [], addr result)
-proc getBoundArguments*(self: Callable): Array =
+proc getBoundArguments*(self: Callable): Array[Variant] =
   `getBoundArguments(Callable)`.call(addr self, [], addr result)
 proc getUnboundArgumentsCount*(self: Callable): Int =
   `getUnboundArgumentsCount(Callable)`.call(addr self, [], addr result)
 proc hash*(self: Callable): Hash =
   `hash(Callable)`.call(addr self, [], addr result)
-proc bindv*(self: var Callable; arguments: Array): Callable =
+proc bindv*(self: var Callable; arguments: Array[Variant]): Callable =
   nilCheck arguments
   `bindv(Callable Array)`.call(addr self, [getPtr arguments], addr result)
 proc unbind*(self: Callable; argcount: Int): Callable =

--- a/src/gdext/gen/gdcallableconstr.nim
+++ b/src/gdext/gen/gdcallableconstr.nim
@@ -1,6 +1,6 @@
 var Callable_constr: array[3, PtrConstructor]
 proc load_Callable_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {1, 2}:
+  for i in 0..2:
     Callable_constr[i] = interface_Variant_getPtrConstructor(VariantType_Callable, int32 i)
 
 # proc callable*(): Callable =

--- a/src/gdext/gen/gdcolorconstr.nim
+++ b/src/gdext/gen/gdcolorconstr.nim
@@ -1,6 +1,6 @@
 var Color_constr: array[7, PtrConstructor]
 proc load_Color_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {5, 6}:
+  for i in 0..6:
     Color_constr[i] = interface_Variant_getPtrConstructor(VariantType_Color, int32 i)
 
 # proc color*(): Color =

--- a/src/gdext/gen/gddictionary.nim
+++ b/src/gdext/gen/gddictionary.nim
@@ -78,7 +78,7 @@ proc merged*(self: Dictionary; dictionary: Dictionary; overwrite: bool = false):
 proc has*(self: Dictionary; key: Variant): bool =
   nilCheck self
   `has(Dictionary Variant)`.call(addr self, [getPtr key], addr result)
-proc hasAll*(self: Dictionary; keys: Array): bool =
+proc hasAll*(self: Dictionary; keys: Array[Variant]): bool =
   nilCheck self
   nilCheck keys
   `hasAll(Dictionary Array)`.call(addr self, [getPtr keys], addr result)
@@ -91,10 +91,10 @@ proc erase*(self: var Dictionary; key: Variant): bool =
 proc hash*(self: Dictionary): Hash =
   nilCheck self
   `hash(Dictionary)`.call(addr self, [], addr result)
-proc keys*(self: Dictionary): Array =
+proc keys*(self: Dictionary): Array[Variant] =
   nilCheck self
   `keys(Dictionary)`.call(addr self, [], addr result)
-proc values*(self: Dictionary): Array =
+proc values*(self: Dictionary): Array[Variant] =
   nilCheck self
   `values(Dictionary)`.call(addr self, [], addr result)
 proc duplicate*(self: Dictionary; deep: bool = false): Dictionary =

--- a/src/gdext/gen/gddictionaryconstr.nim
+++ b/src/gdext/gen/gddictionaryconstr.nim
@@ -1,6 +1,6 @@
 var Dictionary_constr: array[3, PtrConstructor]
 proc load_Dictionary_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {0, 1, 2}:
+  for i in 0..2:
     Dictionary_constr[i] = interface_Variant_getPtrConstructor(VariantType_Dictionary, int32 i)
 
 proc newDictionary*(): Dictionary =

--- a/src/gdext/gen/gdnodepathconstr.nim
+++ b/src/gdext/gen/gdnodepathconstr.nim
@@ -1,6 +1,6 @@
 var NodePath_constr: array[3, PtrConstructor]
 proc load_NodePath_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {1, 2}:
+  for i in 0..2:
     NodePath_constr[i] = interface_Variant_getPtrConstructor(VariantType_NodePath, int32 i)
 
 # proc newNodePath*(): NodePath =

--- a/src/gdext/gen/gdpackedbytearrayconstr.nim
+++ b/src/gdext/gen/gdpackedbytearrayconstr.nim
@@ -1,12 +1,12 @@
 var PackedByteArray_constr: array[3, PtrConstructor]
 proc load_PackedByteArray_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {1, 2}:
+  for i in 0..2:
     PackedByteArray_constr[i] = interface_Variant_getPtrConstructor(VariantType_PackedByteArray, int32 i)
 
 # proc newPackedByteArray*(): PackedByteArray =
 proc newPackedByteArray*(`from`: PackedByteArray): PackedByteArray =
   let argArr = [getPtr `from`]
   PackedByteArray_constr[1](addr result, addr argArr[0])
-proc newPackedByteArray*(`from`: Array): PackedByteArray =
+proc newPackedByteArray*(`from`: Array[Variant]): PackedByteArray =
   let argArr = [getPtr `from`]
   PackedByteArray_constr[2](addr result, addr argArr[0])

--- a/src/gdext/gen/gdpackedcolorarrayconstr.nim
+++ b/src/gdext/gen/gdpackedcolorarrayconstr.nim
@@ -1,12 +1,12 @@
 var PackedColorArray_constr: array[3, PtrConstructor]
 proc load_PackedColorArray_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {1, 2}:
+  for i in 0..2:
     PackedColorArray_constr[i] = interface_Variant_getPtrConstructor(VariantType_PackedColorArray, int32 i)
 
 # proc newPackedColorArray*(): PackedColorArray =
 proc newPackedColorArray*(`from`: PackedColorArray): PackedColorArray =
   let argArr = [getPtr `from`]
   PackedColorArray_constr[1](addr result, addr argArr[0])
-proc newPackedColorArray*(`from`: Array): PackedColorArray =
+proc newPackedColorArray*(`from`: Array[Variant]): PackedColorArray =
   let argArr = [getPtr `from`]
   PackedColorArray_constr[2](addr result, addr argArr[0])

--- a/src/gdext/gen/gdpackedfloat32arrayconstr.nim
+++ b/src/gdext/gen/gdpackedfloat32arrayconstr.nim
@@ -1,12 +1,12 @@
 var PackedFloat32Array_constr: array[3, PtrConstructor]
 proc load_PackedFloat32Array_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {1, 2}:
+  for i in 0..2:
     PackedFloat32Array_constr[i] = interface_Variant_getPtrConstructor(VariantType_PackedFloat32Array, int32 i)
 
 # proc newPackedFloat32Array*(): PackedFloat32Array =
 proc newPackedFloat32Array*(`from`: PackedFloat32Array): PackedFloat32Array =
   let argArr = [getPtr `from`]
   PackedFloat32Array_constr[1](addr result, addr argArr[0])
-proc newPackedFloat32Array*(`from`: Array): PackedFloat32Array =
+proc newPackedFloat32Array*(`from`: Array[Variant]): PackedFloat32Array =
   let argArr = [getPtr `from`]
   PackedFloat32Array_constr[2](addr result, addr argArr[0])

--- a/src/gdext/gen/gdpackedfloat64arrayconstr.nim
+++ b/src/gdext/gen/gdpackedfloat64arrayconstr.nim
@@ -1,12 +1,12 @@
 var PackedFloat64Array_constr: array[3, PtrConstructor]
 proc load_PackedFloat64Array_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {1, 2}:
+  for i in 0..2:
     PackedFloat64Array_constr[i] = interface_Variant_getPtrConstructor(VariantType_PackedFloat64Array, int32 i)
 
 # proc newPackedFloat64Array*(): PackedFloat64Array =
 proc newPackedFloat64Array*(`from`: PackedFloat64Array): PackedFloat64Array =
   let argArr = [getPtr `from`]
   PackedFloat64Array_constr[1](addr result, addr argArr[0])
-proc newPackedFloat64Array*(`from`: Array): PackedFloat64Array =
+proc newPackedFloat64Array*(`from`: Array[Variant]): PackedFloat64Array =
   let argArr = [getPtr `from`]
   PackedFloat64Array_constr[2](addr result, addr argArr[0])

--- a/src/gdext/gen/gdpackedint32arrayconstr.nim
+++ b/src/gdext/gen/gdpackedint32arrayconstr.nim
@@ -1,12 +1,12 @@
 var PackedInt32Array_constr: array[3, PtrConstructor]
 proc load_PackedInt32Array_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {1, 2}:
+  for i in 0..2:
     PackedInt32Array_constr[i] = interface_Variant_getPtrConstructor(VariantType_PackedInt32Array, int32 i)
 
 # proc newPackedInt32Array*(): PackedInt32Array =
 proc newPackedInt32Array*(`from`: PackedInt32Array): PackedInt32Array =
   let argArr = [getPtr `from`]
   PackedInt32Array_constr[1](addr result, addr argArr[0])
-proc newPackedInt32Array*(`from`: Array): PackedInt32Array =
+proc newPackedInt32Array*(`from`: Array[Variant]): PackedInt32Array =
   let argArr = [getPtr `from`]
   PackedInt32Array_constr[2](addr result, addr argArr[0])

--- a/src/gdext/gen/gdpackedint64arrayconstr.nim
+++ b/src/gdext/gen/gdpackedint64arrayconstr.nim
@@ -1,12 +1,12 @@
 var PackedInt64Array_constr: array[3, PtrConstructor]
 proc load_PackedInt64Array_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {1, 2}:
+  for i in 0..2:
     PackedInt64Array_constr[i] = interface_Variant_getPtrConstructor(VariantType_PackedInt64Array, int32 i)
 
 # proc newPackedInt64Array*(): PackedInt64Array =
 proc newPackedInt64Array*(`from`: PackedInt64Array): PackedInt64Array =
   let argArr = [getPtr `from`]
   PackedInt64Array_constr[1](addr result, addr argArr[0])
-proc newPackedInt64Array*(`from`: Array): PackedInt64Array =
+proc newPackedInt64Array*(`from`: Array[Variant]): PackedInt64Array =
   let argArr = [getPtr `from`]
   PackedInt64Array_constr[2](addr result, addr argArr[0])

--- a/src/gdext/gen/gdpackedstringarrayconstr.nim
+++ b/src/gdext/gen/gdpackedstringarrayconstr.nim
@@ -1,12 +1,12 @@
 var PackedStringArray_constr: array[3, PtrConstructor]
 proc load_PackedStringArray_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {1, 2}:
+  for i in 0..2:
     PackedStringArray_constr[i] = interface_Variant_getPtrConstructor(VariantType_PackedStringArray, int32 i)
 
 # proc newPackedStringArray*(): PackedStringArray =
 proc newPackedStringArray*(`from`: PackedStringArray): PackedStringArray =
   let argArr = [getPtr `from`]
   PackedStringArray_constr[1](addr result, addr argArr[0])
-proc newPackedStringArray*(`from`: Array): PackedStringArray =
+proc newPackedStringArray*(`from`: Array[Variant]): PackedStringArray =
   let argArr = [getPtr `from`]
   PackedStringArray_constr[2](addr result, addr argArr[0])

--- a/src/gdext/gen/gdpackedvector2arrayconstr.nim
+++ b/src/gdext/gen/gdpackedvector2arrayconstr.nim
@@ -1,12 +1,12 @@
 var PackedVector2Array_constr: array[3, PtrConstructor]
 proc load_PackedVector2Array_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {1, 2}:
+  for i in 0..2:
     PackedVector2Array_constr[i] = interface_Variant_getPtrConstructor(VariantType_PackedVector2Array, int32 i)
 
 # proc newPackedVector2Array*(): PackedVector2Array =
 proc newPackedVector2Array*(`from`: PackedVector2Array): PackedVector2Array =
   let argArr = [getPtr `from`]
   PackedVector2Array_constr[1](addr result, addr argArr[0])
-proc newPackedVector2Array*(`from`: Array): PackedVector2Array =
+proc newPackedVector2Array*(`from`: Array[Variant]): PackedVector2Array =
   let argArr = [getPtr `from`]
   PackedVector2Array_constr[2](addr result, addr argArr[0])

--- a/src/gdext/gen/gdpackedvector3arrayconstr.nim
+++ b/src/gdext/gen/gdpackedvector3arrayconstr.nim
@@ -1,12 +1,12 @@
 var PackedVector3Array_constr: array[3, PtrConstructor]
 proc load_PackedVector3Array_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {1, 2}:
+  for i in 0..2:
     PackedVector3Array_constr[i] = interface_Variant_getPtrConstructor(VariantType_PackedVector3Array, int32 i)
 
 # proc newPackedVector3Array*(): PackedVector3Array =
 proc newPackedVector3Array*(`from`: PackedVector3Array): PackedVector3Array =
   let argArr = [getPtr `from`]
   PackedVector3Array_constr[1](addr result, addr argArr[0])
-proc newPackedVector3Array*(`from`: Array): PackedVector3Array =
+proc newPackedVector3Array*(`from`: Array[Variant]): PackedVector3Array =
   let argArr = [getPtr `from`]
   PackedVector3Array_constr[2](addr result, addr argArr[0])

--- a/src/gdext/gen/gdpackedvector4arrayconstr.nim
+++ b/src/gdext/gen/gdpackedvector4arrayconstr.nim
@@ -1,12 +1,12 @@
 var PackedVector4Array_constr: array[3, PtrConstructor]
 proc load_PackedVector4Array_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {1, 2}:
+  for i in 0..2:
     PackedVector4Array_constr[i] = interface_Variant_getPtrConstructor(VariantType_PackedVector4Array, int32 i)
 
 # proc newPackedVector4Array*(): PackedVector4Array =
 proc newPackedVector4Array*(`from`: PackedVector4Array): PackedVector4Array =
   let argArr = [getPtr `from`]
   PackedVector4Array_constr[1](addr result, addr argArr[0])
-proc newPackedVector4Array*(`from`: Array): PackedVector4Array =
+proc newPackedVector4Array*(`from`: Array[Variant]): PackedVector4Array =
   let argArr = [getPtr `from`]
   PackedVector4Array_constr[2](addr result, addr argArr[0])

--- a/src/gdext/gen/gdplaneconstr.nim
+++ b/src/gdext/gen/gdplaneconstr.nim
@@ -1,6 +1,6 @@
 var Plane_constr: array[7, PtrConstructor]
 proc load_Plane_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {2, 4, 5}:
+  for i in 0..6:
     Plane_constr[i] = interface_Variant_getPtrConstructor(VariantType_Plane, int32 i)
 
 # proc plane*(): Plane =

--- a/src/gdext/gen/gdprojectionconstr.nim
+++ b/src/gdext/gen/gdprojectionconstr.nim
@@ -1,6 +1,6 @@
 var Projection_constr: array[4, PtrConstructor]
 proc load_Projection_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {2}:
+  for i in 0..3:
     Projection_constr[i] = interface_Variant_getPtrConstructor(VariantType_Projection, int32 i)
 
 # proc projection*(): Projection =

--- a/src/gdext/gen/gdquaternionconstr.nim
+++ b/src/gdext/gen/gdquaternionconstr.nim
@@ -1,6 +1,6 @@
 var Quaternion_constr: array[6, PtrConstructor]
 proc load_Quaternion_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {2, 3, 4}:
+  for i in 0..5:
     Quaternion_constr[i] = interface_Variant_getPtrConstructor(VariantType_Quaternion, int32 i)
 
 # proc quaternion*(): Quaternion =

--- a/src/gdext/gen/gdsignal.nim
+++ b/src/gdext/gen/gdsignal.nim
@@ -36,7 +36,7 @@ proc disconnect*(self: var Signal; callable: Callable): void =
   `disconnect(Signal Callable)`.call(addr self, [getPtr callable])
 proc isConnected*(self: Signal; callable: Callable): bool =
   `isConnected(Signal Callable)`.call(addr self, [getPtr callable], addr result)
-proc getConnections*(self: Signal): Array =
+proc getConnections*(self: Signal): Array[Variant] =
   `getConnections(Signal)`.call(addr self, [], addr result)
 proc hasConnections*(self: Signal): bool =
   `hasConnections(Signal)`.call(addr self, [], addr result)

--- a/src/gdext/gen/gdsignalconstr.nim
+++ b/src/gdext/gen/gdsignalconstr.nim
@@ -1,6 +1,6 @@
 var Signal_constr: array[3, PtrConstructor]
 proc load_Signal_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {1, 2}:
+  for i in 0..2:
     Signal_constr[i] = interface_Variant_getPtrConstructor(VariantType_Signal, int32 i)
 
 # proc signal*(): Signal =

--- a/src/gdext/gen/gdstring.nim
+++ b/src/gdext/gen/gdstring.nim
@@ -93,7 +93,7 @@ func `%`*(left: String; right: Signal): String = {.noSideEffect.}: `%(String Sig
 func `%`*(left: String; right: Dictionary): String = {.noSideEffect.}:
   nilCheck right
   `%(String Dictionary)`(getPtr left, getPtr right, addr result)
-func `%`*(left: String; right: Array): String = {.noSideEffect.}:
+func `%`*(left: String; right: Array[Variant]): String = {.noSideEffect.}:
   nilCheck right
   `%(String Array)`(getPtr left, getPtr right, addr result)
 func `%`*(left: String; right: PackedByteArray): String = {.noSideEffect.}: `%(String PackedByteArray)`(getPtr left, getPtr right, addr result)

--- a/src/gdext/gen/gdstringconstr.nim
+++ b/src/gdext/gen/gdstringconstr.nim
@@ -1,6 +1,6 @@
 var String_constr: array[4, PtrConstructor]
 proc load_String_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {1, 2, 3}:
+  for i in 0..3:
     String_constr[i] = interface_Variant_getPtrConstructor(VariantType_String, int32 i)
 
 # proc newGdString*(): String =

--- a/src/gdext/gen/gdstringname.nim
+++ b/src/gdext/gen/gdstringname.nim
@@ -93,7 +93,7 @@ func `%`*(left: StringName; right: Signal): String = {.noSideEffect.}: `%(String
 func `%`*(left: StringName; right: Dictionary): String = {.noSideEffect.}:
   nilCheck right
   `%(StringName Dictionary)`(getPtr left, getPtr right, addr result)
-func `%`*(left: StringName; right: Array): String = {.noSideEffect.}:
+func `%`*(left: StringName; right: Array[Variant]): String = {.noSideEffect.}:
   nilCheck right
   `%(StringName Array)`(getPtr left, getPtr right, addr result)
 func `%`*(left: StringName; right: PackedByteArray): String = {.noSideEffect.}: `%(StringName PackedByteArray)`(getPtr left, getPtr right, addr result)

--- a/src/gdext/gen/gdstringnameconstr.nim
+++ b/src/gdext/gen/gdstringnameconstr.nim
@@ -1,6 +1,6 @@
 var StringName_constr: array[3, PtrConstructor]
 proc load_StringName_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {1, 2}:
+  for i in 0..2:
     StringName_constr[i] = interface_Variant_getPtrConstructor(VariantType_StringName, int32 i)
 
 # proc newStringName*(): StringName =

--- a/src/gdext/gen/gdtransform2dconstr.nim
+++ b/src/gdext/gen/gdtransform2dconstr.nim
@@ -1,6 +1,6 @@
 var Transform2D_constr: array[5, PtrConstructor]
 proc load_Transform2D_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {2, 3}:
+  for i in 0..4:
     Transform2D_constr[i] = interface_Variant_getPtrConstructor(VariantType_Transform2D, int32 i)
 
 # proc transform2D*(): Transform2D =

--- a/src/gdext/gen/gdtransform3dconstr.nim
+++ b/src/gdext/gen/gdtransform3dconstr.nim
@@ -1,6 +1,6 @@
 var Transform3D_constr: array[5, PtrConstructor]
 proc load_Transform3D_constructor {.execon: staticevents.init_engine.on_load_builtinclassConstructor.} =
-  for i in {4}:
+  for i in 0..4:
     Transform3D_constr[i] = interface_Variant_getPtrConstructor(VariantType_Transform3D, int32 i)
 
 # proc transform3D*(): Transform3D =

--- a/src/gdext/private/nilchecks.nim
+++ b/src/gdext/private/nilchecks.nim
@@ -15,16 +15,13 @@ proc newTypedArrayInternal*(typ: VariantType; className: pointer): pointer =
 proc newDictionaryInternal*(): pointer =
   typeNew[VARIANT_TYPE_DICTIONARY](addr result, nil)
 
-proc nilCheck*(self: Array) =
+proc nilCheck*[T](self: Array[T]) =
   privateAccess Array
   if unlikely(cast[pointer](self) == nil):
-    cast[ptr Array](addr self)[].cowdata = newArrayInternal()
-
-proc nilCheck*[T](self: TypedArray[T]) =
-  privateAccess Array
-  when compiles(T.className):
-    if unlikely(cast[pointer](self) == nil):
-      cast[ptr Array](addr self)[].cowdata = newTypedArrayInternal(T.variantType, addr className(T))
+    when T is Variant:
+      cast[ptr Array[T]](addr self)[].cowdata = newArrayInternal()
+    else:
+      cast[ptr Array[T]](addr self)[].cowdata = newTypedArrayInternal(T.variantType, addr className(T))
 
 proc nilCheck*(self: Dictionary) =
   privateAccess Dictionary

--- a/src/gdext/private/typeshift.nim
+++ b/src/gdext/private/typeshift.nim
@@ -16,7 +16,7 @@ template encode*[T: SomeBuiltins](v: T; p: pointer) =
 proc decode*[T: SomeBuiltins](p: pointer; _: typedesc[T]): T =
   cast[ptr T](p)[]
 proc variant*[T: SomeBuiltins](v: T): Variant =
-  when T is Array or T is TypedArray or T is Dictionary:
+  when T is Array or T is Dictionary:
     v.nilCheck()
   variantFromType[variantType T](addr result, addr v)
 proc get*[T: SomeBuiltins](v: Variant; _: typedesc[T]): T =
@@ -81,7 +81,6 @@ convert_alternative_autocast AltFloat, Float
 convert_generics_forcecast enum, Int
 
 convert_generic_params_forcecast set, Int
-convert_generic_params_forcecast TypedArray, Array
 
 # Variant
 # =======

--- a/src/gdext/sugars.nim
+++ b/src/gdext/sugars.nim
@@ -2,6 +2,7 @@ import gdext/builtinindex
 import gdext/stringtools
 import gdext/objecttools
 import gdext/varianttools
+import gdext/arraytools {.all.}
 
 {.push, inline.}
 
@@ -9,7 +10,8 @@ converter convertToString*(str: string): String = newGdString str
 converter convertToStringName*(str: string): StringName = newStringName str
 converter convertToNodePath*(str: string): NodePath = newNodePath newGdString str
 
-converter convertToArray*(arr: TypedArray): Array = Array arr
+converter convertToArray*[T: not Variant](arr: Array[T]): Array[Variant] = arr.wild
+converter convertToArray*[T: not Variant](arr: var Array[T]): var Array[Variant] = arr.wild
 
 converter convertToSingleton*[T: SomeClass](_: typedesc[T]): T = singleton(T)
 

--- a/src/gdext/varianttools.nim
+++ b/src/gdext/varianttools.nim
@@ -2,7 +2,9 @@ import std/[strformat, hashes, sequtils]
 
 import gdext/builtinindex
 import gdext/arraytools
-import gdext/private/[gdinterface, typeshift]
+import gdext/private/[gdinterface, typeshift, propertyinfo]
+
+import gdext/classes/gdClassDB
 
 proc iterInit(self: Variant; r_iter: var Variant; r_valid: var bool): bool =
   interfaceVariantIterInit(addr self, addr r_iter, addr r_valid)
@@ -254,14 +256,20 @@ iterator pairs*(self: Variant): tuple[key, item: Variant] =
   for key in self.keys: yield (key, self[key])
 
 proc `of`*[T: SomeProperty](a: Variant; b: typedesc[T]): bool =
-  when T is TypedArray:
-    var empty {.global.} = newTypedArray[T.T]()
   {.hint[CondTrue]: off.}
   result = if a.getType == b.variantType:
     when b is Object:
       (a as Object) of b
-    elif b is TypedArray:
-      (a as Array).isSameTyped(empty)
+    elif b is Array:
+      when b.T is Variant:
+        true
+      else:
+        let typ = (a as Array[Variant]).getTypedBuiltin.VariantType
+        case typ
+        of VARIANT_TYPE_OBJECT:
+          ClassDB.isParentClass((a as Array[Variant]).getTypedClassName, b.T.className)
+        else:
+          typ == b.T.variantType
     else:
       true
   else:

--- a/tasks.nims
+++ b/tasks.nims
@@ -87,7 +87,7 @@ proc report(version, script: string) =
     quit &"[Nim {version}] \"{script}\" failed."
 
 task compatibilityTest, "Compile with a supported range of Nims and check for compatibility.":
-  const versions = ["2.0.12", "2.0.14", "2.0.16", "2.2.0", "2.2.2", "2.2.4", "2.2.6"]
+  const versions = ["2.2.0", "2.2.2", "2.2.4", "2.2.6"]
   for version in versions:
     report version, &"choosenim {version}"
     report version, "nim r tests/importall"

--- a/testproject/editor/nim/src/classes/gdproptestnode.nim
+++ b/testproject/editor/nim/src/classes/gdproptestnode.nim
@@ -32,7 +32,7 @@ MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT"""
-  StringArray_with_export_multiline*: TypedArray[String]
+  StringArray_with_export_multiline*: Array[String]
   PackedStringArray_with_export_multiline*: PackedStringArray
   NodePath_with_export_node_path*: NodePath
   string_with_export_storage*: string = "with export_storage"
@@ -43,7 +43,7 @@ MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT"""
   color_with_export_no_alpha*: Color = color(1, 1, 1)
 
 method onInit(self: PropTestNode) =
-  self.StringArray_with_export_multiline = newTypedArray[String](1)
+  self.StringArray_with_export_multiline = newArray[String](1)
   self.PackedStringArray_with_export_multiline = newPackedStringArray()
   assert self.PackedStringArray_with_export_multiline.resize(1) == 0
 
@@ -201,8 +201,8 @@ gdexport "string_with_export_multiline",
   Appearance.multiline
 # Currently not works,
 gdexport "StringArray_with_export_multiline",
-  proc (self: PropTestNode): TypedArray[String] = self.StringArray_with_export_multiline,
-  proc (self: PropTestNode; value: TypedArray[String]) = self.StringArray_with_export_multiline = value,
+  proc (self: PropTestNode): Array[String] = self.StringArray_with_export_multiline,
+  proc (self: PropTestNode; value: Array[String]) = self.StringArray_with_export_multiline = value,
   Appearance.multiline
 gdexport "PackedStringArray_with_export_multiline",
   proc (self: PropTestNode): PackedStringArray = self.PackedStringArray_with_export_multiline,

--- a/testproject/editor/nim/src/classes/gdproptestnode_pragmas.nim
+++ b/testproject/editor/nim/src/classes/gdproptestnode_pragmas.nim
@@ -10,8 +10,9 @@ type PropTestPragmasEnum* = enum
 
 type PropTestNodePragmas* {.gdsync.} = ptr object of Node
   icon* {.gdexport.}: gdref Texture2D
-  string_array* {.gdexport.}: TypedArray[String]
-  texture2D_array* {.gdexport.}: TypedArray[Texture2D]
+  string_array* {.gdexport.}: Array[String]
+  texture2D_array* {.gdexport.}: Array[Texture2D]
+  variant_array* {.gdexport.}: Array[Variant]
   PropTestEnum_with_export* {.gdexport.}: PropTestPragmasEnum
   string_with_export* {.gdexport.}: string = "with export"
   string_with_export_placeholder* {.gdexport: Appearance.placeholder("placeholder here...").}: string
@@ -37,7 +38,7 @@ MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT
 MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT"""
 
-  StringArray_with_export_multiline* {.gdexport: Appearance.multiline.}: TypedArray[String]
+  StringArray_with_export_multiline* {.gdexport: Appearance.multiline.}: Array[String]
   PackedStringArray_with_export_multiline* {.gdexport: Appearance.multiline.}: PackedStringArray
   NodePath_with_export_node_path* {.gdexport.}: NodePath
   string_with_export_storage* {.gdexport: Appearance.storage.}: string = "with export_storage"
@@ -60,9 +61,7 @@ MULTILINE-TEXT MULTILINE-TEXT MULTILINE-TEXT"""
 PropTestNodePragmas.bind PropTestPragmasEnum
 
 method onInit(self: PropTestNodePragmas) =
-  self.StringArray_with_export_multiline = newTypedArray[String](1)
-  # self.string_array = newTypedArray[String]()
-  self.texture2D_array = newTypedArray[Texture2D]()
+  self.StringArray_with_export_multiline = newArray[String](1)
 
 method enterTree(self: PropTestNodePragmas) {.gdsync.} =
   self.icon = ResourceLoader.load("res://icon.png") as gdref Texture2D

--- a/testproject/runtime/nim/src/cases/issues.nim
+++ b/testproject/runtime/nim/src/cases/issues.nim
@@ -38,7 +38,7 @@ runtime: suite "Community Reported":
     destroy myTestNode
 
   test "array add should compile and work":
-    var arr = Array()
+    var arr = Array[Variant]()
     let myString = "not a variant"
     arr.add(myString)
     check arr[0].as(string) == myString

--- a/testproject/runtime/nim/src/cases/primitives.nim
+++ b/testproject/runtime/nim/src/cases/primitives.nim
@@ -1,6 +1,6 @@
 import gdext
 import testutils
-import std/[unicode, strutils, tables]
+import std/[unicode, strutils, tables, hashes]
 import gdext/classes/gdnode
 include gdext/gen/variantsizes
 
@@ -184,6 +184,218 @@ runtime: suite "size":
     check sizeof(Variant) == Size.Variant
 
 runtime: suite "Array":
+  test "method definitions":
+    var sa: Array[String] = newArray([String "one", "two", "three"])
+    var va: Array[Variant] = newArray([variant "one", variant "two", variant "three"])
+    var ia: Array[Int] = newArray([Int 1, 2, 3])
+
+    check ia.size is Int
+    check va.size is Int
+
+    check ia.isEmpty is bool
+    check va.isEmpty is bool
+
+    check compiles ia.clear
+    check compiles va.clear
+
+    check ia.hash is Hash
+    check va.hash is Hash
+
+    check compiles ia.assign(ia)
+    check compiles va.assign(va)
+    check compiles va.assign(ia)
+    check not compiles ia.assign(va)
+    check not compiles ia.assign(sa)
+
+    check ia.get(Int 0) is Int
+    check va.get(Int 0) is Variant
+
+    check compiles va.set(Int 0, Int 10)
+    check compiles ia.set(Int 0, Int 10)
+    check compiles va.set(Int 0, variant 10)
+    check not compiles va.set(Int 0, newSeq[int]())
+    check not compiles ia.set(Int 0, variant 10)
+
+    check compiles va.pushBack(Int 10)
+    check compiles ia.pushBack(Int 10)
+    check compiles va.pushBack(variant 10)
+    check not compiles va.pushBack(newSeq[int]())
+    check not compiles ia.pushBack(variant 10)
+
+    check compiles va.pushFront(Int 10)
+    check compiles ia.pushFront(Int 10)
+    check compiles va.pushFront(variant 10)
+    check not compiles va.pushFront(newSeq[int]())
+    check not compiles ia.pushFront(variant 10)
+
+    check compiles va.append(Int 10)
+    check compiles ia.append(Int 10)
+    check compiles va.append(variant 10)
+    check not compiles va.append(newSeq[int]())
+    check not compiles ia.append(variant 10)
+
+    check compiles va.appendArray(va)
+    check compiles va.appendArray(ia)
+    check compiles ia.appendArray(ia)
+    check not compiles ia.appendArray(va)
+    check not compiles ia.appendArray(sa)
+
+    check va.resize(Int 10) is Int
+    check ia.resize(Int 10) is Int
+
+    check va.insert(Int 0, Int 10) is Int
+    check ia.insert(Int 0, Int 10) is Int
+    check va.insert(Int 0, variant 10) is Int
+    check not compiles va.insert(Int 0, newSeq[int]())
+    check not compiles ia.insert(Int 0, variant 10)
+
+    check compiles va.removeAt(Int 0)
+    check compiles ia.removeAt(Int 0)
+
+    check compiles va.fill(variant 10)
+    check compiles va.fill(Int 10)
+    check compiles ia.fill(Int 10)
+    check not compiles ia.fill(variant 10)
+
+    check compiles va.erase(variant 10)
+    check compiles va.erase(Int 10)
+    check compiles ia.erase(Int 10)
+    check compiles ia.erase(variant 10)
+    check not compiles va.erase(newSeq[int]())
+    check not compiles ia.erase(newSeq[int]())
+
+    check ia.front() is Int
+    check va.front() is Variant
+
+    check ia.back() is Int
+    check va.back() is Variant
+
+    check ia.pickRandom() is Int
+    check va.pickRandom() is Variant
+
+    check va.find(variant 10) is Int
+    check va.find(Int 10) is Int
+    check ia.find(Int 10) is Int
+    check ia.find(variant 10) is Int
+    check not compiles va.find(newSeq[int]())
+    check not compiles ia.find(newSeq[int]())
+
+    check va.findCustom(Callable()) is Int
+    check ia.findCustom(Callable()) is Int
+
+    check va.rfind(variant 10) is Int
+    check va.rfind(Int 10) is Int
+    check ia.rfind(Int 10) is Int
+    check ia.rfind(variant 10) is Int
+    check not compiles va.rfind(newSeq[int]())
+    check not compiles ia.rfind(newSeq[int]())
+
+    check va.rfindCustom(Callable()) is Int
+    check ia.rfindCustom(Callable()) is Int
+
+    check va.count(variant 10) is Int
+    check va.count(Int 10) is Int
+    check ia.count(Int 10) is Int
+    check ia.count(variant 10) is Int
+    check not compiles va.count(newSeq[int]())
+    check not compiles ia.count(newSeq[int]())
+
+    check va.has(variant 10) is bool
+    check va.has(Int 10) is bool
+    check ia.has(Int 10) is bool
+    check ia.has(variant 10) is bool
+    check not compiles va.has(newSeq[int]())
+    check not compiles ia.has(newSeq[int]())
+
+    check ia.popBack() is Int
+    check va.popBack() is Variant
+
+    check ia.popFront() is Int
+    check va.popFront() is Variant
+
+    check ia.popAt(Int 0) is Int
+    check va.popAt(Int 0) is Variant
+
+    check compiles ia.sort()
+    check compiles va.sort()
+
+    check compiles ia.sortCustom(Callable())
+    check compiles va.sortCustom(Callable())
+
+    check compiles ia.shuffle()
+    check compiles va.shuffle()
+
+    check va.bsearch(variant 10) is Int
+    check va.bsearch(Int 10) is Int
+    check ia.bsearch(Int 10) is Int
+    check ia.bsearch(variant 10) is Int
+    check not compiles va.bsearch(newSeq[int]())
+    check not compiles ia.bsearch(newSeq[int]())
+
+    check va.bsearchCustom(variant 10, Callable()) is Int
+    check va.bsearchCustom(Int 10, Callable()) is Int
+    check ia.bsearchCustom(Int 10, Callable()) is Int
+    check ia.bsearchCustom(variant 10, Callable()) is Int
+    check not compiles va.bsearchCustom(newSeq[int](), Callable())
+    check not compiles ia.bsearchCustom(newSeq[int](), Callable())
+
+    check compiles ia.reverse()
+    check compiles va.reverse()
+
+    check ia.duplicate() is Array[Int]
+    check va.duplicate() is Array[Variant]
+
+    check ia.duplicateDeep() is Array[Int]
+    check va.duplicateDeep() is Array[Variant]
+
+    check ia.slice(0, 2) is Array[Int]
+    check va.slice(0, 2) is Array[Variant]
+
+    check va.filter(Callable()) is Array[Variant]
+    check ia.filter(Callable()) is Array[Int]
+
+    check va.map(Callable()) is Array[Variant]
+    check ia.map(Callable()) is Array[Int]
+
+    check va.reduce(Callable(), Variant()) is Variant
+    check ia.reduce(Callable(), Int 0) is Int
+
+    check va.any(Callable()) is bool
+    check ia.any(Callable()) is bool
+
+    check va.all(Callable()) is bool
+    check ia.all(Callable()) is bool
+
+    check va.max() is Variant
+    check ia.max() is Int
+
+    check va.min() is Variant
+    check ia.min() is Int
+
+    check va.isTyped() is bool
+    check ia.isTyped() is bool
+
+    check va.isSameTyped(va) is bool
+    check va.isSameTyped(ia) is bool
+    check ia.isSameTyped(va) is bool
+    check ia.isSameTyped(ia) is bool
+    check ia.isSameTyped(sa) is bool
+
+    check va.getTypedBuiltin() is Int
+    check ia.getTypedBuiltin() is Int
+
+    check va.getTypedClassName() is StringName
+    check ia.getTypedClassName() is StringName
+
+    check va.getTypedScript() is Variant
+    check ia.getTypedScript() is Variant
+
+    check compiles va.makeReadOnly()
+    check compiles ia.makeReadOnly()
+
+    check va.isReadOnly() is bool
+    check ia.isReadOnly() is bool
+
   test "nil access":
     var arr: Array[Variant]
     let imm_arr = arr

--- a/testproject/runtime/nim/src/cases/primitives.nim
+++ b/testproject/runtime/nim/src/cases/primitives.nim
@@ -59,13 +59,13 @@ runtime: suite "to string":
   test "NodePath":
     check $newNodePath("path/to/somewhere") == $variant(newNodePath("path/to/somewhere"))
   test "Array":
-    var arr = newArray(5)
+    var arr = newArray[Variant](5)
     for i in 0..<arr.len:
       arr[i] = variant i
     check $arr == $variant(arr)
     check ($arr).startsWith "["
   test "TypedArray":
-    var arr = newTypedArray[int](5)
+    var arr = newArray[Int](5)
     for i in 0..<arr.len:
       arr[i] = i
     check $arr == $variant(arr)
@@ -185,30 +185,126 @@ runtime: suite "size":
 
 runtime: suite "Array":
   test "nil access":
-    var arr: Array
+    var arr: Array[Variant]
     let imm_arr = arr
     check arr.len == 0
     check imm_arr.len == 0
   test "construct":
-    var arr = newArray(10)
+    var arr = newArray[Variant](10)
     check not arr.isTyped
     check arr.len == 10
     for i, val in arr:
       check val == variant()
   test "mutable iter":
-    var arr = newArray(10)
+    var arr = newArray[Variant](10)
     for i, val in arr.mpairs:
       val = variant(i)
     for i, val in arr:
       check val.get(int) == i
   test "subscript":
-    var arr = newArray(10)
+    var arr = newArray[Variant](10)
     for i in 0..<arr.len:
       check arr[i] == variant()
     for i in 0..<arr.len:
       arr[i] = variant i
     for i in 0..<arr.len:
       check arr[i].get(int) == i
+
+  test "`[]`(HSlice)":
+    var pi = newArray [variant 1, variant 2, variant 3, variant 4]
+    check pi[0..2] == newArray [variant 1, variant 2, variant 3]
+
+  test "`[]=`(HSlice)":
+    var ps = newArray [variant "a", variant "b", variant "c", variant "d", variant "e", variant "f", variant "g", variant "h"]
+    ps[1 .. ^2] = newArray [variant "x", variant "y", variant "z"]
+    check ps == newArray [variant "a", variant "x", variant "y", variant "z", variant "h"]
+
+    var pb = newArray [variant 1, variant 2, variant 3, variant 4, variant 5, variant 6, variant 7, variant 8]
+    pb[1 .. ^2] = newArray [variant 24, variant 25, variant 26]
+    check pb == newArray [variant 1, variant 24, variant 25, variant 26, variant 8]
+
+  test "subscript(out of bounds)":
+    var arr = newArray[Variant](10)
+    expect IndexDefect:
+      discard arr[10]
+
+runtime: suite "TypedArray":
+  test "nil access":
+    var arr: Array[String]
+    let imm_arr = arr
+    check arr.len == 0
+    check imm_arr.len == 0
+  test "construct":
+    var arr = newArray[String](10)
+    check arr.isTyped
+    check cast[VariantType](arr.getTypedBuiltin) == VariantTypeString
+    check arr.len == 10
+    for i, val in arr:
+      check val.length == 0
+
+  test "iter":
+    let res = ["a", "b", "c"]
+    let arr = newArray [String "a", "b", "c"]
+    for i, val in arr:
+      check $val == res[i]
+    block:
+      var i: int
+      for val in arr:
+        check $val == res[i]
+        inc i
+ 
+    let res2 = [Node.instantiate(), Node.instantiate(), Node.instantiate()]
+    for i, r in res2:
+      r.name = res[i]
+    let arr2 = newArray res2
+    for i, val in arr2:
+      check $val.name == res[i]
+    block:
+      var i: int
+      for val in arr2:
+        check $val.name == res[i]
+        inc i
+    for node in res2:
+      destroy node
+
+  test "mutable iter":
+    var arr = newArray[String](10)
+    for i, val in arr.mpairs:
+      val = $i
+    for i, val in arr:
+      check $val == $i
+
+    var arr2 = newArray[Object](10)
+    check not compiles(
+      for i, val in arr2.mpairs: discard
+    )
+
+  test "subscript":
+    var arr = newArray[String](10)
+    for i in 0..<arr.len:
+      check arr[i] == newGdString""
+    for i in 0..<arr.len:
+      arr[i] = newGdString $i
+    for i in 0..<arr.len:
+      check arr[i] == newGdString $i
+
+  test "backward subscript":
+    var obj = instantiate Object
+    var po = newArray [obj]
+    var pi = newArray [1]
+    check po[0] != nil
+    check po[^1] != nil
+    check pi[0] == 1
+    check pi[^1] == 1
+    destroy obj
+
+  test "typed functions":
+    var arr = newArray[String](2)
+    arr.fill "Hello, "
+    arr.pushBack "world!"
+    check $arr.popFront == "Hello, "
+    check $arr[0] == "Hello, "
+    check $arr[1] == "world!"
 
   test "`[]`(HSlice)":
     var pi = newArray [1, 2, 3, 4]
@@ -224,101 +320,7 @@ runtime: suite "Array":
     check pb == newArray [byte 1, 24, 25, 26, 8]
 
   test "subscript(out of bounds)":
-    var arr = newArray(10)
-    expect IndexDefect:
-      discard arr[10]
-
-runtime: suite "TypedArray":
-  test "nil access":
-    var arr: TypedArray[String]
-    let imm_arr = arr
-    check arr.len == 0
-    check imm_arr.len == 0
-  test "construct":
-    var arr = newTypedArray[String](10)
-    check arr.isTyped
-    check cast[VariantType](arr.getTypedBuiltin) == VariantTypeString
-    check arr.len == 10
-    for i, val in arr:
-      check val.length == 0
-
-  test "iter":
-    let res = ["a", "b", "c"]
-    let arr = newTypedArray [newGdString"a", "b", "c"]
-    for i, val in arr:
-      check $val == res[i]
-    block:
-      var i: int
-      for val in arr:
-        check $val == res[i]
-        inc i
- 
-    let res2 = [Node.instantiate(), Node.instantiate(), Node.instantiate()]
-    for i, r in res2:
-      r.name = res[i]
-    let arr2 = newTypedArray res2
-    for i, val in arr2:
-      check $val.name == res[i]
-    block:
-      var i: int
-      for val in arr2:
-        check $val.name == res[i]
-        inc i
-
-  test "mutable iter":
-    var arr = newTypedArray[String](10)
-    for i, val in arr.mpairs:
-      val = $i
-    for i, val in arr:
-      check $val == $i
-
-    var arr2 = newTypedArray[Object](10)
-    check not compiles(
-      for i, val in arr2.mpairs: discard
-    )
-
-  test "subscript":
-    var arr = newTypedArray[String](10)
-    for i in 0..<arr.len:
-      check arr[i] == newGdString""
-    for i in 0..<arr.len:
-      arr[i] = newGdString $i
-    for i in 0..<arr.len:
-      check arr[i] == newGdString $i
-
-  test "backward subscript":
-    var obj = instantiate Object
-    var po = newTypedArray [obj]
-    var pi = newTypedArray [Int 1]
-    check po[0] != nil
-    check po[^1] != nil
-    check pi[0] == 1
-    check pi[^1] == 1
-    destroy obj
-
-  test "typed functions":
-    var arr = newTypedArray[String](2)
-    arr.fill "Hello, "
-    arr.pushBack "world!"
-    check $arr.popFront == "Hello, "
-    check $arr[0] == "Hello, "
-    check $arr[1] == "world!"
-
-  test "`[]`(HSlice)":
-    var pi = newTypedArray [Int 1, 2, 3, 4]
-    check pi[0..2] == newTypedArray [Int 1, 2, 3]
-
-  test "`[]=`(HSlice)":
-    var ps = newTypedArray [String "a","b","c","d","e","f","g","h"]
-    ps[1 .. ^2] = newTypedArray [String "x","y","z"]
-    check ps == newTypedArray [String "a","x","y","z","h"]
-
-    var pb = newTypedArray [byte 1, 2, 3, 4, 5, 6, 7, 8]
-    pb[1 .. ^2] = newTypedArray [byte 24, 25, 26]
-    check pb == newTypedArray [byte 1, 24, 25, 26, 8]
-
-  test "subscript(out of bounds)":
-    var arr = newTypedArray[String](10)
+    var arr = newArray[String](10)
     expect IndexDefect:
       discard arr[10]
 

--- a/testproject/runtime/nim/src/cases/variant.nim
+++ b/testproject/runtime/nim/src/cases/variant.nim
@@ -41,7 +41,7 @@ runtime: suite "Variant":
     check not variant 0
     check variant "String"
     check not variant ""
-    check not variant newArray()
+    check not variant newArray[Variant]()
 
   test "Dictionary in Variant":
     var vdict = variant newDictionary()
@@ -65,7 +65,7 @@ runtime: suite "Variant":
 
 
   test "Array in Variant":
-    var varr = variant newArray()
+    var varr = variant newArray[Variant]()
     check varr.call("size").get(int) == 0
     varr.call("append", "Value1")
     check varr.call("size").get(int) == 1
@@ -158,8 +158,8 @@ runtime: suite "Variant":
       check v of RefCounted
 
     block:
-      var tarr = newTypedArray[String]()
+      var tarr = newArray[String]()
       var v = variant tarr
-      check v of Array
-      check v of TypedArray[String]
-      check not (v of TypedArray[StringName])
+      check v of Array[Variant]
+      check v of Array[String]
+      check not (v of Array[StringName])


### PR DESCRIPTION
**Changes:**
- TypedArray[T] -> Array[T]
- Array -> Array[Variant]

For instance, 

```nim
var untypedArray: Array = newArray(10)
untypedArray = newArray(["A", "B", "C"])

var typedArray: TypedArray[String] = newTypedArray[String](10)
typedArray = newTypedArray([String "A", "B", "C"])

untypedArray = typedArray
```

will be

```nim
var untypedArray: Array[Variant] = newArray[Variant](10)
untypedArray = newArray([Variant 1, 2.0, "3"])

var typedArray: Array[String] = newArray[String](10)
typedArray = newArray([String "A", "B", "C"])

untypedArray = typedArray
```